### PR TITLE
chore(server)!: rename `RouteFactory.createBasicRoute` to `RouteFactory.collectionRoute`

### DIFF
--- a/examples/ls-imp/src/index.ts
+++ b/examples/ls-imp/src/index.ts
@@ -14,7 +14,7 @@ export const routerImpl = router({
   schema,
   routes: {
     groups: publicRoute
-      .createBasicRoute(schema.groups)
+      .collectionRoute(schema.groups)
       .withMutations(({ mutation }) => ({
         hello: mutation(z.string()).handler(async ({ req }) => {
           return {
@@ -54,7 +54,7 @@ export const routerImpl = router({
           });
         }),
       })),
-    cards: publicRoute.createBasicRoute(schema.cards),
+    cards: publicRoute.collectionRoute(schema.cards),
   },
 });
 

--- a/packages/live-state/test/server/router.test.ts
+++ b/packages/live-state/test/server/router.test.ts
@@ -417,7 +417,7 @@ describe("RouteFactory", () => {
     const factory = RouteFactory.create();
     const mockShape = { name: "users" } as LiveObjectAny;
 
-    const route = factory.createBasicRoute(mockShape);
+    const route = factory.collectionRoute(mockShape);
 
     expect(route).toBeInstanceOf(Route);
     expect(route.resourceName).toBe("users");
@@ -440,7 +440,7 @@ describe("RouteFactory", () => {
     const factory = RouteFactory.create().use(middleware1, middleware2);
     const mockShape = { name: "users" } as LiveObjectAny;
 
-    const route = factory.createBasicRoute(mockShape);
+    const route = factory.collectionRoute(mockShape);
 
     expect(route.middlewares.has(middleware1)).toBe(true);
     expect(route.middlewares.has(middleware2)).toBe(true);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added middleware chaining on routes via use() for fluent configuration.
  * Implemented robust find and set handlers, improving data retrieval and upsert behavior.

* **Bug Fixes**
  * Restored functional find/set mutations to ensure reliable queries and updates.

* **Refactor**
  * Renamed route builder from createBasicRoute to collectionRoute. Update your route definitions to use the new name.

* **Tests**
  * Updated tests to reflect API rename and revised database interaction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->