### PR TITLE
refactor: update IDB object stores based on the current schema

### DIFF
--- a/examples/storefront/src/app/live-client.ts
+++ b/examples/storefront/src/app/live-client.ts
@@ -5,6 +5,7 @@ import { schema } from "@repo/ls-impl/schema";
 export const { store, client } = createClient<Router>({
   url: "ws://localhost:5001/ws",
   schema,
+  storage: {
+    name: "storefront",
+  },
 });
-
-// export const { useLiveData, useSubscribe } = reactiveClient(client);

--- a/packages/live-state/package.json
+++ b/packages/live-state/package.json
@@ -41,6 +41,7 @@
     "ulid": "^3.0.0"
   },
   "dependencies": {
+    "crypto-hash": "^3.1.0",
     "idb": "^8.0.3",
     "kysely": "^0.28.2",
     "qs": "^6.14.0",

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -42,14 +42,18 @@ class InnerClient {
     { timeoutHandle: NodeJS.Timeout; handler: (data: any) => void }
   > = {};
 
-  public constructor(opts: ClientOptions) {
+  public constructor(opts: ClientOptions & { storage: { name: string } }) {
     this.url = opts.url;
 
-    this.store = new OptimisticStore(opts.schema, (stack) => {
-      Object.values(stack)
-        ?.flat()
-        ?.forEach((m) => this.sendWsMessage(m));
-    });
+    this.store = new OptimisticStore(
+      opts.schema,
+      opts.storage.name,
+      (stack) => {
+        Object.values(stack)
+          ?.flat()
+          ?.forEach((m) => this.sendWsMessage(m));
+      }
+    );
 
     this.ws = new WebSocketClient({
       url: opts.url,
@@ -261,7 +265,7 @@ export type Client<TRouter extends AnyRouter> = {
 };
 
 export const createClient = <TRouter extends AnyRouter>(
-  opts: ClientOptions
+  opts: ClientOptions & { storage: { name: string } }
 ): Client<TRouter> => {
   const ogClient = new InnerClient(opts);
 

--- a/packages/live-state/src/client/websocket/storage.ts
+++ b/packages/live-state/src/client/websocket/storage.ts
@@ -7,10 +7,10 @@ const META_KEY = "__meta";
 export class KVStorage {
   private db?: IDBPDatabase<Record<string, DefaultMutationMessage["payload"]>>;
 
-  public async init(schema: Schema<any>) {
+  public async init(schema: Schema<any>, name: string) {
     if (typeof window === "undefined") return;
 
-    this.db = await openDB("live-state", 1, {
+    this.db = await openDB(name, 1, {
       upgrade(db) {
         Object.keys(schema).forEach((k) => db.createObjectStore(k));
         db.createObjectStore(META_KEY);

--- a/packages/live-state/src/client/websocket/store.ts
+++ b/packages/live-state/src/client/websocket/store.ts
@@ -28,11 +28,12 @@ export class OptimisticStore {
 
   public constructor(
     public readonly schema: Schema<any>,
+    storageName: string,
     afterLoadMutations?: (stack: typeof this.optimisticMutationStack) => void
   ) {
     this.kvStorage = new KVStorage();
 
-    this.kvStorage.init(this.schema).then(() => {
+    this.kvStorage.init(this.schema, storageName).then(() => {
       this.kvStorage
         .getMeta<typeof this.optimisticMutationStack>("mutationStack")
         .then((data) => {

--- a/packages/live-state/src/schema/index.ts
+++ b/packages/live-state/src/schema/index.ts
@@ -237,6 +237,16 @@ export class Relation<
     };
   }
 
+  toJSON() {
+    return {
+      entityName: this.entity.name,
+      type: this.type,
+      required: this.required,
+      relationalColumn: this.relationalColumn,
+      foreignColumn: this.foreignColumn,
+    };
+  }
+
   static createOneFactory<TOriginEntity extends LiveObjectAny>() {
     return <
       TEntity extends LiveObjectAny,

--- a/packages/live-state/src/utils.ts
+++ b/packages/live-state/src/utils.ts
@@ -1,6 +1,12 @@
+import { sha256 } from "crypto-hash";
+
 export type Simplify<T> =
   T extends Record<string, any>
     ? {
         [K in keyof T]: Simplify<T[K]>;
       }
     : T;
+
+export const hash = (value: any) => {
+  return sha256(JSON.stringify(value));
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       '@types/react':
         specifier: '>=18.0.0'
         version: 18.3.20
+      crypto-hash:
+        specifier: ^3.1.0
+        version: 3.1.0
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -1055,6 +1058,10 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-hash@3.1.0:
+    resolution: {integrity: sha512-HR8JlZ+Dn54Lc5gGWZJxJitWbOCUzWb9/AlyONGecBnYZ+n/ONvt0gQnEzDNpJMYeRrYO7KogQ4qwyTPKnWKEw==}
+    engines: {node: '>=18'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -2687,6 +2694,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-hash@3.1.0: {}
 
   csstype@3.1.3: {}
 


### PR DESCRIPTION
When we update the schema (e.g. adding a new table) we want IDB to reflect that properly.

The way I'm going to do this is as following:
1. Check the current IDB version (if exists) and use that as a starting point.
2. Compare the schema hash stored in the database with the current schema.
  2.1. If they match, then we are good.
3. Increase the version number to trigger an IDB update, thus creating tables that are required.

What I'm not sure is:
1. How do we handle a table schema update (e.g. adding a new field)?
  Linear's approach is to discard the old data, that seems like a good approach but I'm not sure how this plays out in terms of side effects...
2. What about old migrations? 
  I think they should be OK, otherwise the developer wrote a breaking change which will cause them be rejected...