### PR TITLE
feat: prioritize custom insert/update procedures

### DIFF
--- a/packages/live-state/src/client/fetch/index.ts
+++ b/packages/live-state/src/client/fetch/index.ts
@@ -64,6 +64,32 @@ const safeFetch = async (
   return data;
 };
 
+const isUnknownProcedureError = (error: unknown): boolean => {
+  // TODO: Remove this helper when default mutation fallback is removed.
+  if (error instanceof Error && error.message.includes("Unknown procedure")) {
+    return true;
+  }
+
+  if (
+    error instanceof Error &&
+    typeof error.cause === "object" &&
+    error.cause !== null &&
+    ("message" in error.cause || "code" in error.cause)
+  ) {
+    const cause = error.cause as { message?: unknown; code?: unknown };
+    const causeMessage = cause.message;
+    const hasUnknownProcedureCode =
+      cause.code === "UNKNOWN_PROCEDURE" ||
+      cause.code === "unknown_procedure";
+    const hasUnknownProcedureMessage =
+      typeof causeMessage === "string" &&
+      causeMessage.includes("Unknown procedure");
+    return hasUnknownProcedureCode || hasUnknownProcedureMessage;
+  }
+
+  return false;
+};
+
 const serializeNullValues = (value: any): any => {
   if (value === null) {
     return "null";
@@ -217,8 +243,31 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
         const headers = (await consumeGeneratable(opts.credentials)) ?? {};
 
         if (method === "insert") {
-          const { id, ...input } = argumentsList[0];
-          await safeFetch(
+          // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
+          try {
+            return await safeFetch(
+              `${opts.url}/${route}/${method}`,
+              {
+                method: "POST",
+                headers: {
+                  ...headers,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  payload: argumentsList[0],
+                  meta: { timestamp: new Date().toISOString() },
+                }),
+              },
+              opts.fetchOptions,
+            );
+          } catch (error) {
+            if (!isUnknownProcedureError(error)) {
+              throw error;
+            }
+          }
+
+          const { id, ...input } = argumentsList[0] ?? {};
+          return await safeFetch(
             `${opts.url}/${route}/insert`,
             {
               method: "POST",
@@ -237,14 +286,46 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
             },
             opts.fetchOptions,
           );
-          return;
         }
 
         if (method === "update") {
-          const [id, input] = argumentsList;
+          // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
+          const customPayload =
+            argumentsList.length > 1 &&
+            typeof argumentsList[0] === "string" &&
+            typeof argumentsList[1] === "object" &&
+            argumentsList[1] !== null
+              ? { id: argumentsList[0], ...argumentsList[1] }
+              : argumentsList[0];
 
-          const { id: _id, ...rest } = input;
-          await safeFetch(
+          try {
+            return await safeFetch(
+              `${opts.url}/${route}/${method}`,
+              {
+                method: "POST",
+                headers: {
+                  ...headers,
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  payload: customPayload,
+                  meta: { timestamp: new Date().toISOString() },
+                }),
+              },
+              opts.fetchOptions,
+            );
+          } catch (error) {
+            if (!isUnknownProcedureError(error)) {
+              throw error;
+            }
+          }
+
+          const [id, input] =
+            argumentsList.length > 1
+              ? argumentsList
+              : [argumentsList[0]?.id, argumentsList[0]];
+          const { id: _id, ...rest } = input ?? {};
+          return await safeFetch(
             `${opts.url}/${route}/update`,
             {
               method: "POST",
@@ -263,7 +344,6 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
             },
             opts.fetchOptions,
           );
-          return;
         }
 
         return await safeFetch(

--- a/packages/live-state/src/client/types.ts
+++ b/packages/live-state/src/client/types.ts
@@ -123,17 +123,21 @@ type CollectionMutateType<
   TRoute extends ClientRouterConstraint["routes"][string],
   TShouldAwait extends boolean,
 > = TRoute["resourceSchema"] extends LiveObjectAny
-  ? {
-      /** @deprecated Use custom mutations instead. Default insert will be removed in a future version. */
-      insert: (
-        input: Simplify<InferInsert<TRoute["resourceSchema"]>>
-      ) => ConditionalPromise<void, TShouldAwait>;
-      /** @deprecated Use custom mutations instead. Default update will be removed in a future version. */
-      update: (
-        id: string,
-        value: Simplify<InferUpdate<TRoute["resourceSchema"]>>
-      ) => ConditionalPromise<void, TShouldAwait>;
-    } & {
+  ? Omit<
+      {
+        /** @deprecated Use custom mutations instead. Default insert will be removed in a future version. */
+        insert: (
+          input: Simplify<InferInsert<TRoute["resourceSchema"]>>
+        ) => ConditionalPromise<void, TShouldAwait>;
+        /** @deprecated Use custom mutations instead. Default update will be removed in a future version. */
+        update: (
+          id: string,
+          value: Simplify<InferUpdate<TRoute["resourceSchema"]>>
+        ) => ConditionalPromise<void, TShouldAwait>;
+      },
+      // TODO: Remove default-mutation compatibility typing when default mutations are removed.
+      Extract<keyof TRoute["customMutations"], "insert" | "update">
+    > & {
       [K2 in keyof TRoute["customMutations"]]: CustomMutationFunction<
         InferSchema<TRoute["customMutations"][K2]["inputValidator"]>,
         ReturnType<TRoute["customMutations"][K2]["handler"]>

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -47,6 +47,28 @@ interface WebSocketClientOptions<TSchema extends Schema<any> = Schema<any>>
   };
 }
 
+const isUnknownProcedureError = (error: unknown): boolean => {
+  // TODO: Remove this helper when default mutation fallback is removed.
+  if (error instanceof Error && error.message.includes("Unknown procedure")) {
+    return true;
+  }
+
+  if (
+    error instanceof Error &&
+    typeof error.cause === "object" &&
+    error.cause !== null &&
+    "message" in error.cause
+  ) {
+    const causeMessage = (error.cause as { message?: unknown }).message;
+    return (
+      typeof causeMessage === "string" &&
+      causeMessage.includes("Unknown procedure")
+    );
+  }
+
+  return false;
+};
+
 export type ConnectionStateChangeEvent = {
   type: "CONNECTION_STATE_CHANGE";
   open: boolean;
@@ -835,7 +857,7 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
         },
       }),
       mutate: createObservable(() => {}, {
-        apply: (_, path, argumentsList) => {
+        apply: async (_, path, argumentsList) => {
           if (path.length < 2) return;
           if (path.length > 2)
             throw new Error("Trying to access an invalid path");
@@ -843,12 +865,41 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
           const [route, method] = path;
 
           if (method === "insert") {
-            const { id, ...input } = argumentsList[0];
+            // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
+            try {
+              return await ogClient.genericMutate(route, method, argumentsList[0]);
+            } catch (error) {
+              if (!isUnknownProcedureError(error)) {
+                throw error;
+              }
+            }
+
+            const { id, ...input } = argumentsList[0] ?? {};
             return ogClient.mutate(route, id, "INSERT", input);
           }
 
           if (method === "update") {
-            const [id, input] = argumentsList;
+            // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
+            const customPayload =
+              argumentsList.length > 1 &&
+              typeof argumentsList[0] === "string" &&
+              typeof argumentsList[1] === "object" &&
+              argumentsList[1] !== null
+                ? { id: argumentsList[0], ...argumentsList[1] }
+                : argumentsList[0];
+
+            try {
+              return await ogClient.genericMutate(route, method, customPayload);
+            } catch (error) {
+              if (!isUnknownProcedureError(error)) {
+                throw error;
+              }
+            }
+
+            const [id, input] =
+              argumentsList.length > 1
+                ? argumentsList
+                : [argumentsList[0]?.id, argumentsList[0]];
             return ogClient.mutate(route, id, "UPDATE", input);
           }
 

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -857,7 +857,7 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
         },
       }),
       mutate: createObservable(() => {}, {
-        apply: async (_, path, argumentsList) => {
+        apply: (_, path, argumentsList) => {
           if (path.length < 2) return;
           if (path.length > 2)
             throw new Error("Trying to access an invalid path");
@@ -866,16 +866,16 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
 
           if (method === "insert") {
             // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
-            try {
-              return await ogClient.genericMutate(route, method, argumentsList[0]);
-            } catch (error) {
-              if (!isUnknownProcedureError(error)) {
-                throw error;
-              }
-            }
+            return ogClient
+              .genericMutate(route, method, argumentsList[0])
+              .catch((error) => {
+                if (!isUnknownProcedureError(error)) {
+                  throw error;
+                }
 
-            const { id, ...input } = argumentsList[0] ?? {};
-            return ogClient.mutate(route, id, "INSERT", input);
+                const { id, ...input } = argumentsList[0] ?? {};
+                return ogClient.mutate(route, id, "INSERT", input);
+              });
           }
 
           if (method === "update") {
@@ -888,19 +888,19 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
                 ? { id: argumentsList[0], ...argumentsList[1] }
                 : argumentsList[0];
 
-            try {
-              return await ogClient.genericMutate(route, method, customPayload);
-            } catch (error) {
-              if (!isUnknownProcedureError(error)) {
-                throw error;
-              }
-            }
+            return ogClient
+              .genericMutate(route, method, customPayload)
+              .catch((error) => {
+                if (!isUnknownProcedureError(error)) {
+                  throw error;
+                }
 
-            const [id, input] =
-              argumentsList.length > 1
-                ? argumentsList
-                : [argumentsList[0]?.id, argumentsList[0]];
-            return ogClient.mutate(route, id, "UPDATE", input);
+                const [id, input] =
+                  argumentsList.length > 1
+                    ? argumentsList
+                    : [argumentsList[0]?.id, argumentsList[0]];
+                return ogClient.mutate(route, id, "UPDATE", input);
+              });
           }
 
           return ogClient.genericMutate(route, method, argumentsList[0]);

--- a/packages/live-state/src/server/router.ts
+++ b/packages/live-state/src/server/router.ts
@@ -351,23 +351,29 @@ export class Route<
     }
 
     type ExtractMutations<R> = {
-      [K in keyof R as R[K] extends Mutation<any, any> ? K : never]: R[K];
+      [K in keyof R as R[K] extends Mutation<any, any> ? K : never]: Extract<
+        R[K],
+        Mutation<any, any>
+      >;
     };
     type ExtractQueries<R> = {
-      [K in keyof R as R[K] extends Query<any, any> ? K : never]: R[K];
+      [K in keyof R as R[K] extends Query<any, any> ? K : never]: Extract<
+        R[K],
+        Query<any, any>
+      >;
     };
 
     return new Route<
       TResourceSchema,
       TMiddleware,
-      ExtractMutations<T> & Record<string, Mutation<any, any>>,
-      ExtractQueries<T> & Record<string, Query<any, any>>,
+      ExtractMutations<T>,
+      ExtractQueries<T>,
       TSchema,
       TContext
     >(
       this.resourceSchema,
-      mutations as ExtractMutations<T> & Record<string, Mutation<any, any>>,
-      queries as ExtractQueries<T> & Record<string, Query<any, any>>,
+      mutations as ExtractMutations<T>,
+      queries as ExtractQueries<T>,
       this.authorization,
       this.hooks,
     );
@@ -474,9 +480,25 @@ export class Route<
     return await this.wrapInMiddlewares(async (req: MutationRequest) => {
       if (!req.procedure)
         throw new Error("Procedure is required for mutations");
-      const customProcedure = this.customMutations[req.procedure];
+      // TODO: Remove this INSERT/UPDATE alias resolution when default mutations are removed.
+      const fallbackCustomProcedureName =
+        req.procedure === "INSERT"
+          ? "insert"
+          : req.procedure === "UPDATE"
+            ? "update"
+            : undefined;
+      const resolvedCustomProcedureName =
+        this.customMutations[req.procedure]
+          ? req.procedure
+          : fallbackCustomProcedureName &&
+              this.customMutations[fallbackCustomProcedureName]
+            ? fallbackCustomProcedureName
+            : req.procedure;
+      const customProcedure =
+        this.customMutations[resolvedCustomProcedureName];
 
       if (customProcedure) {
+        req.procedure = resolvedCustomProcedureName;
         const validationResult = customProcedure.inputValidator[
           "~standard"
         ].validate(req.input);

--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -164,21 +164,29 @@ export const httpTransportLayer = (
           const rawBody = request.body ? await request.json() : {};
 
           let body: HttpMutation;
+          let mutationProcedure = procedure;
 
           if (procedure === "insert" || procedure === "update") {
-            const { success, data, error } =
-              httpDefaultMutationSchema.safeParse(rawBody);
-            if (!success) {
-              return Response.json(
-                {
-                  message: "Invalid mutation",
-                  code: "INVALID_REQUEST",
-                  details: error,
-                },
-                { status: 400 }
-              );
+            // TODO: Remove dual parsing (legacy default + generic) when default mutations are removed.
+            const defaultResult = httpDefaultMutationSchema.safeParse(rawBody);
+            if (defaultResult.success) {
+              body = defaultResult.data;
+              mutationProcedure = procedure.toUpperCase();
+            } else {
+              const genericResult = httpGenericMutationSchema.safeParse(rawBody);
+              if (!genericResult.success) {
+                return Response.json(
+                  {
+                    message: "Invalid mutation",
+                    code: "INVALID_REQUEST",
+                    details: genericResult.error,
+                  },
+                  { status: 400 }
+                );
+              }
+
+              body = genericResult.data;
             }
-            body = data;
           } else {
             const { success, data, error } =
               httpGenericMutationSchema.safeParse(rawBody);
@@ -203,10 +211,7 @@ export const httpTransportLayer = (
               input: body.payload,
               context: initialContext,
               resourceId: (body as DefaultMutation).resourceId,
-              procedure:
-                procedure === "insert" || procedure === "update"
-                  ? procedure.toUpperCase()
-                  : procedure,
+              procedure: mutationProcedure,
               queryParams: {},
               meta: (body as any).meta,
             },
@@ -215,6 +220,17 @@ export const httpTransportLayer = (
           return Response.json(result);
         } catch (e) {
           logger.error("Error parsing mutation from the client:", e);
+
+          if (
+            e instanceof Error &&
+            e.message.includes("Unknown procedure")
+          ) {
+            // TODO: Remove UNKNOWN_PROCEDURE compatibility response when default mutation fallback is removed.
+            return Response.json(
+              { message: e.message, code: "UNKNOWN_PROCEDURE" },
+              { status: 400 }
+            );
+          }
 
           return Response.json(
             { message: "Internal server error", code: "INTERNAL_SERVER_ERROR" },

--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -173,6 +173,22 @@ export const httpTransportLayer = (
               body = defaultResult.data;
               mutationProcedure = procedure.toUpperCase();
             } else {
+              const hasGenericMutationShape =
+                typeof rawBody === "object" &&
+                rawBody !== null &&
+                "payload" in rawBody &&
+                "meta" in rawBody;
+              if (!hasGenericMutationShape) {
+                return Response.json(
+                  {
+                    message: "Invalid mutation",
+                    code: "INVALID_REQUEST",
+                    details: defaultResult.error,
+                  },
+                  { status: 400 }
+                );
+              }
+
               const genericResult = httpGenericMutationSchema.safeParse(rawBody);
               if (!genericResult.success) {
                 return Response.json(

--- a/packages/live-state/test/client/fetch.test.ts
+++ b/packages/live-state/test/client/fetch.test.ts
@@ -373,13 +373,19 @@ describe("createClient", () => {
             Authorization: "Bearer token",
             "Content-Type": "application/json",
           },
-          body: expect.stringContaining('"resourceId":"1"'),
+          body: expect.stringContaining('"payload":{"id":"1","name":"John"}'),
         }
       );
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(body).toHaveProperty("resourceId", "1");
-      expect(body).toHaveProperty("payload");
+      expect(body).toEqual(
+        expect.objectContaining({
+          payload: { id: "1", name: "John" },
+          meta: expect.objectContaining({
+            timestamp: expect.any(String),
+          }),
+        })
+      );
     });
 
     test("should handle insert without credentials", async () => {
@@ -438,7 +444,9 @@ describe("createClient", () => {
           headers: {
             "Content-Type": "application/json",
           },
-          body: expect.stringContaining('"resourceId":"1"'),
+          body: expect.stringContaining(
+            '"payload":{"id":"1","title":"Test Post","authorId":"user1"}'
+          ),
         }
       );
     });
@@ -471,13 +479,19 @@ describe("createClient", () => {
             Authorization: "Bearer token",
             "Content-Type": "application/json",
           },
-          body: expect.stringContaining('"resourceId":"1"'),
+          body: expect.stringContaining('"payload":{"id":"1","name":"John Updated"}'),
         }
       );
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(body).toHaveProperty("resourceId", "1");
-      expect(body).toHaveProperty("payload");
+      expect(body).toEqual(
+        expect.objectContaining({
+          payload: { id: "1", name: "John Updated" },
+          meta: expect.objectContaining({
+            timestamp: expect.any(String),
+          }),
+        })
+      );
     });
 
     test("should exclude id from update payload", async () => {
@@ -499,7 +513,7 @@ describe("createClient", () => {
       await client.mutate.users.update("1", updateData);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(body.payload).not.toHaveProperty("id");
+      expect(body.payload).toHaveProperty("id", "1");
     });
 
     test("should handle different routes for update", async () => {
@@ -527,7 +541,7 @@ describe("createClient", () => {
           headers: {
             "Content-Type": "application/json",
           },
-          body: expect.stringContaining('"resourceId":"1"'),
+          body: expect.stringContaining('"payload":{"id":"1","title":"Updated Post"}'),
         }
       );
     });
@@ -786,8 +800,8 @@ describe("createClient", () => {
       await client.mutate.users.insert(userData);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(body.payload.name).toHaveProperty("_meta");
-      expect(body.payload.name._meta).toHaveProperty("timestamp");
+      expect(body.payload.name).toBe("John");
+      expect(body.meta).toHaveProperty("timestamp");
     });
 
     test("should handle different mutation types", async () => {
@@ -809,8 +823,8 @@ describe("createClient", () => {
       await client.mutate.users.update("1", updateData);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(body.payload.name).toHaveProperty("_meta");
-      expect(body.payload.name._meta).toHaveProperty("timestamp");
+      expect(body.payload.name).toBe("John Updated");
+      expect(body.meta).toHaveProperty("timestamp");
     });
   });
 

--- a/packages/live-state/test/e2e/custom-procedures.test.ts
+++ b/packages/live-state/test/e2e/custom-procedures.test.ts
@@ -493,15 +493,20 @@ describe("Custom Procedures End-to-End Tests", () => {
         likes: 1,
       });
 
+      await wsClient.store.mutate.posts.update(postId, {
+        title: "Fallback Post Updated",
+        likes: 3,
+      });
+
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       const posts = await wsClient.store.query.posts.get();
       const createdPost = posts.find((post) => post.id === postId);
       expect(createdPost).toBeDefined();
-      expect(createdPost?.title).toBe("Fallback Post");
+      expect(createdPost?.title).toBe("Fallback Post Updated");
       expect(createdPost?.content).toBe("Uses default insert");
       expect(createdPost?.authorId).toBe(authorId);
-      expect(createdPost?.likes).toBe(1);
+      expect(createdPost?.likes).toBe(3);
     });
 
     test("should call custom mutation with input", async () => {
@@ -739,13 +744,18 @@ describe("Custom Procedures End-to-End Tests", () => {
         likes: 2,
       });
 
+      await fetchClient.mutate.posts.update(postId, {
+        title: "Fetch Fallback Post Updated",
+        likes: 4,
+      });
+
       const posts = await fetchClient.query.posts.get();
       const createdPost = posts.find((post: any) => post.id === postId);
       expect(createdPost).toBeDefined();
-      expect(createdPost?.title).toBe("Fetch Fallback Post");
+      expect(createdPost?.title).toBe("Fetch Fallback Post Updated");
       expect(createdPost?.content).toBe("Uses default insert");
       expect(createdPost?.authorId).toBe(authorId);
-      expect(createdPost?.likes).toBe(2);
+      expect(createdPost?.likes).toBe(4);
     });
 
     test("should call custom mutation with input", async () => {

--- a/packages/live-state/test/e2e/custom-procedures.test.ts
+++ b/packages/live-state/test/e2e/custom-procedures.test.ts
@@ -161,6 +161,53 @@ const testRouter = router({
           return { updatedIds: updated, count: updated.length };
         }),
       })),
+    priorityUsers: publicRoute
+      .collectionRoute(testSchema.users)
+      .withProcedures(({ mutation }) => ({
+        insert: mutation(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            email: z.string(),
+            reject: z.boolean().optional(),
+          })
+        ).handler(async ({ req, db }) => {
+          if (req.input.reject) {
+            throw new Error("Custom insert rejected");
+          }
+
+          await db.users.insert({
+            id: req.input.id,
+            name: `[CUSTOM] ${req.input.name}`,
+            email: req.input.email,
+          });
+
+          return { id: req.input.id, source: "custom-insert" };
+        }),
+        update: mutation(
+          z.object({
+            id: z.string(),
+            name: z.string().optional(),
+            email: z.string().optional(),
+            reject: z.boolean().optional(),
+          })
+        ).handler(async ({ req, db }) => {
+          if (req.input.reject) {
+            throw new Error("Custom update rejected");
+          }
+
+          const updateValue = {
+            ...(req.input.name
+              ? { name: `[CUSTOM UPDATE] ${req.input.name}` }
+              : {}),
+            ...(req.input.email ? { email: req.input.email } : {}),
+          };
+
+          await db.users.update(req.input.id, updateValue);
+
+          return { id: req.input.id, source: "custom-update" };
+        }),
+      })),
 
     posts: publicRoute.collectionRoute(testSchema.posts),
   },
@@ -379,6 +426,84 @@ describe("Custom Procedures End-to-End Tests", () => {
   });
 
   describe("WebSocket Client - Custom Mutations", () => {
+    test("should prefer custom insert/update procedures for insert and update methods", async () => {
+      const customUserId = generateId();
+      const insertResult = await wsClient.store.mutate.priorityUsers.insert({
+        id: customUserId,
+        name: "Priority User",
+        email: "priority@example.com",
+      });
+
+      expect(insertResult).toBeDefined();
+      expect(insertResult.id).toBe(customUserId);
+      expect(insertResult.source).toBe("custom-insert");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const updateResult = await wsClient.store.mutate.priorityUsers.update({
+        id: customUserId,
+        name: "Renamed Priority User",
+      });
+
+      expect(updateResult).toBeDefined();
+      expect(updateResult.id).toBe(customUserId);
+      expect(updateResult.source).toBe("custom-update");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const users = await wsClient.store.query.users.get();
+      const updatedUser = users.find((u) => u.id === customUserId);
+      expect(updatedUser).toBeDefined();
+      expect(updatedUser?.name).toBe("[CUSTOM UPDATE] Renamed Priority User");
+      expect(updatedUser?.email).toBe("priority@example.com");
+    });
+
+    test("should not fallback to default mutation when custom procedure rejects", async () => {
+      const rejectedUserId = generateId();
+
+      await expect(
+        wsClient.store.mutate.priorityUsers.insert({
+          id: rejectedUserId,
+          name: "Rejected User",
+          email: "rejected@example.com",
+          reject: true,
+        })
+      ).rejects.toThrow("Custom insert rejected");
+
+      const users = await wsClient.store.query.users.get();
+      const rejectedUser = users.find((u) => u.id === rejectedUserId);
+      expect(rejectedUser).toBeUndefined();
+    });
+
+    test("should fallback to legacy default mutation when custom insert/update does not exist", async () => {
+      const authorId = generateId();
+      const postId = generateId();
+
+      await storage.insert(testSchema.users, {
+        id: authorId,
+        name: "Fallback Author",
+        email: "fallback-author@example.com",
+      });
+
+      await wsClient.store.mutate.posts.insert({
+        id: postId,
+        title: "Fallback Post",
+        content: "Uses default insert",
+        authorId,
+        likes: 1,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const posts = await wsClient.store.query.posts.get();
+      const createdPost = posts.find((post) => post.id === postId);
+      expect(createdPost).toBeDefined();
+      expect(createdPost?.title).toBe("Fallback Post");
+      expect(createdPost?.content).toBe("Uses default insert");
+      expect(createdPost?.authorId).toBe(authorId);
+      expect(createdPost?.likes).toBe(1);
+    });
+
     test("should call custom mutation with input", async () => {
       const result = await wsClient.store.mutate.users.createUserWithRole({
         name: "Admin User",
@@ -566,6 +691,63 @@ describe("Custom Procedures End-to-End Tests", () => {
   });
 
   describe("Fetch Client - Custom Mutations", () => {
+    test("should prefer custom insert/update procedures for insert and update methods", async () => {
+      const customUserId = generateId();
+      const insertResult = await fetchClient.mutate.priorityUsers.insert({
+        id: customUserId,
+        name: "Fetch Priority User",
+        email: "fetch-priority@example.com",
+      });
+
+      expect(insertResult).toBeDefined();
+      expect(insertResult.id).toBe(customUserId);
+      expect(insertResult.source).toBe("custom-insert");
+
+      const updateResult = await fetchClient.mutate.priorityUsers.update({
+        id: customUserId,
+        name: "Fetch Renamed Priority User",
+      });
+
+      expect(updateResult).toBeDefined();
+      expect(updateResult.id).toBe(customUserId);
+      expect(updateResult.source).toBe("custom-update");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const users = await fetchClient.query.users.get();
+      const updatedUser = users.find((u: any) => u.id === customUserId);
+      expect(updatedUser).toBeDefined();
+      expect(updatedUser?.name).toBe("[CUSTOM UPDATE] Fetch Renamed Priority User");
+      expect(updatedUser?.email).toBe("fetch-priority@example.com");
+    });
+
+    test("should fallback to legacy default mutation when custom insert/update does not exist", async () => {
+      const authorId = generateId();
+      const postId = generateId();
+
+      await storage.insert(testSchema.users, {
+        id: authorId,
+        name: "Fetch Fallback Author",
+        email: "fetch-fallback-author@example.com",
+      });
+
+      await fetchClient.mutate.posts.insert({
+        id: postId,
+        title: "Fetch Fallback Post",
+        content: "Uses default insert",
+        authorId,
+        likes: 2,
+      });
+
+      const posts = await fetchClient.query.posts.get();
+      const createdPost = posts.find((post: any) => post.id === postId);
+      expect(createdPost).toBeDefined();
+      expect(createdPost?.title).toBe("Fetch Fallback Post");
+      expect(createdPost?.content).toBe("Uses default insert");
+      expect(createdPost?.authorId).toBe(authorId);
+      expect(createdPost?.likes).toBe(2);
+    });
+
     test("should call custom mutation with input", async () => {
       const result = await fetchClient.mutate.users.createUserWithRole({
         name: "Guest User",

--- a/packages/live-state/test/types/client.test-d.ts
+++ b/packages/live-state/test/types/client.test-d.ts
@@ -1953,6 +1953,35 @@ const customMutationRouter = createRouter({
           };
         }),
 
+        // Custom insert/update names that should override legacy default signatures
+        insert: mutation(
+          z.object({
+            name: z.string(),
+            email: z.string().email(),
+            age: z.number(),
+          })
+        ).handler(async ({ req }) => {
+          return {
+            id: "inserted-user-123",
+            name: req.input.name,
+            email: req.input.email,
+            age: req.input.age,
+            source: "custom-insert" as const,
+          };
+        }),
+        update: mutation(
+          z.object({
+            id: z.string(),
+            name: z.string().optional(),
+            age: z.number().optional(),
+          })
+        ).handler(async ({ req }) => {
+          return {
+            id: req.input.id,
+            updated: true as const,
+          };
+        }),
+
         // Optional input mutation
         optionalGreeting: mutation(z.string().optional()).handler(
           async ({ req }) => {
@@ -2084,6 +2113,43 @@ describe("custom mutations websocket client", () => {
         name: string;
         email: string;
         age: number;
+      }>
+    >();
+  });
+
+  test("should use custom insert signature when insert mutation exists", () => {
+    const customInsertMutation = customMutationMutate.customMutationUsers.insert;
+
+    expectTypeOf(customInsertMutation).parameter(0).toEqualTypeOf<{
+      name: string;
+      email: string;
+      age: number;
+    }>();
+
+    expectTypeOf(customInsertMutation).returns.toEqualTypeOf<
+      Promise<{
+        id: string;
+        name: string;
+        email: string;
+        age: number;
+        source: "custom-insert";
+      }>
+    >();
+  });
+
+  test("should use custom update signature when update mutation exists", () => {
+    const customUpdateMutation = customMutationMutate.customMutationUsers.update;
+
+    expectTypeOf(customUpdateMutation).parameter(0).toEqualTypeOf<{
+      id: string;
+      name?: string | undefined;
+      age?: number | undefined;
+    }>();
+
+    expectTypeOf(customUpdateMutation).returns.toEqualTypeOf<
+      Promise<{
+        id: string;
+        updated: true;
       }>
     >();
   });
@@ -2255,6 +2321,45 @@ describe("custom mutations fetch client", () => {
         name: string;
         email: string;
         age: number;
+      }>
+    >();
+  });
+
+  test("should use custom insert signature when insert mutation exists with Promise", () => {
+    const customInsertMutation =
+      customMutationFetchClient.mutate.customMutationUsers.insert;
+
+    expectTypeOf(customInsertMutation).parameter(0).toEqualTypeOf<{
+      name: string;
+      email: string;
+      age: number;
+    }>();
+
+    expectTypeOf(customInsertMutation).returns.toEqualTypeOf<
+      Promise<{
+        id: string;
+        name: string;
+        email: string;
+        age: number;
+        source: "custom-insert";
+      }>
+    >();
+  });
+
+  test("should use custom update signature when update mutation exists with Promise", () => {
+    const customUpdateMutation =
+      customMutationFetchClient.mutate.customMutationUsers.update;
+
+    expectTypeOf(customUpdateMutation).parameter(0).toEqualTypeOf<{
+      id: string;
+      name?: string | undefined;
+      age?: number | undefined;
+    }>();
+
+    expectTypeOf(customUpdateMutation).returns.toEqualTypeOf<
+      Promise<{
+        id: string;
+        updated: true;
       }>
     >();
   });


### PR DESCRIPTION
## Summary
- prioritize custom `insert`/`update` procedures across server, websocket client, and fetch client
- keep legacy default `INSERT`/`UPDATE` behavior as fallback when custom procedures are not defined
- add e2e and type coverage for precedence, fallback, and compatibility TODO markers

## Test plan
- [x] `pnpm test --filter="./packages/*" -- test/e2e/custom-procedures.test.ts`
- [x] `pnpm test --filter="./packages/*" -- test/types/client.test-d.ts`
- [x] `pnpm typecheck --filter="./packages/*"`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mutations now automatically fall back to default behavior when custom procedures are unavailable, improving compatibility between legacy and new endpoints.

* **Bug Fixes**
  * Improved error detection for unknown procedure failures, with better handling across both direct and nested error structures.

* **Tests**
  * Added comprehensive end-to-end and type safety tests for custom mutation procedures and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->