### PR TITLE
feat(server): accept generic authorization functions

### DIFF
--- a/examples/ls-imp/src/index.ts
+++ b/examples/ls-imp/src/index.ts
@@ -73,6 +73,11 @@ export const routerImpl = router({
         }),
       })),
     cards: publicRoute.collectionRoute(schema.cards, {
+      // insert: ({ ctx, value }) => {
+      //   console.log("Insert auth context", ctx);
+      //   console.log("Insert auth value", value);
+      //   return Math.random() < 0.5;
+      // },
       // read: (ctx) => {
       //   console.log("Auth context", ctx);
       //   return {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Authorization hooks now receive request context (and mutation value for writes) and may return either allow/deny or a filter to constrain results.
  - Improved handling when authorization grants or denies access.

- Bug Fixes
  - More consistent propagation and surface of errors from authorization handlers.

- Refactor
  - Public authorization API updated; integrations may require minor adjustments.

- Tests
  - Expanded coverage for query, insert, update, complex authorization, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->