### PR TITLE
chore(server): accept right zod types

### DIFF
--- a/packages/live-state/src/server/router.ts
+++ b/packages/live-state/src/server/router.ts
@@ -1,5 +1,6 @@
-import { z, type ZodTypeAny } from "zod";
-import type { Middleware, NextFunction, ParsedRequest, Storage } from ".";
+import { z } from "zod";
+import type * as z3 from "zod/v3";
+import type * as z4 from "zod/v4/core";
 import type {
   LiveObjectAny,
   LiveObjectMutationInput,
@@ -7,6 +8,7 @@ import type {
   MaterializedLiveType,
   Schema,
 } from "../schema";
+import type { Middleware, NextFunction, ParsedRequest, Storage } from ".";
 
 export type RouteRecord = Record<string, AnyRoute>;
 
@@ -52,14 +54,14 @@ export type RequestHandler<
 }) => Promise<TResult>;
 
 export type Mutation<
-  TInputValidator extends ZodTypeAny, // TODO use StandardSchema instead
+  TInputValidator extends z3.ZodTypeAny | z4.$ZodType, // TODO use StandardSchema instead
   THandler extends RequestHandler<z.infer<TInputValidator>, any, any>,
 > = {
   inputValidator: TInputValidator;
   handler: THandler;
 };
 
-const mutationCreator = <TInputValidator extends ZodTypeAny>(
+const mutationCreator = <TInputValidator extends z3.ZodTypeAny | z4.$ZodType>(
   validator?: TInputValidator
 ) => {
   return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Mutations now accept input validators from both Zod v3 and Zod v4, providing broader compatibility across projects.
  - Existing setups continue to work without changes; current validators remain supported.
  - Works in mixed environments where different Zod versions are present, offering greater flexibility for teams and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->