### PR TITLE
refactor: separate insert and update requests

### DIFF
--- a/examples/ls-imp/src/index.ts
+++ b/examples/ls-imp/src/index.ts
@@ -45,7 +45,7 @@ export const routerImpl = router({
         customInsert: mutation(z.string()).handler(async ({ req, db }) => {
           return db.insert(schema.groups, {
             id: generateId(),
-            name: req.input,
+            name: req.input!,
           });
         }),
         customUpdate: mutation(z.string()).handler(async ({ req, db }) => {
@@ -72,7 +72,16 @@ export const routerImpl = router({
           });
         }),
       })),
-    cards: publicRoute.collectionRoute(schema.cards),
+    cards: publicRoute.collectionRoute(schema.cards, {
+      // read: (ctx) => {
+      //   console.log("Auth context", ctx);
+      //   return {
+      //     counter: {
+      //       $gte: 1,
+      //     },
+      //   };
+      // },
+    }),
   },
 });
 

--- a/examples/storefront/src/app/board.tsx
+++ b/examples/storefront/src/app/board.tsx
@@ -33,13 +33,31 @@ export function Board(): JSX.Element {
         <Button
           className="w-sm"
           onClick={() => {
-            client.groups.upsert({
+            client.groups.insert({
               id: ulid().toLowerCase(),
               name: `New Group ${Object.keys(groups ?? {}).length + 1} (fetch)`,
             });
           }}
         >
           Add Group (fetch)
+        </Button>
+        <Button
+          className="w-sm"
+          onClick={() => {
+            client.groups.get().then((res) => {
+              const group = Object.entries(res)[0];
+
+              if (!group) {
+                return;
+              }
+
+              client.groups.update(group[0], {
+                name: `Updated Group ${Math.random().toString(36).substring(2, 15)} (fetch)`,
+              });
+            });
+          }}
+        >
+          Update Group (fetch)
         </Button>
         <Button
           className="w-sm"

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -128,7 +128,10 @@ class InnerClient implements QueryExecutor {
         const { resource } = parsedMessage;
 
         try {
-          this.store.addMutation(resource, parsedMessage);
+          this.store.addMutation(
+            resource,
+            parsedMessage as DefaultMutationMessage
+          );
         } catch (e) {
           console.error("Error merging mutation from the server:", e);
         }

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -3,6 +3,7 @@ import type { RawQueryRequest } from "../../core/schemas/core-protocol";
 import {
   type ClientMessage,
   type clQueryMsgSchema,
+  type DefaultMutationMessage,
   type MutationMessage,
   type ServerMessage,
   serverMessageSchema,
@@ -188,11 +189,12 @@ class InnerClient implements QueryExecutor {
   public mutate(
     routeName: string,
     resourceId: string,
+    procedure: "INSERT" | "UPDATE",
     payload: Partial<
       Omit<Simplify<LiveObjectMutationInput<LiveObjectAny>>["value"], "id">
     >
   ) {
-    const mutationMessage: MutationMessage = {
+    const mutationMessage: DefaultMutationMessage = {
       id: generateId(),
       type: "MUTATE",
       resource: routeName,
@@ -202,6 +204,7 @@ class InnerClient implements QueryExecutor {
         new Date().toISOString()
       ),
       resourceId,
+      procedure,
     };
 
     this.store?.addMutation(routeName, mutationMessage, true);
@@ -316,12 +319,12 @@ export const createClient = <TRouter extends AnyRouter>(
 
           if (method === "insert") {
             const { id, ...input } = argumentsList[0];
-            return ogClient.mutate(route, id, input);
+            return ogClient.mutate(route, id, "INSERT", input);
           }
 
           if (method === "update") {
             const [id, input] = argumentsList;
-            return ogClient.mutate(route, id, input);
+            return ogClient.mutate(route, id, "UPDATE", input);
           }
 
           return ogClient.genericMutate(route, method, argumentsList[0]);

--- a/packages/live-state/src/client/websocket/store.ts
+++ b/packages/live-state/src/client/websocket/store.ts
@@ -3,7 +3,6 @@ import type { RawQueryRequest } from "../../core/schemas/core-protocol";
 import type { DefaultMutationMessage } from "../../core/schemas/web-socket";
 import {
   type IncludeClause,
-  type InferLiveType,
   inferValue,
   type LiveObjectAny,
   type LiveString,
@@ -15,7 +14,7 @@ import {
 import { hash } from "../../utils";
 import type { ClientOptions } from "..";
 import { applyWhere, filterWithLimit } from "../utils";
-import { type GraphNode, ObjectGraph } from "./obj-graph";
+import { ObjectGraph } from "./obj-graph";
 import { KVStorage } from "./storage";
 
 type RawObjPool = Record<
@@ -309,6 +308,7 @@ export class OptimisticStore {
         type: "MUTATE",
         resource: resourceType,
         resourceId: id,
+        procedure: "INSERT", // this is not used by the store, but it's required by the schema
         payload,
       });
     });

--- a/packages/live-state/src/core/schemas/core-protocol.ts
+++ b/packages/live-state/src/core/schemas/core-protocol.ts
@@ -35,6 +35,7 @@ const baseMutationSchema = z.object({
   id: z.string().optional(),
   type: z.literal("MUTATE"),
   resource: z.string(),
+  resourceId: z.string().optional(),
 });
 
 export const genericMutationSchema = baseMutationSchema.extend({
@@ -45,15 +46,20 @@ export const genericMutationSchema = baseMutationSchema.extend({
 export type GenericMutation = z.infer<typeof genericMutationSchema>;
 
 export const defaultMutationSchema = baseMutationSchema.extend({
-  resourceId: z.string(),
+  procedure: z.enum(["INSERT", "UPDATE"]),
   payload: defaultPayloadSchema,
 });
 
-export type DefaultMutation = z.infer<typeof defaultMutationSchema>;
+export type DefaultMutation = Omit<
+  z.infer<typeof defaultMutationSchema>,
+  "resourceId"
+> & {
+  resourceId: string;
+};
 
 export const mutationSchema = z.union([
-  genericMutationSchema,
   defaultMutationSchema,
+  genericMutationSchema,
 ]);
 
 export type RawMutationRequest = z.infer<typeof mutationSchema>;

--- a/packages/live-state/src/core/schemas/http.ts
+++ b/packages/live-state/src/core/schemas/http.ts
@@ -20,6 +20,7 @@ export const httpDefaultMutationSchema = defaultMutationSchema.omit({
   id: true,
   type: true,
   resource: true,
+  procedure: true,
 });
 
 export const httpMutationSchema = z.union([

--- a/packages/live-state/src/core/schemas/web-socket.ts
+++ b/packages/live-state/src/core/schemas/web-socket.ts
@@ -27,7 +27,12 @@ export const defaultMutationMsgSchema = defaultMutationSchema.extend({
   id: msgId,
 });
 
-export type DefaultMutationMessage = z.infer<typeof defaultMutationMsgSchema>;
+export type DefaultMutationMessage = Omit<
+  z.infer<typeof defaultMutationMsgSchema>,
+  "resourceId"
+> & {
+  resourceId: string;
+};
 
 export const genericMutationMsgSchema = genericMutationSchema.extend({
   id: msgId,

--- a/packages/live-state/src/server/index.ts
+++ b/packages/live-state/src/server/index.ts
@@ -1,4 +1,4 @@
-import type { RawMutationRequest } from "../core/schemas/core-protocol";
+import type { DefaultMutation } from "../core/schemas/core-protocol";
 import type { Schema } from "../schema";
 import type { AnyRouter } from "./router";
 import type { Storage } from "./storage";
@@ -29,7 +29,7 @@ export type ContextProvider = (
 
 export type RequestType = ParsedRequest["type"];
 
-export type MutationHandler = (mutation: RawMutationRequest) => void;
+export type MutationHandler = (mutation: DefaultMutation) => void;
 
 export type NextFunction<T> = (req: ParsedRequest) => Promise<T> | T;
 
@@ -105,7 +105,8 @@ export class Server<TRouter extends AnyRouter> {
       result &&
       opts.req.type === "MUTATE" &&
       result.acceptedValues &&
-      Object.keys(result.acceptedValues).length > 0
+      Object.keys(result.acceptedValues).length > 0 &&
+      (opts.req.procedure === "INSERT" || opts.req.procedure === "UPDATE")
     ) {
       // TODO refactor this to be called by the storage instead of the server
       this.mutationSubscriptions.forEach((handler) => {
@@ -115,6 +116,7 @@ export class Server<TRouter extends AnyRouter> {
           resource: opts.req.resourceName,
           payload: result.acceptedValues ?? {},
           resourceId: opts.req.resourceId!,
+          procedure: opts.req.procedure as "INSERT" | "UPDATE",
         });
       });
     }

--- a/packages/live-state/src/server/storage/interface.ts
+++ b/packages/live-state/src/server/storage/interface.ts
@@ -48,7 +48,14 @@ export abstract class Storage {
   ): Promise<Record<string, InferLiveObject<T>>>;
 
   /** @internal */
-  public abstract rawUpsert<T extends LiveObjectAny>(
+  public abstract rawInsert<T extends LiveObjectAny>(
+    resourceName: string,
+    resourceId: string,
+    value: MaterializedLiveType<T>
+  ): Promise<MaterializedLiveType<T>>;
+
+  /** @internal */
+  public abstract rawUpdate<T extends LiveObjectAny>(
     resourceName: string,
     resourceId: string,
     value: MaterializedLiveType<T>
@@ -61,7 +68,7 @@ export abstract class Storage {
     const now = new Date().toISOString();
 
     return inferValue(
-      await this.rawUpsert(
+      await this.rawInsert(
         resource.name,
         (value as any).id as string,
         {
@@ -92,7 +99,7 @@ export abstract class Storage {
     const { id, ...rest } = value as any;
 
     return inferValue(
-      await this.rawUpsert(resource.name, resourceId, {
+      await this.rawUpdate(resource.name, resourceId, {
         value: Object.fromEntries(
           Object.entries(rest).map(([k, v]) => [
             k,

--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -1,13 +1,13 @@
 import cookie from "cookie";
 import qs from "qs";
-import type { AnyRouter, Server } from "..";
 import type { DefaultMutation } from "../../core/schemas/core-protocol";
 import {
+  type HttpMutation,
   httpDefaultMutationSchema,
   httpGenericMutationSchema,
-  type HttpMutation,
   httpQuerySchema,
 } from "../../core/schemas/http";
+import type { AnyRouter, Server } from "..";
 
 export const httpTransportLayer = (
   server: Server<AnyRouter>
@@ -95,7 +95,7 @@ export const httpTransportLayer = (
 
           let body: HttpMutation;
 
-          if (procedure === "set") {
+          if (procedure === "insert" || procedure === "update") {
             const { success, data, error } =
               httpDefaultMutationSchema.safeParse(rawBody);
             if (!success) {
@@ -133,7 +133,10 @@ export const httpTransportLayer = (
               input: body.payload,
               context: initialContext,
               resourceId: (body as DefaultMutation).resourceId,
-              procedure: procedure !== "set" ? procedure : undefined,
+              procedure:
+                procedure === "insert" || procedure === "update"
+                  ? procedure.toUpperCase()
+                  : procedure,
               query: {},
             },
           });

--- a/packages/live-state/src/server/transport-layers/web-socket.ts
+++ b/packages/live-state/src/server/transport-layers/web-socket.ts
@@ -142,7 +142,11 @@ export const webSocketAdapter = (server: Server<AnyRouter>) => {
               },
             });
 
-            if ((parsedMessage as GenericMutation).procedure) {
+            if (
+              (parsedMessage as GenericMutation).procedure &&
+              (parsedMessage as GenericMutation).procedure !== "INSERT" &&
+              (parsedMessage as GenericMutation).procedure !== "UPDATE"
+            ) {
               reply({
                 id: parsedMessage.id,
                 type: "REPLY",

--- a/packages/live-state/test/client/websocket/store.test.ts
+++ b/packages/live-state/test/client/websocket/store.test.ts
@@ -570,6 +570,7 @@ describe("OptimisticStore", () => {
       resource: "users",
       resourceId: "user1",
       payload: data.user1,
+      procedure: "INSERT",
     });
     expect(addMutationSpy).toHaveBeenCalledWith("users", {
       id: "user2",
@@ -577,6 +578,7 @@ describe("OptimisticStore", () => {
       resource: "users",
       resourceId: "user2",
       payload: data.user2,
+      procedure: "INSERT",
     });
   });
 

--- a/packages/live-state/test/server/index.test.ts
+++ b/packages/live-state/test/server/index.test.ts
@@ -267,6 +267,7 @@ describe("Server", () => {
       type: "MUTATE",
       resourceName: "users",
       resourceId: "user1",
+      procedure: "INSERT",
       context: { messageId: "msg123" },
       headers: {},
       cookies: {},
@@ -281,6 +282,7 @@ describe("Server", () => {
       resource: "users",
       payload: { name: "John" },
       resourceId: "user1",
+      procedure: "INSERT",
     });
     expect(handler2).toHaveBeenCalledWith({
       id: "msg123",
@@ -288,6 +290,7 @@ describe("Server", () => {
       resource: "users",
       payload: { name: "John" },
       resourceId: "user1",
+      procedure: "INSERT",
     });
   });
 

--- a/packages/live-state/test/server/storage.test.ts
+++ b/packages/live-state/test/server/storage.test.ts
@@ -38,7 +38,13 @@ describe("Storage", () => {
       async find() {
         return {};
       }
-      async rawUpsert() {
+      async rawInsert() {
+        return {} as any;
+      }
+      async rawUpdate() {
+        return {} as any;
+      }
+      async transaction() {
         return {} as any;
       }
     })();
@@ -48,11 +54,13 @@ describe("Storage", () => {
     expect(typeof storage.findOne).toBe("function");
     expect(typeof storage.rawFind).toBe("function");
     expect(typeof storage.find).toBe("function");
-    expect(typeof storage.rawUpsert).toBe("function");
+    expect(typeof storage.rawInsert).toBe("function");
+    expect(typeof storage.rawUpdate).toBe("function");
+    expect(typeof storage.transaction).toBe("function");
   });
 
   test("should implement insert method", async () => {
-    const mockRawUpsert = vi.fn().mockResolvedValue({
+    const mockRawInsert = vi.fn().mockResolvedValue({
       value: {
         id: { value: "test-id" },
         name: {
@@ -76,7 +84,13 @@ describe("Storage", () => {
       async find() {
         return {};
       }
-      rawUpsert = mockRawUpsert;
+      rawInsert = mockRawInsert;
+      async rawUpdate() {
+        return {} as any;
+      }
+      async transaction() {
+        return {} as any;
+      }
     })();
 
     const mockResource = { name: "users" } as LiveObjectAny;
@@ -84,7 +98,7 @@ describe("Storage", () => {
 
     const result = await storage.insert(mockResource, mockValue);
 
-    expect(mockRawUpsert).toHaveBeenCalledWith(
+    expect(mockRawInsert).toHaveBeenCalledWith(
       "users",
       "test-id",
       expect.objectContaining({
@@ -101,7 +115,7 @@ describe("Storage", () => {
   });
 
   test("should implement update method", async () => {
-    const mockRawUpsert = vi.fn().mockResolvedValue({
+    const mockRawUpdate = vi.fn().mockResolvedValue({
       value: {
         name: {
           value: "Jane",
@@ -124,7 +138,13 @@ describe("Storage", () => {
       async find() {
         return {};
       }
-      rawUpsert = mockRawUpsert;
+      async rawInsert() {
+        return {} as any;
+      }
+      rawUpdate = mockRawUpdate;
+      async transaction() {
+        return {} as any;
+      }
     })();
 
     const mockResource = { name: "users" } as LiveObjectAny;
@@ -132,7 +152,7 @@ describe("Storage", () => {
 
     const result = await storage.update(mockResource, "test-id", mockValue);
 
-    expect(mockRawUpsert).toHaveBeenCalledWith(
+    expect(mockRawUpdate).toHaveBeenCalledWith(
       "users",
       "test-id",
       expect.objectContaining({
@@ -145,6 +165,164 @@ describe("Storage", () => {
       })
     );
     expect(result).toEqual({ name: "Jane" });
+  });
+
+  test("should handle insert method with complex nested data", async () => {
+    const mockRawInsert = vi.fn().mockResolvedValue({
+      value: {
+        id: { value: "test-id" },
+        profile: {
+          value: {
+            name: {
+              value: "John",
+              _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+            },
+            settings: {
+              value: {
+                theme: {
+                  value: "dark",
+                  _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+                },
+              },
+              _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+            },
+          },
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+    });
+
+    const storage = new (class extends Storage {
+      async updateSchema() {}
+      async rawFindById() {
+        return undefined;
+      }
+      async findOne() {
+        return undefined;
+      }
+      async rawFind() {
+        return {};
+      }
+      async find() {
+        return {};
+      }
+      rawInsert = mockRawInsert;
+      async rawUpdate() {
+        return {} as any;
+      }
+      async transaction() {
+        return {} as any;
+      }
+    })();
+
+    const mockResource = { name: "users" } as LiveObjectAny;
+    const mockValue = {
+      id: "test-id",
+      profile: {
+        name: "John",
+        settings: {
+          theme: "dark",
+        },
+      },
+    };
+
+    const result = await storage.insert(mockResource, mockValue);
+
+    expect(mockRawInsert).toHaveBeenCalledWith(
+      "users",
+      "test-id",
+      expect.objectContaining({
+        value: expect.objectContaining({
+          id: expect.objectContaining({
+            value: "test-id",
+            _meta: expect.objectContaining({ timestamp: expect.any(String) }),
+          }),
+          profile: expect.objectContaining({
+            value: expect.objectContaining({
+              name: "John",
+              settings: expect.objectContaining({
+                theme: "dark",
+              }),
+            }),
+            _meta: expect.objectContaining({ timestamp: expect.any(String) }),
+          }),
+        }),
+      })
+    );
+    expect(result).toEqual({
+      id: "test-id",
+      profile: {
+        name: "John",
+        settings: {
+          theme: "dark",
+        },
+      },
+    });
+  });
+
+  test("should handle update method excluding id field", async () => {
+    const mockRawUpdate = vi.fn().mockResolvedValue({
+      value: {
+        name: {
+          value: "Jane",
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+        email: {
+          value: "jane@example.com",
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+    });
+
+    const storage = new (class extends Storage {
+      async updateSchema() {}
+      async rawFindById() {
+        return undefined;
+      }
+      async findOne() {
+        return undefined;
+      }
+      async rawFind() {
+        return {};
+      }
+      async find() {
+        return {};
+      }
+      async rawInsert() {
+        return {} as any;
+      }
+      rawUpdate = mockRawUpdate;
+      async transaction() {
+        return {} as any;
+      }
+    })();
+
+    const mockResource = { name: "users" } as LiveObjectAny;
+    const mockValue = {
+      id: "test-id",
+      name: "Jane",
+      email: "jane@example.com",
+    };
+
+    const result = await storage.update(mockResource, "test-id", mockValue);
+
+    expect(mockRawUpdate).toHaveBeenCalledWith(
+      "users",
+      "test-id",
+      expect.objectContaining({
+        value: expect.objectContaining({
+          name: expect.objectContaining({
+            value: "Jane",
+            _meta: expect.objectContaining({ timestamp: expect.any(String) }),
+          }),
+          email: expect.objectContaining({
+            value: "jane@example.com",
+            _meta: expect.objectContaining({ timestamp: expect.any(String) }),
+          }),
+        }),
+      })
+    );
+    expect(result).toEqual({ name: "Jane", email: "jane@example.com" });
   });
 });
 
@@ -576,7 +754,31 @@ describe("SQLStorage", () => {
     });
   });
 
-  test("should handle rawUpsert for new record", async () => {
+  test("should handle rawInsert", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockValue: MaterializedLiveType<any> = {
       value: {
         id: { value: "test-id" },
@@ -587,9 +789,6 @@ describe("SQLStorage", () => {
       },
     };
 
-    // Mock db to simulate new record (no existing record found)
-    mockDb.executeTakeFirst.mockResolvedValue(undefined); // No existing record
-    
     // Mock insertInto chain for both tables
     const mockInsertInto = {
       values: vi.fn().mockReturnThis(),
@@ -597,18 +796,41 @@ describe("SQLStorage", () => {
     };
     mockDb.insertInto.mockReturnValue(mockInsertInto);
 
-    const result = await storage.rawUpsert("users", "test-id", mockValue);
+    const result = await storage.rawInsert("users", "test-id", mockValue);
 
-    expect(mockDb.selectFrom).toHaveBeenCalledWith("users");
-    expect(mockDb.where).toHaveBeenCalledWith("id", "=", "test-id");
     expect(mockDb.insertInto).toHaveBeenCalledWith("users");
-    expect(mockDb.insertInto).toHaveBeenCalledWith("users_meta");
-    expect(mockInsertInto.values).toHaveBeenCalledWith({ name: "John", id: "test-id" });
-    expect(mockInsertInto.values).toHaveBeenCalledWith({ name: "2023-01-01T00:00:00.000Z", id: "test-id" });
+    expect(mockInsertInto.values).toHaveBeenCalledWith({
+      name: "John",
+      id: "test-id",
+    });
     expect(result).toEqual(mockValue);
   });
 
-  test("should handle rawUpsert for existing record", async () => {
+  test("should handle rawUpdate", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
     const mockValue: MaterializedLiveType<any> = {
       value: {
         id: { value: "test-id" },
@@ -619,9 +841,6 @@ describe("SQLStorage", () => {
       },
     };
 
-    // Mock db to simulate existing record
-    mockDb.executeTakeFirst.mockResolvedValue({ id: "test-id" }); // Existing record
-    
     // Mock updateTable chain for both tables
     const mockUpdateTable = {
       set: vi.fn().mockReturnThis(),
@@ -630,14 +849,14 @@ describe("SQLStorage", () => {
     };
     mockDb.updateTable.mockReturnValue(mockUpdateTable);
 
-    const result = await storage.rawUpsert("users", "test-id", mockValue);
+    const result = await storage.rawUpdate("users", "test-id", mockValue);
 
-    expect(mockDb.selectFrom).toHaveBeenCalledWith("users");
-    expect(mockDb.where).toHaveBeenCalledWith("id", "=", "test-id");
     expect(mockDb.updateTable).toHaveBeenCalledWith("users");
     expect(mockDb.updateTable).toHaveBeenCalledWith("users_meta");
     expect(mockUpdateTable.set).toHaveBeenCalledWith({ name: "John" });
-    expect(mockUpdateTable.set).toHaveBeenCalledWith({ name: "2023-01-01T00:00:00.000Z" });
+    expect(mockUpdateTable.set).toHaveBeenCalledWith({
+      name: "2023-01-01T00:00:00.000Z",
+    });
     expect(mockUpdateTable.where).toHaveBeenCalledWith("id", "=", "test-id");
     expect(result).toEqual(mockValue);
   });
@@ -702,5 +921,859 @@ describe("SQLStorage", () => {
 
     expect(result.value.tags.value).toHaveLength(2);
     expect(result.value.tags._meta.timestamp).toBe("2023-01-01T00:00:00.000Z");
+  });
+
+  test("should handle transaction with commit", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockTrx = {
+      commit: vi
+        .fn()
+        .mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) }),
+      rollback: vi
+        .fn()
+        .mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) }),
+      isCommitted: false,
+      isRolledBack: false,
+    };
+
+    mockDb.transaction.mockReturnValue({
+      execute: vi.fn().mockImplementation(async (fn) => {
+        const result = await fn({
+          selectFrom: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          executeTakeFirst: vi.fn().mockResolvedValue(undefined),
+          updateTable: vi.fn().mockReturnThis(),
+          set: vi.fn().mockReturnThis(),
+          execute: vi.fn().mockResolvedValue(undefined),
+          insertInto: vi.fn().mockReturnThis(),
+          values: vi.fn().mockReturnThis(),
+        });
+        return result;
+      }),
+    });
+
+    // Mock startTransaction
+    mockDb.startTransaction = vi.fn().mockReturnValue({
+      execute: vi.fn().mockResolvedValue(mockTrx),
+    });
+
+    const result = await storage.transaction(async ({ trx, commit }) => {
+      await commit();
+      return "success";
+    });
+
+    expect(result).toBe("success");
+    expect(mockDb.startTransaction).toHaveBeenCalled();
+  });
+
+  test("should handle transaction with rollback on error", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockTrx = {
+      commit: vi
+        .fn()
+        .mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) }),
+      rollback: vi
+        .fn()
+        .mockReturnValue({ execute: vi.fn().mockResolvedValue(undefined) }),
+      isCommitted: false,
+      isRolledBack: false,
+    };
+
+    // Mock startTransaction
+    mockDb.startTransaction = vi.fn().mockReturnValue({
+      execute: vi.fn().mockResolvedValue(mockTrx),
+    });
+
+    await expect(
+      storage.transaction(async () => {
+        throw new Error("Transaction error");
+      })
+    ).rejects.toThrow("Transaction error");
+
+    expect(mockTrx.rollback).toHaveBeenCalled();
+  });
+
+  test("should throw error when schema not initialized for rawFindById", async () => {
+    const storageWithoutSchema = new SQLStorage(mockPool);
+
+    await expect(
+      storageWithoutSchema.rawFindById("users", "test-id")
+    ).rejects.toThrow("Schema not initialized");
+  });
+
+  test("should throw error when schema not initialized for rawFind", async () => {
+    const storageWithoutSchema = new SQLStorage(mockPool);
+
+    await expect(storageWithoutSchema.rawFind("users")).rejects.toThrow(
+      "Schema not initialized"
+    );
+  });
+
+  test("should throw error when schema not initialized for transaction", async () => {
+    const storageWithoutSchema = new SQLStorage(mockPool);
+
+    await expect(
+      storageWithoutSchema.transaction(async () => "test")
+    ).rejects.toThrow("Schema not initialized");
+  });
+
+  test("should handle rawFind with where clause", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockRawResult = [
+      {
+        id: "user1",
+        name: "John",
+        _meta: { name: "2023-01-01T00:00:00.000Z" },
+      },
+    ];
+
+    mockDb.execute.mockResolvedValue(mockRawResult);
+
+    const result = await storage.rawFind("users", { name: "John" });
+
+    expect(mockDb.selectFrom).toHaveBeenCalledWith("users");
+    expect(result).toEqual({
+      user1: {
+        value: {
+          name: {
+            value: "John",
+            _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+          },
+        },
+      },
+    });
+  });
+
+  test("should handle rawFind with include clause", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {
+          posts: {
+            type: "many",
+            entity: { name: "posts" },
+            foreignColumn: "userId",
+          },
+        },
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockRawResult = [
+      {
+        id: "user1",
+        name: "John",
+        _meta: { name: "2023-01-01T00:00:00.000Z" },
+      },
+    ];
+
+    mockDb.execute.mockResolvedValue(mockRawResult);
+
+    const result = await storage.rawFind("users", undefined, { posts: true });
+
+    expect(mockDb.selectFrom).toHaveBeenCalledWith("users");
+    expect(result).toEqual({
+      user1: {
+        value: {
+          name: {
+            value: "John",
+            _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+          },
+        },
+      },
+    });
+  });
+
+  test("should handle rawFindById with include clause", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {
+          posts: {
+            type: "many",
+            entity: { name: "posts" },
+            foreignColumn: "userId",
+          },
+        },
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockRawValue = {
+      id: "test-id",
+      name: "John",
+      _meta: { name: "2023-01-01T00:00:00.000Z" },
+    };
+
+    mockDb.executeTakeFirst.mockResolvedValue(mockRawValue);
+
+    const result = await storage.rawFindById("users", "test-id", {
+      posts: true,
+    });
+
+    expect(mockDb.selectFrom).toHaveBeenCalledWith("users");
+    expect(mockDb.where).toHaveBeenCalledWith("id", "=", "test-id");
+    expect(result).toEqual({
+      value: {
+        id: { value: "test-id" },
+        name: {
+          value: "John",
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+    });
+  });
+
+  test("should handle findOne with include options", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {
+          posts: {
+            type: "many",
+            entity: { name: "posts" },
+            foreignColumn: "userId",
+          },
+        },
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockResource = { name: "users" } as LiveObjectAny;
+    const mockRawValue = {
+      id: "test-id",
+      name: "John",
+      _meta: { name: "2023-01-01T00:00:00.000Z" },
+    };
+
+    mockDb.executeTakeFirst.mockResolvedValue(mockRawValue);
+
+    const result = await storage.findOne(mockResource, "test-id", {
+      include: { posts: true },
+    });
+
+    expect(result).toEqual({ id: "test-id", name: "John" });
+  });
+
+  test("should handle find with where and include options", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {
+          posts: {
+            type: "many",
+            entity: { name: "posts" },
+            foreignColumn: "userId",
+          },
+        },
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockResource = { name: "users" } as LiveObjectAny;
+    const mockRawResult = [
+      {
+        id: "user1",
+        name: "John",
+        _meta: { name: "2023-01-01T00:00:00.000Z" },
+      },
+    ];
+
+    mockDb.execute.mockResolvedValue(mockRawResult);
+
+    const result = await storage.find(mockResource, {
+      where: { name: "John" },
+      include: { posts: true },
+    });
+
+    expect(result).toEqual({
+      user1: { name: "John" },
+    });
+  });
+
+  test("should handle convertToMaterializedLiveType with Date objects", () => {
+    const date = new Date("2023-01-01T00:00:00.000Z");
+    const value = {
+      id: "test-id",
+      createdAt: date,
+      _meta: {
+        createdAt: "2023-01-01T00:00:00.000Z",
+      },
+    };
+
+    const result = (storage as any).convertToMaterializedLiveType(value);
+
+    expect(result).toEqual({
+      value: {
+        id: { value: "test-id" },
+        createdAt: {
+          value: date,
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+    });
+  });
+
+  test("should handle convertToMaterializedLiveType with null values", () => {
+    const value = {
+      id: "test-id",
+      description: null,
+      _meta: {
+        description: "2023-01-01T00:00:00.000Z",
+      },
+    };
+
+    const result = (storage as any).convertToMaterializedLiveType(value);
+
+    expect(result).toEqual({
+      value: {
+        id: { value: "test-id" },
+        description: {
+          value: null,
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+    });
+  });
+
+  test("should handle rawInsert with fields that have no _meta", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockValue: MaterializedLiveType<any> = {
+      value: {
+        id: { value: "test-id" },
+        name: {
+          value: "John",
+          // No _meta field
+        },
+      },
+    };
+
+    // Mock insertInto chain for both tables
+    const mockInsertInto = {
+      values: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDb.insertInto.mockReturnValue(mockInsertInto);
+
+    const result = await storage.rawInsert("users", "test-id", mockValue);
+
+    expect(mockDb.insertInto).toHaveBeenCalledWith("users");
+    expect(mockInsertInto.values).toHaveBeenCalledWith({
+      id: "test-id",
+    });
+    expect(result).toEqual(mockValue);
+  });
+
+  test("should handle rawUpdate with fields that have no _meta", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockValue: MaterializedLiveType<any> = {
+      value: {
+        id: { value: "test-id" },
+        name: {
+          value: "John",
+          // No _meta field
+        },
+      },
+    };
+
+    // Mock updateTable chain for both tables
+    const mockUpdateTable = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDb.updateTable.mockReturnValue(mockUpdateTable);
+
+    const result = await storage.rawUpdate("users", "test-id", mockValue);
+
+    expect(mockDb.updateTable).toHaveBeenCalledWith("users");
+    expect(mockDb.updateTable).toHaveBeenCalledWith("users_meta");
+    expect(mockUpdateTable.set).toHaveBeenCalledWith({});
+    expect(result).toEqual(mockValue);
+  });
+
+  test("should handle updateSchema with existing tables and columns", async () => {
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+
+    mockDb.introspection.getTables.mockResolvedValue([
+      {
+        name: "users",
+        columns: [
+          { name: "id", dataType: "varchar" },
+          { name: "name", dataType: "varchar" },
+        ],
+      },
+      {
+        name: "users_meta",
+        columns: [
+          { name: "id", dataType: "varchar" },
+          { name: "name", dataType: "varchar" },
+        ],
+      },
+    ]);
+
+    await storage.updateSchema(mockSchema);
+
+    // Should not create tables or add columns since they already exist
+    expect(mockDb.schema.createTable).not.toHaveBeenCalled();
+    expect(mockDb.schema.alterTable).not.toHaveBeenCalled();
+  });
+
+  test("should handle updateSchema with column type mismatch", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          age: {
+            getStorageFieldType: () => ({
+              type: "integer",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+
+    mockDb.introspection.getTables.mockResolvedValue([
+      {
+        name: "users",
+        columns: [
+          { name: "id", dataType: "varchar" },
+          { name: "age", dataType: "varchar" }, // Wrong type
+        ],
+      },
+      {
+        name: "users_meta",
+        columns: [
+          { name: "id", dataType: "varchar" },
+          { name: "age", dataType: "varchar" },
+        ],
+      },
+    ]);
+
+    await storage.updateSchema(mockSchema);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Column type mismatch:",
+      "age",
+      "expected to have type:",
+      "integer",
+      "but has type:",
+      "varchar"
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  test("should handle updateSchema with field that has all storage options", async () => {
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          email: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: false,
+              unique: true,
+              index: true,
+              references: "other_table.id",
+              default: "default@example.com",
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+
+    mockDb.introspection.getTables.mockResolvedValue([
+      {
+        name: "users",
+        columns: [],
+      },
+      {
+        name: "users_meta",
+        columns: [],
+      },
+    ]);
+
+    const mockAlterTable = {
+      addColumn: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    mockDb.schema.alterTable.mockReturnValue(mockAlterTable);
+
+    await storage.updateSchema(mockSchema);
+
+    expect(mockAlterTable.addColumn).toHaveBeenCalledWith(
+      "email",
+      "varchar",
+      expect.any(Function)
+    );
+    expect(mockDb.schema.createIndex).toHaveBeenCalledWith("users_email_index");
+  });
+
+  test("should handle updateSchema with index creation error", async () => {
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: false,
+              index: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+
+    mockDb.introspection.getTables.mockResolvedValue([
+      {
+        name: "users",
+        columns: [],
+      },
+      {
+        name: "users_meta",
+        columns: [],
+      },
+    ]);
+
+    const mockAlterTable = {
+      addColumn: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
+    };
+
+    mockDb.schema.alterTable.mockReturnValue(mockAlterTable);
+    mockDb.schema.createIndex.mockReturnValue({
+      on: vi.fn().mockReturnValue({
+        column: vi.fn().mockReturnValue({
+          execute: vi
+            .fn()
+            .mockRejectedValue(new Error("Index creation failed")),
+        }),
+      }),
+    });
+
+    // Should not throw error, just catch and continue
+    await expect(storage.updateSchema(mockSchema)).resolves.not.toThrow();
+  });
+
+  test("should handle updateSchema with column creation error", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: false,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+
+    mockDb.introspection.getTables.mockResolvedValue([
+      {
+        name: "users",
+        columns: [],
+      },
+      {
+        name: "users_meta",
+        columns: [],
+      },
+    ]);
+
+    const mockAlterTable = {
+      addColumn: vi.fn().mockReturnValue({
+        execute: vi.fn().mockRejectedValue(new Error("Column creation failed")),
+      }),
+    };
+
+    mockDb.schema.alterTable.mockReturnValue(mockAlterTable);
+
+    await expect(storage.updateSchema(mockSchema)).rejects.toThrow(
+      "Column creation failed"
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Error adding column",
+      "name",
+      expect.any(Error)
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  test("should handle SQLStorage constructor with Kysely instance", () => {
+    const mockKyselyInstance = {} as any;
+    const mockSchema = {} as Schema<any>;
+
+    const storageWithKysely = new SQLStorage(mockKyselyInstance, mockSchema);
+
+    expect(storageWithKysely).toBeInstanceOf(SQLStorage);
+  });
+
+  test("should handle rawInsert with meta table insert", async () => {
+    // Initialize schema first
+    const mockSchema: Schema<any> = {
+      users: {
+        name: "users",
+        fields: {
+          id: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              primary: true,
+              nullable: false,
+            }),
+          },
+          name: {
+            getStorageFieldType: () => ({
+              type: "varchar",
+              nullable: true,
+            }),
+          },
+        },
+        relations: {},
+      },
+    };
+    await storage.updateSchema(mockSchema);
+
+    const mockValue: MaterializedLiveType<any> = {
+      value: {
+        id: { value: "test-id" },
+        name: {
+          value: "John",
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+    };
+
+    // Mock insertInto chain for both tables
+    const mockInsertInto = {
+      values: vi.fn().mockReturnThis(),
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDb.insertInto.mockReturnValue(mockInsertInto);
+
+    const result = await storage.rawInsert("users", "test-id", mockValue);
+
+    expect(mockDb.insertInto).toHaveBeenCalledWith("users");
+    expect(mockDb.insertInto).toHaveBeenCalledWith("users_meta");
+    expect(mockInsertInto.values).toHaveBeenCalledWith({
+      name: "John",
+      id: "test-id",
+    });
+    expect(mockInsertInto.values).toHaveBeenCalledWith({
+      name: "2023-01-01T00:00:00.000Z",
+      id: "test-id",
+    });
+    expect(result).toEqual(mockValue);
   });
 });

--- a/packages/live-state/test/server/transport-layers/http.test.ts
+++ b/packages/live-state/test/server/transport-layers/http.test.ts
@@ -119,7 +119,7 @@ describe("httpTransportLayer", () => {
     });
   });
 
-  test("should handle POST request with set mutation", async () => {
+  test("should handle POST request for insert mutation", async () => {
     const requestBody = {
       resourceId: "user1",
       payload: {
@@ -132,7 +132,7 @@ describe("httpTransportLayer", () => {
       },
     };
 
-    const request = new Request("http://localhost/users/set", {
+    const request = new Request("http://localhost/users/insert", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -165,7 +165,7 @@ describe("httpTransportLayer", () => {
           },
         },
         resourceId: "user1",
-        procedure: undefined,
+        procedure: "INSERT",
       }),
     });
   });
@@ -208,7 +208,7 @@ describe("httpTransportLayer", () => {
       payload: { name: "John" },
     };
 
-    const request = new Request("http://localhost/users/set", {
+    const request = new Request("http://localhost/users/insert", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -326,7 +326,7 @@ describe("httpTransportLayer", () => {
   });
 
   test("should handle POST request without body", async () => {
-    const request = new Request("http://localhost/users/set", {
+    const request = new Request("http://localhost/users/insert", {
       method: "POST",
       headers: {
         "content-type": "application/json",

--- a/packages/live-state/test/server/transport-layers/web-socket.test.ts
+++ b/packages/live-state/test/server/transport-layers/web-socket.test.ts
@@ -205,6 +205,7 @@ describe("webSocketAdapter", () => {
         },
       },
       id: "msg-1",
+      procedure: "INSERT",
     };
 
     (mockServer.handleRequest as Mock).mockResolvedValue({
@@ -225,7 +226,7 @@ describe("webSocketAdapter", () => {
           },
         },
         resourceId: "user1",
-        procedure: undefined,
+        procedure: "INSERT",
         context: expect.objectContaining({
           messageId: "msg-1",
         }),
@@ -293,6 +294,7 @@ describe("webSocketAdapter", () => {
         },
       },
       id: "msg-1",
+      procedure: "INSERT",
     };
 
     (mockServer.handleRequest as Mock).mockRejectedValue(


### PR DESCRIPTION
refactor: separate insert and update requests

test: separate inserts and updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Separate create (insert) and update operations across API and transport layers; HTTP and WebSocket flows now carry an explicit mutation procedure.
  - Storefront: new "Update Group" button and create uses the new insert flow.

- Bug Fixes
  - Stronger validation and clearer error messages when creating existing items or updating missing ones.

- Chores / Tests
  - Expanded tests: authorization, custom mutations, transactions, transport and edge-case mutation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->