### PR TITLE
fix(server): handle nested many-to-one where clauses correctly

### DIFF
--- a/packages/live-state/src/server/storage/sql-utils.ts
+++ b/packages/live-state/src/server/storage/sql-utils.ts
@@ -80,11 +80,6 @@ function innerApplyWhere<T extends LiveObjectAny>(
                 const otherResource = relation.entity.name;
 
                 if (relation.type === "many") {
-                  const parentColumn =
-                    "relationalColumn" in relation
-                      ? relation.relationalColumn
-                      : "id";
-
                   return eb.exists(
                     applyWhere(
                       schema,
@@ -92,15 +87,13 @@ function innerApplyWhere<T extends LiveObjectAny>(
                       eb
                         .selectFrom(otherResource)
                         // @ts-expect-error
-                        .select("id"),
-                      {
-                        $and: [
-                          val,
-                          {
-                            [`${otherResource}.${relation.foreignColumn}`]: `${resource}.${parentColumn}`,
-                          },
-                        ],
-                      }
+                        .select("id")
+                        .whereRef(
+                          relation.foreignColumn,
+                          "=",
+                          `${resource}.id`
+                        ),
+                      val
                     )
                   );
                 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
    - Fixed many-type relation filtering in nested queries by tightening how relational predicates are expressed, improving match accuracy.
- **Improvements**
    - More reliable deep relation filtering across multiple levels, with clearer handling of comparison operators and nulls.
- **Tests**
    - Expanded and strengthened tests for EXISTS-based subqueries and complex nested conditions; added targeted structural assertions, adjusted fixtures, and skipped unsupported deep one-to-one scenarios with TODO markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->