### PR TITLE
fix(server): handle optional _meta

### DIFF
--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -315,6 +315,9 @@ export class SQLStorage extends Storage {
       metaValues[key] = metaVal;
     }
 
+    console.log("values", values);
+    console.log("metaValues", metaValues);
+
     await Promise.all([
       this.db
         .updateTable(resourceName)
@@ -322,9 +325,9 @@ export class SQLStorage extends Storage {
         .where("id", "=", resourceId)
         .execute(),
       this.db
-        .updateTable(`${resourceName}_meta`)
-        .set(metaValues)
-        .where("id", "=", resourceId)
+        .insertInto(`${resourceName}_meta`)
+        .values({ ...metaValues, id: resourceId })
+        .onConflict((oc) => oc.column("id").doUpdateSet(metaValues))
         .execute(),
     ]);
 

--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -315,9 +315,6 @@ export class SQLStorage extends Storage {
       metaValues[key] = metaVal;
     }
 
-    console.log("values", values);
-    console.log("metaValues", metaValues);
-
     await Promise.all([
       this.db
         .updateTable(resourceName)

--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -403,8 +403,6 @@ export class SQLStorage extends Storage {
   private convertToMaterializedLiveType<T extends LiveObjectAny>(
     value: Record<string, any>
   ): MaterializedLiveType<T> {
-    if (!value._meta) throw new Error("Missing _meta");
-
     return {
       value: Object.entries(value).reduce((acc, [key, val]) => {
         if (key === "_meta") return acc;

--- a/packages/live-state/test/server/storage.test.ts
+++ b/packages/live-state/test/server/storage.test.ts
@@ -363,6 +363,9 @@ describe("SQLStorage", () => {
       execute: vi.fn().mockResolvedValue([]),
       insertInto: vi.fn().mockReturnThis(),
       values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
       updateTable: vi.fn().mockReturnThis(),
       set: vi.fn().mockReturnThis(),
       transaction: vi.fn().mockReturnValue({
@@ -377,6 +380,11 @@ describe("SQLStorage", () => {
             execute: vi.fn().mockResolvedValue(undefined),
             insertInto: vi.fn().mockReturnThis(),
             values: vi.fn().mockReturnThis(),
+            onConflict: vi.fn().mockReturnValue({
+              column: vi.fn().mockReturnValue({
+                doUpdateSet: vi.fn().mockReturnThis(),
+              }),
+            }),
           })
         ),
       }),
@@ -792,6 +800,9 @@ describe("SQLStorage", () => {
     // Mock insertInto chain for both tables
     const mockInsertInto = {
       values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
       execute: vi.fn().mockResolvedValue(undefined),
     };
     mockDb.insertInto.mockReturnValue(mockInsertInto);
@@ -849,13 +860,24 @@ describe("SQLStorage", () => {
     };
     mockDb.updateTable.mockReturnValue(mockUpdateTable);
 
+    // Mock insertInto chain for meta table
+    const mockInsertInto = {
+      values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDb.insertInto.mockReturnValue(mockInsertInto);
+
     const result = await storage.rawUpdate("users", "test-id", mockValue);
 
     expect(mockDb.updateTable).toHaveBeenCalledWith("users");
-    expect(mockDb.updateTable).toHaveBeenCalledWith("users_meta");
+    expect(mockDb.insertInto).toHaveBeenCalledWith("users_meta");
     expect(mockUpdateTable.set).toHaveBeenCalledWith({ name: "John" });
-    expect(mockUpdateTable.set).toHaveBeenCalledWith({
+    expect(mockInsertInto.values).toHaveBeenCalledWith({
       name: "2023-01-01T00:00:00.000Z",
+      id: "test-id",
     });
     expect(mockUpdateTable.where).toHaveBeenCalledWith("id", "=", "test-id");
     expect(result).toEqual(mockValue);
@@ -1396,6 +1418,9 @@ describe("SQLStorage", () => {
     // Mock insertInto chain for both tables
     const mockInsertInto = {
       values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
       execute: vi.fn().mockResolvedValue(undefined),
     };
     mockDb.insertInto.mockReturnValue(mockInsertInto);
@@ -1452,11 +1477,22 @@ describe("SQLStorage", () => {
     };
     mockDb.updateTable.mockReturnValue(mockUpdateTable);
 
+    // Mock insertInto chain for meta table
+    const mockInsertInto = {
+      values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
+      execute: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDb.insertInto.mockReturnValue(mockInsertInto);
+
     const result = await storage.rawUpdate("users", "test-id", mockValue);
 
     expect(mockDb.updateTable).toHaveBeenCalledWith("users");
-    expect(mockDb.updateTable).toHaveBeenCalledWith("users_meta");
+    expect(mockDb.insertInto).toHaveBeenCalledWith("users_meta");
     expect(mockUpdateTable.set).toHaveBeenCalledWith({});
+    expect(mockInsertInto.values).toHaveBeenCalledWith({ id: "test-id" });
     expect(result).toEqual(mockValue);
   });
 
@@ -1758,6 +1794,9 @@ describe("SQLStorage", () => {
     // Mock insertInto chain for both tables
     const mockInsertInto = {
       values: vi.fn().mockReturnThis(),
+      onConflict: vi.fn().mockReturnValue({
+        execute: vi.fn().mockResolvedValue(undefined),
+      }),
       execute: vi.fn().mockResolvedValue(undefined),
     };
     mockDb.insertInto.mockReturnValue(mockInsertInto);

--- a/packages/live-state/test/server/storage.test.ts
+++ b/packages/live-state/test/server/storage.test.ts
@@ -861,7 +861,7 @@ describe("SQLStorage", () => {
     expect(result).toEqual(mockValue);
   });
 
-  test("should throw error when convertToMaterializedLiveType receives value without _meta", () => {
+  test.skip("should throw error when convertToMaterializedLiveType receives value without _meta", () => {
     const value = { id: "test-id", name: "John" };
 
     expect(() => (storage as any).convertToMaterializedLiveType(value)).toThrow(


### PR DESCRIPTION
fix(server): handle optional _meta

fix: handle updates where entry didn't had any meta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Improved metadata persistence with conflict-aware upsert behavior during updates.
    - Prevented failures when metadata is missing by deriving timestamps when available.
- **Tests**
    - Expanded coverage for conflict-resolution flows and updated expectations for metadata inserts.
    - Skipped outdated tests relying on strict metadata presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->