### PR TITLE
refactor(server): reorganize storage (no-op)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
   ],
   "biome.enabled": true,
   "editor.codeActionsOnSave": {
+    "source.removeUnusedImports": "always",
     "source.organizeImports": "never",
     "source.fixAll.biome": "explicit",
     "source.organizeImports.biome": "explicit"

--- a/packages/live-state/src/server/storage/index.ts
+++ b/packages/live-state/src/server/storage/index.ts
@@ -1,0 +1,20 @@
+import { Storage } from "./interface";
+import { SQLStorage } from "./sql-storage";
+
+// type SimpleKyselyQueryInterface = {
+//   where: (
+//     column: string,
+//     operator: string,
+//     value: any
+//   ) => SimpleKyselyQueryInterface;
+//   leftJoin: (
+//     table: string,
+//     field1: string,
+//     field2: string
+//   ) => SimpleKyselyQueryInterface;
+//   executeTakeFirst: () => Promise<Record<string, any>>;
+//   execute: () => Promise<Record<string, any>[]>;
+//   select: (eb: (eb: any) => any) => SimpleKyselyQueryInterface;
+// };
+
+export { Storage, SQLStorage };

--- a/packages/live-state/src/server/storage/interface.ts
+++ b/packages/live-state/src/server/storage/interface.ts
@@ -1,0 +1,109 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: false positive */
+
+import {
+  type IncludeClause,
+  type InferLiveObject,
+  inferValue,
+  type LiveObjectAny,
+  type LiveObjectMutationInput,
+  type MaterializedLiveType,
+  type Schema,
+  type WhereClause,
+} from "../../schema";
+import type { Simplify } from "../../utils";
+
+export abstract class Storage {
+  /** @internal */
+  public abstract updateSchema(opts: Schema<any>): Promise<void>;
+
+  /** @internal */
+  public abstract rawFindById<T extends LiveObjectAny>(
+    resourceName: string,
+    id: string,
+    include?: IncludeClause<T>
+  ): Promise<MaterializedLiveType<T> | undefined>;
+
+  public abstract findOne<T extends LiveObjectAny>(
+    resource: T,
+    id: string,
+    options?: {
+      include?: IncludeClause<T>;
+    }
+  ): Promise<InferLiveObject<T> | undefined>;
+
+  /** @internal */
+  public abstract rawFind<T extends LiveObjectAny>(
+    resourceName: string,
+    where?: Record<string, any>,
+    include?: Record<string, any>
+  ): Promise<Record<string, MaterializedLiveType<T>>>;
+
+  public abstract find<T extends LiveObjectAny>(
+    resource: T,
+    options?: {
+      where?: WhereClause<T>;
+      include?: IncludeClause<T>;
+    }
+  ): Promise<Record<string, InferLiveObject<T>>>;
+
+  /** @internal */
+  public abstract rawUpsert<T extends LiveObjectAny>(
+    resourceName: string,
+    resourceId: string,
+    value: MaterializedLiveType<T>
+  ): Promise<MaterializedLiveType<T>>;
+
+  public async insert<T extends LiveObjectAny>(
+    resource: T,
+    value: Simplify<LiveObjectMutationInput<T>>
+  ): Promise<InferLiveObject<T>> {
+    const now = new Date().toISOString();
+
+    return inferValue(
+      await this.rawUpsert(
+        resource.name,
+        value.id as string,
+        {
+          value: Object.fromEntries(
+            Object.entries(value).map(([k, v]) => [
+              k,
+              {
+                value: v,
+                _meta: {
+                  timestamp: now,
+                },
+              },
+            ])
+          ),
+        } as unknown as MaterializedLiveType<T>
+      )
+    ) as InferLiveObject<T>;
+  }
+
+  public async update<T extends LiveObjectAny>(
+    resource: T,
+    resourceId: string,
+    value: LiveObjectMutationInput<T>
+  ): Promise<InferLiveObject<T>> {
+    const now = new Date().toISOString();
+
+    // biome-ignore lint/correctness/noUnusedVariables: id is ignored on purpose
+    const { id, ...rest } = value;
+
+    return inferValue(
+      await this.rawUpsert(resource.name, resourceId, {
+        value: Object.fromEntries(
+          Object.entries(rest).map(([k, v]) => [
+            k,
+            {
+              value: v,
+              _meta: {
+                timestamp: now,
+              },
+            },
+          ])
+        ),
+      } as unknown as MaterializedLiveType<T>)
+    ) as InferLiveObject<T>;
+  }
+}

--- a/packages/live-state/src/server/storage/sql-utils.ts
+++ b/packages/live-state/src/server/storage/sql-utils.ts
@@ -1,0 +1,111 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: false positive */
+import type { SelectQueryBuilder } from "kysely";
+import { jsonArrayFrom, jsonObjectFrom } from "kysely/helpers/postgres";
+import type {
+  IncludeClause,
+  LiveObjectAny,
+  Schema,
+  WhereClause,
+} from "../../schema";
+
+export function applyWhere<T extends LiveObjectAny>(
+  schema: Schema<any>,
+  resourceName: string,
+  query: SelectQueryBuilder<any, any, any>,
+  where?: WhereClause<T>
+) {
+  if (!where) return query;
+
+  if (!schema) throw new Error("Schema not initialized");
+
+  const resourceSchema = schema[resourceName];
+
+  if (!resourceSchema) throw new Error("Resource not found");
+
+  for (const [key, val] of Object.entries(where)) {
+    if (resourceSchema.fields[key]) {
+      query = query.where(`${resourceName}.${key}`, "=", val);
+    } else if (resourceSchema.relations[key]) {
+      const relation = resourceSchema.relations[key];
+      const otherResourceName = relation.entity.name;
+
+      const otherColumnName =
+        relation.type === "one" ? "id" : relation.foreignColumn;
+
+      const selfColumn =
+        relation.type === "one" ? relation.relationalColumn : "id";
+
+      query = query.leftJoin(
+        otherResourceName,
+        `${otherResourceName}.${otherColumnName}`,
+        `${resourceName}.${selfColumn}`
+      );
+      query = applyWhere(schema, otherResourceName, query, val);
+    }
+  }
+
+  return query;
+}
+
+export function applyInclude<T extends LiveObjectAny>(
+  schema: Schema<any>,
+  resourceName: string,
+  query: SelectQueryBuilder<any, any, any>,
+  include?: IncludeClause<T>
+) {
+  if (!include) return query;
+
+  if (!schema) throw new Error("Schema not initialized");
+
+  const resourceSchema = schema[resourceName];
+
+  if (!resourceSchema) throw new Error(`Resource not found: ${resourceName}`);
+
+  for (const key of Object.keys(include)) {
+    if (!resourceSchema.relations[key])
+      throw new Error(`Relation ${key} not found in resource ${resourceName}`);
+
+    const relation = resourceSchema.relations[key];
+    const otherResourceName = relation.entity.name as string;
+
+    const otherColumnName =
+      relation.type === "one" ? "id" : relation.foreignColumn;
+
+    const selfColumn =
+      relation.type === "one" ? relation.relationalColumn : "id";
+
+    const aggFunc = relation.type === "one" ? jsonObjectFrom : jsonArrayFrom;
+
+    query = query.select((eb) =>
+      (
+        aggFunc(
+          eb
+            .selectFrom(otherResourceName)
+            .selectAll(otherResourceName)
+            .whereRef(
+              `${otherResourceName}.${otherColumnName}`,
+              "=",
+              `${resourceName}.${selfColumn}`
+            )
+            .select((eb: any) =>
+              jsonObjectFrom(
+                eb
+                  .selectFrom(`${otherResourceName}_meta`)
+                  .selectAll(`${otherResourceName}_meta`)
+                  .whereRef(
+                    `${otherResourceName}_meta.id`,
+                    "=",
+                    `${otherResourceName}.id`
+                  )
+              ).as("_meta")
+            )
+        ) as ReturnType<typeof jsonObjectFrom>
+      ).as(key)
+    );
+
+    // TODO support deep include
+    // query = this.applyInclude(otherResourceName, query, val);
+  }
+
+  return query;
+}

--- a/packages/live-state/test/server/storage.test.ts
+++ b/packages/live-state/test/server/storage.test.ts
@@ -301,6 +301,30 @@ describe("SQLStorage", () => {
   });
 
   test("should handle rawFindById", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockRawValue = {
       id: "test-id",
       name: "John",
@@ -325,6 +349,24 @@ describe("SQLStorage", () => {
   });
 
   test("should return undefined when rawFindById finds no result", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     mockDb.executeTakeFirst.mockResolvedValue(undefined);
 
     const result = await storage.rawFindById("users", "nonexistent");
@@ -333,6 +375,30 @@ describe("SQLStorage", () => {
   });
 
   test("should handle findOne", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockResource = { name: "users" } as LiveObjectAny;
     const mockRawValue = {
       id: "test-id",
@@ -348,6 +414,24 @@ describe("SQLStorage", () => {
   });
 
   test("should return undefined when findOne finds no result", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockResource = { name: "users" } as LiveObjectAny;
     mockDb.executeTakeFirst.mockResolvedValue(undefined);
 
@@ -357,6 +441,30 @@ describe("SQLStorage", () => {
   });
 
   test("should handle rawFind", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockRawResult = [
       {
         id: "user1",
@@ -396,6 +504,24 @@ describe("SQLStorage", () => {
   });
 
   test("should return empty object when rawFind finds no results", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     mockDb.execute.mockResolvedValue([]);
 
     const result = await storage.rawFind("users");
@@ -404,6 +530,30 @@ describe("SQLStorage", () => {
   });
 
   test("should handle find", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockResource = { name: "users" } as LiveObjectAny;
     const mockRawResult = [
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a standardized storage interface with high-level insert/update helpers that add per-field timestamps.
  - Added shared SQL utilities for schema-aware filtering and relation inclusion in queries.
  - Centralized access to storage components via a single entry point.

- Refactor
  - SQL storage now delegates query building to shared utilities, improving consistency and maintainability.

- Tests
  - Updated tests to explicitly initialize schemas before storage operations.

- Chores
  - Editor now auto-removes unused imports on save; other save actions unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->