### PR TITLE
feat: implement hooks system for lifecycle events in schema

### DIFF
--- a/packages/live-state/src/server/hooks.ts
+++ b/packages/live-state/src/server/hooks.ts
@@ -1,0 +1,169 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: hooks operate generically over any entity shape */
+
+import { inferValue, type LiveObjectAny, type MaterializedLiveType, type Schema } from "../schema";
+import type {
+	AfterInsertHook,
+	AfterUpdateHook,
+	BeforeInsertHook,
+	BeforeUpdateHook,
+	Hooks,
+} from "./router";
+
+/**
+ * Schema-keyed registry of lifecycle hooks.
+ *
+ * Top-level keys are constrained to entity names on `TSchema`. Per-entity
+ * payloads (`value`, `rawValue`, `previousValue`, …) are inferred from the
+ * corresponding `TSchema[K]` collection shape.
+ */
+export type HooksRegistry<
+	TSchema extends Schema<any>,
+	TContext = Record<string, any>,
+> = {
+	[K in keyof TSchema]?: TSchema[K] extends LiveObjectAny
+		? Hooks<TSchema[K], TSchema, TContext>
+		: never;
+};
+
+/**
+ * Declares lifecycle hooks for a schema.
+ *
+ * Identity function whose generic parameters constrain the returned object's
+ * top-level keys to schema entity names and thread `TContext` through to
+ * handler payloads.
+ *
+ * @example
+ * ```ts
+ * const hooks = defineHooks<typeof schema, AppContext>({
+ *   posts: {
+ *     beforeInsert: ({ ctx, value }) => {
+ *       if (ctx?.role !== "admin") throw new Error("Unauthorized");
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export const defineHooks = <
+	TSchema extends Schema<any>,
+	TContext = Record<string, any>,
+>(
+	definition: HooksRegistry<TSchema, TContext>,
+): HooksRegistry<TSchema, TContext> => definition;
+
+const HOOK_NAMES = [
+	"beforeInsert",
+	"afterInsert",
+	"beforeUpdate",
+	"afterUpdate",
+] as const satisfies readonly (keyof Hooks<any, any, any>)[];
+
+type AnyHooks = Hooks<any, any, any>;
+
+/**
+ * Composes a sequence of `beforeInsert` / `beforeUpdate` handlers into a single
+ * handler. The handlers run in order; if one returns a transformed raw value,
+ * the next handler sees it via `value` / `rawValue`. A handler returning
+ * `void` passes the current value through unchanged.
+ */
+const composeBeforeHandlers = <
+	THook extends BeforeInsertHook<any, any, any> | BeforeUpdateHook<any, any, any>,
+>(
+	handlers: THook[],
+): THook => {
+	if (handlers.length === 1) return handlers[0]!;
+	return (async (opts: any) => {
+		let currentRaw: MaterializedLiveType<LiveObjectAny> = opts.rawValue;
+		let currentValue: any = opts.value;
+		let changed = false;
+		for (const handler of handlers) {
+			const result = await handler({
+				...opts,
+				value: currentValue,
+				rawValue: currentRaw,
+			});
+			if (result) {
+				currentRaw = result as MaterializedLiveType<LiveObjectAny>;
+				currentValue = inferValue(currentRaw) as any;
+				currentValue.id = opts.value.id;
+				changed = true;
+			}
+		}
+		return changed ? currentRaw : undefined;
+	}) as THook;
+};
+
+/**
+ * Composes a sequence of `afterInsert` / `afterUpdate` handlers into a single
+ * handler that awaits each in order.
+ */
+const composeAfterHandlers = <
+	THook extends AfterInsertHook<any, any, any> | AfterUpdateHook<any, any, any>,
+>(
+	handlers: THook[],
+): THook => {
+	if (handlers.length === 1) return handlers[0]!;
+	return (async (opts: any) => {
+		for (const handler of handlers) {
+			await handler(opts);
+		}
+	}) as THook;
+};
+
+/**
+ * Combines per-entity hook slices by chaining handlers for the same entity and
+ * hook name in argument order.
+ *
+ * `before*` handlers thread their return value through the chain (a returned
+ * raw value replaces the current value for subsequent handlers). `after*`
+ * handlers simply run sequentially.
+ */
+export const mergeEntityHooks = (
+	slices: Array<AnyHooks | undefined>,
+): AnyHooks | undefined => {
+	const defined = slices.filter((s): s is AnyHooks => s != null);
+	if (defined.length === 0) return undefined;
+	if (defined.length === 1) return defined[0]!;
+
+	const merged: AnyHooks = {};
+	for (const name of HOOK_NAMES) {
+		const handlers = defined
+			.map((s) => s[name])
+			.filter((h): h is NonNullable<AnyHooks[typeof name]> => h != null);
+		if (handlers.length === 0) continue;
+		if (name === "afterInsert" || name === "afterUpdate") {
+			(merged as any)[name] = composeAfterHandlers(handlers as any);
+		} else {
+			(merged as any)[name] = composeBeforeHandlers(handlers as any);
+		}
+	}
+	return merged;
+};
+
+/**
+ * Combines multiple `defineHooks` slices into a single registry. Handlers for
+ * the same entity and hook name run sequentially in argument order; a slice
+ * that transforms a value in `beforeInsert` / `beforeUpdate` hands the result
+ * to subsequent slices.
+ */
+export const mergeHooks = <
+	TSchema extends Schema<any>,
+	TContext = Record<string, any>,
+>(
+	...definitions: HooksRegistry<TSchema, TContext>[]
+): HooksRegistry<TSchema, TContext> => {
+	const result: Record<string, AnyHooks> = {};
+	const entityKeys = new Set<string>();
+	for (const def of definitions) {
+		for (const key of Object.keys(def as Record<string, unknown>)) {
+			entityKeys.add(key);
+		}
+	}
+	for (const key of Array.from(entityKeys)) {
+		const slices = definitions.map(
+			(def) => (def as Record<string, AnyHooks | undefined>)[key],
+		);
+		const merged = mergeEntityHooks(slices);
+		if (merged) result[key] = merged;
+	}
+	return result as HooksRegistry<TSchema, TContext>;
+};

--- a/packages/live-state/src/server/index.ts
+++ b/packages/live-state/src/server/index.ts
@@ -9,11 +9,13 @@ import type { PromiseOrSync } from "../core/utils";
 import { mergeWhereClauses } from "../core/utils";
 import { inferValue, type Schema, type WhereClause } from "../schema";
 import { createLogger, type Logger, LogLevel } from "../utils";
-import type { AnyRouter, AnyRouteOrProcedure, QueryProcedureRequest, QueryResult, Route } from "./router";
+import { mergeEntityHooks, type HooksRegistry } from "./hooks";
+import type { AnyRouter, AnyRouteOrProcedure, Hooks, QueryProcedureRequest, QueryResult, Route } from "./router";
 import type { Storage } from "./storage";
 import type { Batcher } from "./storage/batcher";
 
 export * from "./adapters/express";
+export * from "./hooks";
 export * from "./router";
 export * from "./storage";
 
@@ -63,6 +65,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
   readonly schema: Schema<any>;
   readonly middlewares: Set<Middleware<any>> = new Set();
   readonly logger: Logger;
+  readonly hooksRegistry: Map<string, Hooks<any, any, any>> = new Map();
 
   contextProvider?: ContextProvider<TContext>;
 
@@ -75,6 +78,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     schema: Schema<any>;
     middlewares?: Middleware<any>[];
     contextProvider?: ContextProvider<TContext>;
+    hooks?: HooksRegistry<any, TContext>;
     logLevel?: LogLevel;
   }) {
     this.router = opts.router;
@@ -85,6 +89,25 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     });
     opts.middlewares?.forEach((middleware) => {
       this.middlewares.add(middleware);
+    });
+
+    const routerHooks = this.router.hooksRegistry as
+      | Map<string, Hooks<any, any, any>>
+      | undefined;
+    const entityKeys = new Set<string>();
+    if (routerHooks) {
+      routerHooks.forEach((_, key) => {
+        entityKeys.add(key);
+      });
+    }
+    if (opts.hooks) {
+      for (const key of Object.keys(opts.hooks)) entityKeys.add(key);
+    }
+    entityKeys.forEach((key) => {
+      const v2 = routerHooks?.get(key);
+      const v3 = opts.hooks?.[key] as Hooks<any, any, any> | undefined;
+      const merged = mergeEntityHooks([v2, v3]);
+      if (merged) this.hooksRegistry.set(key, merged);
     });
 
     this.storage.init(this.schema, this.logger, this);
@@ -176,6 +199,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     schema: Schema<any>;
     middlewares?: Middleware<any>[];
     contextProvider: ContextProvider<TContext>;
+    hooks?: HooksRegistry<any, TContext>;
     logLevel?: LogLevel;
   }): Server<TRouter, TContext>;
   public static create<TRouter extends AnyRouter>(opts: {
@@ -183,6 +207,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     storage: Storage;
     schema: Schema<any>;
     middlewares?: Middleware<any>[];
+    hooks?: HooksRegistry<any, Record<string, any>>;
     logLevel?: LogLevel;
   }): Server<TRouter, Record<string, any>>;
   public static create<TRouter extends AnyRouter, TContext = Record<string, any>>(opts: {
@@ -191,9 +216,14 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     schema: Schema<any>;
     middlewares?: Middleware<any>[];
     contextProvider?: ContextProvider<TContext>;
+    hooks?: HooksRegistry<any, TContext>;
     logLevel?: LogLevel;
   }) {
     return new Server<TRouter, TContext>(opts);
+  }
+
+  public getHooks(resourceName: string): Hooks<any, any, any> | undefined {
+    return this.hooksRegistry.get(resourceName);
   }
 
   public handleQuery(opts: {

--- a/packages/live-state/src/server/index.ts
+++ b/packages/live-state/src/server/index.ts
@@ -66,6 +66,8 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
   readonly middlewares: Set<Middleware<any>> = new Set();
   readonly logger: Logger;
   readonly hooksRegistry: Map<string, Hooks<any, any, any>> = new Map();
+  private readonly initPromise: Promise<void>;
+  private initError?: unknown;
 
   contextProvider?: ContextProvider<TContext>;
 
@@ -110,7 +112,11 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
       if (merged) this.hooksRegistry.set(key, merged);
     });
 
-    this.storage.init(this.schema, this.logger, this);
+    this.initPromise = this.storage
+      .init(this.schema, this.logger, this)
+      .catch((error) => {
+        this.initError = error;
+      });
     this.contextProvider = opts.contextProvider;
 
     this.queryEngine = new QueryEngine({
@@ -226,10 +232,12 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     return this.hooksRegistry.get(resourceName);
   }
 
-  public handleQuery(opts: {
+  public async handleQuery(opts: {
     req: QueryRequest;
     subscription?: (mutation: DefaultMutation) => void;
   }): Promise<QueryResult<any>> {
+    await this.ensureInitialized();
+
     return this.wrapInMiddlewares(async (req: QueryRequest) => {
       const { headers, cookies, queryParams, context, ...rawQuery } = req;
 
@@ -262,6 +270,8 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
   }
 
   public async handleMutation(opts: { req: MutationRequest }): Promise<any> {
+    await this.ensureInitialized();
+
     const result = await this.wrapInMiddlewares(
       async (req: MutationRequest) => {
         const route = this.router.routes[req.resource] as
@@ -287,6 +297,8 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
     req: QueryProcedureRequest;
     subscription?: (mutation: DefaultMutation) => void;
   }): Promise<any> {
+    await this.ensureInitialized();
+
     const result = await this.wrapInMiddlewares(
       async (req: QueryProcedureRequest) => {
         const route = this.router.routes[req.resource] as
@@ -371,6 +383,14 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
           middleware({ req, next: next as NextFunction<any, any> }),
         next
       )(req);
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    await this.initPromise;
+
+    if (this.initError) {
+      throw this.initError;
+    }
   }
 }
 

--- a/packages/live-state/src/server/router.ts
+++ b/packages/live-state/src/server/router.ts
@@ -382,6 +382,9 @@ export class Route<
     return this.withProcedures(({ mutation }) => mutationFactory({ mutation }));
   }
 
+  /**
+   * @deprecated Declare hooks with `defineHooks` and pass them to `server({ hooks })` instead.
+   */
   public withHooks(hooks: Hooks<TResourceSchema, TSchema, TContext>) {
     return new Route<
       TResourceSchema,

--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -260,7 +260,7 @@ export class SQLStorage extends Storage {
     mutationId?: string,
     context?: Record<string, any>,
   ): Promise<RawMutationResult<T>> {
-    const hooks = this.server?.router?.getHooks(resourceName);
+    const hooks: any = this.server?.getHooks(resourceName);
     const entity = this.schema?.[resourceName];
 
     const [mergedRecord, acceptedValues] = entity?.mergeMutation?.(
@@ -387,7 +387,7 @@ export class SQLStorage extends Storage {
     mutationId?: string,
     context?: Record<string, any>,
   ): Promise<RawMutationResult<T>> {
-    const hooks = this.server?.router?.getHooks(resourceName);
+    const hooks: any = this.server?.getHooks(resourceName);
     const entity = this.schema?.[resourceName];
 
     const existingRecord = await this.rawFindById<T>(resourceName, resourceId);

--- a/packages/live-state/test/server/hooks.test.ts
+++ b/packages/live-state/test/server/hooks.test.ts
@@ -1,0 +1,318 @@
+import Database from "better-sqlite3";
+import { Kysely, SqliteDialect, type Selectable } from "kysely";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	createRelations,
+	createSchema,
+	id,
+	number,
+	object,
+	reference,
+	string,
+} from "../../src/schema";
+import {
+	defineHooks,
+	mergeHooks,
+	routeFactory,
+	router,
+	server,
+	type Server,
+} from "../../src/server";
+import { SQLStorage } from "../../src/server/storage";
+
+const group = object("groups", {
+	id: id(),
+	name: string(),
+});
+
+const card = object("cards", {
+	id: id(),
+	name: string(),
+	counter: number(),
+	groupId: reference("groups.id"),
+});
+
+const groupRelations = createRelations(group, ({ many }) => ({
+	cards: many(card, "groupId"),
+}));
+
+const cardRelations = createRelations(card, ({ one }) => ({
+	group: one(group, "groupId"),
+}));
+
+const schema = createSchema({
+	group,
+	card,
+	groupRelations,
+	cardRelations,
+});
+
+type TestContext = { role: "admin" | "user" };
+
+describe("defineHooks", () => {
+	test("returns the definition object untouched", () => {
+		const def = defineHooks<typeof schema, TestContext>({
+			groups: { beforeInsert: vi.fn() },
+		});
+		expect(def.groups?.beforeInsert).toBeDefined();
+	});
+});
+
+describe("mergeHooks", () => {
+	test("combines slices across different entities", () => {
+		const a = defineHooks<typeof schema>({
+			groups: { beforeInsert: vi.fn() },
+		});
+		const b = defineHooks<typeof schema>({
+			cards: { afterInsert: vi.fn() },
+		});
+		const merged = mergeHooks(a, b);
+		expect(merged.groups?.beforeInsert).toBeDefined();
+		expect(merged.cards?.afterInsert).toBeDefined();
+	});
+
+	test("runs afterInsert handlers sequentially in argument order", async () => {
+		const calls: string[] = [];
+		const first = vi.fn(async () => {
+			calls.push("first");
+		});
+		const second = vi.fn(async () => {
+			calls.push("second");
+		});
+		const merged = mergeHooks<typeof schema>(
+			{ groups: { afterInsert: first } },
+			{ groups: { afterInsert: second } },
+		);
+		await merged.groups?.afterInsert?.({
+			value: { id: "g1" } as any,
+			rawValue: {} as any,
+			db: {} as any,
+		});
+		expect(calls).toEqual(["first", "second"]);
+	});
+
+	test("beforeInsert chain threads transformed raw value to next handler", async () => {
+		const seen: Array<Record<string, unknown>> = [];
+		const first = vi.fn(async (opts: any) => {
+			seen.push({ handler: "first", value: opts.value });
+			return {
+				value: { ...opts.rawValue.value, name: { value: "transformed" } },
+			};
+		});
+		const second = vi.fn(async (opts: any) => {
+			seen.push({ handler: "second", value: opts.value });
+		});
+		const merged = mergeHooks<typeof schema>(
+			{ groups: { beforeInsert: first } },
+			{ groups: { beforeInsert: second } },
+		);
+
+		const result = await merged.groups?.beforeInsert?.({
+			value: { id: "g1", name: "original" } as any,
+			rawValue: { value: { name: { value: "original" } } } as any,
+			db: {} as any,
+		});
+
+		expect(first).toHaveBeenCalledOnce();
+		expect(second).toHaveBeenCalledOnce();
+		expect((seen[1]?.value as { name: string }).name).toBe("transformed");
+		expect(result).toBeDefined();
+	});
+
+	test("beforeInsert chain returns undefined when no handler transforms", async () => {
+		const merged = mergeHooks<typeof schema>(
+			{ groups: { beforeInsert: vi.fn(async () => {}) } },
+			{ groups: { beforeInsert: vi.fn(async () => {}) } },
+		);
+		const result = await merged.groups?.beforeInsert?.({
+			value: { id: "g1", name: "n" } as any,
+			rawValue: { value: { name: { value: "n" } } } as any,
+			db: {} as any,
+		});
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("Server hooks registry", () => {
+	let db: Database.Database;
+	let kyselyDb: Kysely<{ [x: string]: Selectable<any> }>;
+	let storage: SQLStorage;
+	let testServer: Server<any, any>;
+
+	const publicRoute = routeFactory<typeof schema>();
+	const testRouter = router({
+		schema,
+		routes: {
+			groups: publicRoute.collectionRoute(schema.groups),
+			cards: publicRoute.collectionRoute(schema.cards),
+		},
+	});
+
+	const encode = (input: Record<string, unknown>) =>
+		schema.groups.encodeMutation("set", input as any, new Date().toISOString());
+
+	const insertGroup = (srv: Server<any, any>, id: string, name: string) =>
+		srv.handleMutation({
+			req: {
+				type: "MUTATE",
+				resource: "groups",
+				resourceId: id,
+				procedure: "INSERT",
+				input: encode({ name }),
+				headers: {},
+				cookies: {},
+				queryParams: {},
+				context: {},
+			},
+		});
+
+	const updateGroup = (srv: Server<any, any>, id: string, name: string) =>
+		srv.handleMutation({
+			req: {
+				type: "MUTATE",
+				resource: "groups",
+				resourceId: id,
+				procedure: "UPDATE",
+				input: encode({ name }),
+				headers: {},
+				cookies: {},
+				queryParams: {},
+				context: {},
+			},
+		});
+
+	beforeEach(async () => {
+		db = new Database(":memory:");
+		db.pragma("foreign_keys = ON");
+		kyselyDb = new Kysely({
+			dialect: new SqliteDialect({ database: db }),
+		});
+		storage = new SQLStorage(kyselyDb, schema);
+		await storage.init(schema);
+	});
+
+	afterEach(async () => {
+		await kyselyDb.destroy();
+	});
+
+	test("getHooks returns hooks from defineHooks", () => {
+		const hooks = defineHooks<typeof schema>({
+			groups: { beforeInsert: vi.fn() },
+		});
+		testServer = server({
+			router: testRouter,
+			storage,
+			schema,
+			hooks,
+		});
+		expect(testServer.getHooks("groups")).toBeDefined();
+		expect(testServer.getHooks("cards")).toBeUndefined();
+		expect(testServer.getHooks("nonexistent")).toBeUndefined();
+	});
+
+	test("beforeInsert and afterInsert fire on INSERT mutation", async () => {
+		const beforeInsert = vi.fn();
+		const afterInsert = vi.fn();
+		testServer = server({
+			router: testRouter,
+			storage,
+			schema,
+			hooks: defineHooks<typeof schema>({
+				groups: { beforeInsert, afterInsert },
+			}),
+		});
+
+		await insertGroup(testServer, "g1", "Alpha");
+
+		expect(beforeInsert).toHaveBeenCalledOnce();
+		expect(afterInsert).toHaveBeenCalledOnce();
+		const beforeArgs = beforeInsert.mock.calls[0]![0];
+		expect(beforeArgs.value.id).toBe("g1");
+		expect(beforeArgs.value.name).toBe("Alpha");
+	});
+
+	test("beforeUpdate and afterUpdate fire on UPDATE mutation", async () => {
+		const beforeUpdate = vi.fn();
+		const afterUpdate = vi.fn();
+		testServer = server({
+			router: testRouter,
+			storage,
+			schema,
+			hooks: defineHooks<typeof schema>({
+				groups: { beforeUpdate, afterUpdate },
+			}),
+		});
+
+		await insertGroup(testServer, "g1", "Alpha");
+		await updateGroup(testServer, "g1", "Beta");
+
+		expect(beforeUpdate).toHaveBeenCalledOnce();
+		expect(afterUpdate).toHaveBeenCalledOnce();
+		const args = afterUpdate.mock.calls[0]![0];
+		expect(args.previousValue?.name).toBe("Alpha");
+		expect(args.value.name).toBe("Beta");
+	});
+
+	test("mergeHooks slices both run on the same mutation in order", async () => {
+		const calls: string[] = [];
+		const sliceA = defineHooks<typeof schema>({
+			groups: {
+				beforeInsert: async () => {
+					calls.push("A");
+				},
+			},
+		});
+		const sliceB = defineHooks<typeof schema>({
+			groups: {
+				beforeInsert: async () => {
+					calls.push("B");
+				},
+			},
+		});
+		testServer = server({
+			router: testRouter,
+			storage,
+			schema,
+			hooks: mergeHooks(sliceA, sliceB),
+		});
+
+		await insertGroup(testServer, "g1", "Alpha");
+
+		expect(calls).toEqual(["A", "B"]);
+	});
+
+	test("V3 hooks chain with V2 route-level hooks (V2 runs first)", async () => {
+		const calls: string[] = [];
+		const v2Route = routeFactory<typeof schema>()
+			.collectionRoute(schema.groups)
+			.withHooks({
+				beforeInsert: async () => {
+					calls.push("v2");
+				},
+			});
+		const mixedRouter = router({
+			schema,
+			routes: {
+				groups: v2Route,
+				cards: publicRoute.collectionRoute(schema.cards),
+			},
+		});
+
+		testServer = server({
+			router: mixedRouter,
+			storage,
+			schema,
+			hooks: defineHooks<typeof schema>({
+				groups: {
+					beforeInsert: async () => {
+						calls.push("v3");
+					},
+				},
+			}),
+		});
+
+		await insertGroup(testServer, "g1", "Alpha");
+
+		expect(calls).toEqual(["v2", "v3"]);
+	});
+});

--- a/packages/live-state/test/types/hooks.test-d.ts
+++ b/packages/live-state/test/types/hooks.test-d.ts
@@ -1,0 +1,80 @@
+import { describe, expectTypeOf, test } from "vitest";
+import {
+	createSchema,
+	id,
+	object,
+	reference,
+	string,
+} from "../../src/schema";
+import {
+	defineHooks,
+	mergeHooks,
+	type HooksRegistry,
+} from "../../src/server/hooks";
+
+const user = object("users", {
+	id: id(),
+	name: string(),
+});
+
+const post = object("posts", {
+	id: id(),
+	title: string(),
+	authorId: reference("users.id"),
+});
+
+const schema = createSchema({
+	users: user,
+	posts: post,
+});
+
+type AppContext = { user: string; role: "admin" | "user" };
+
+describe("defineHooks", () => {
+	test("accepts schema entity keys", () => {
+		const hooks = defineHooks<typeof schema, AppContext>({
+			users: {
+				beforeInsert: ({ ctx, value }) => {
+					expectTypeOf(ctx).toEqualTypeOf<AppContext | undefined>();
+					expectTypeOf(value.id).toEqualTypeOf<string>();
+				},
+			},
+			posts: {
+				afterInsert: ({ value }) => {
+					expectTypeOf(value.id).toEqualTypeOf<string>();
+				},
+			},
+		});
+		expectTypeOf(hooks).toEqualTypeOf<HooksRegistry<typeof schema, AppContext>>();
+	});
+
+	test("rejects unknown entity keys", () => {
+		defineHooks<typeof schema, AppContext>({
+			// @ts-expect-error not a schema entity
+			widgets: { beforeInsert: () => {} },
+		});
+	});
+
+	test("defaults TContext to Record<string, any>", () => {
+		defineHooks<typeof schema>({
+			users: {
+				beforeInsert: ({ ctx }) => {
+					expectTypeOf(ctx).toEqualTypeOf<Record<string, any> | undefined>();
+				},
+			},
+		});
+	});
+});
+
+describe("mergeHooks", () => {
+	test("returns a HooksRegistry", () => {
+		const a = defineHooks<typeof schema, AppContext>({
+			users: { beforeInsert: () => {} },
+		});
+		const b = defineHooks<typeof schema, AppContext>({
+			posts: { afterInsert: () => {} },
+		});
+		const merged = mergeHooks(a, b);
+		expectTypeOf(merged).toEqualTypeOf<HooksRegistry<typeof schema, AppContext>>();
+	});
+});


### PR DESCRIPTION
This PR introduces a new hooks system that allows users to define lifecycle hooks for various schema entities. The `defineHooks` function enables the declaration of hooks such as `beforeInsert`, `afterInsert`, `beforeUpdate`, and `afterUpdate`, which can be merged and executed in sequence. Additionally, the `Server` class has been updated to support a hooks registry, allowing for the retrieval and management of hooks associated with different resources.

New tests have been added to ensure the functionality of the hooks system, including the correct execution order of hooks and their integration with the server's mutation handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a strongly-typed lifecycle hook system supporting `beforeInsert`, `afterInsert`, `beforeUpdate`, and `afterUpdate` events for entities
  * Hooks can be centrally defined and passed to the server, with support for composing multiple hook definitions
  * Added a method to retrieve merged hooks for specific resources

* **Deprecations**
  * Route-level hooks are now deprecated; define hooks at the server level instead

<!-- end of auto-generated comment: release notes by coderabbit.ai -->