### PR TITLE
chore: deprecate default mutations

### DIFF
--- a/packages/live-state/src/client/types.ts
+++ b/packages/live-state/src/client/types.ts
@@ -124,9 +124,11 @@ type CollectionMutateType<
   TShouldAwait extends boolean,
 > = TRoute["resourceSchema"] extends LiveObjectAny
   ? {
+      /** @deprecated Use custom mutations instead. Default insert will be removed in a future version. */
       insert: (
         input: Simplify<InferInsert<TRoute["resourceSchema"]>>
       ) => ConditionalPromise<void, TShouldAwait>;
+      /** @deprecated Use custom mutations instead. Default update will be removed in a future version. */
       update: (
         id: string,
         value: Simplify<InferUpdate<TRoute["resourceSchema"]>>

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -483,6 +483,7 @@ class InnerClient implements QueryExecutor {
     return this.store.subscribe(query, callback);
   }
 
+  /** @deprecated Use custom mutations instead. Default insert/update mutations will be removed in a future version. */
   public mutate(
     routeName: string,
     resourceId: string,


### PR DESCRIPTION
## Summary
- Mark default `insert` and `update` mutation methods as `@deprecated` on the client type definitions and internal WebSocket client method
- Prompts users to migrate to custom mutations instead

## Test plan
- [ ] Verify IDE shows deprecation strikethrough on `mutate.<route>.insert()` and `mutate.<route>.update()`
- [ ] Confirm `pnpm typecheck` passes
- [ ] Confirm no runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * Default insert and update mutation operations have been marked as deprecated and will be removed in a future release. Users should begin transitioning to alternative mutation approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->