### PR TITLE
feat: client bootstrap status + useClientState hook

### DIFF
--- a/packages/live-state/src/client/react.tsx
+++ b/packages/live-state/src/client/react.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useSyncExternalStore } from 'react';
 import type { QueryBuilder } from '../core/query';
 import type {
 	CustomQueryRequest,
@@ -7,6 +7,7 @@ import type {
 import { hash } from '../utils';
 import type { Client } from '.';
 import type { ClientRouterConstraint } from './types';
+import type { ClientBootstrapStatus } from './websocket/client';
 
 class Store {
 	private subscriptions: Map<
@@ -80,6 +81,52 @@ export const useLiveQuery = <
 		),
 		observable.get,
 	) as ReturnType<T['get']>;
+};
+
+export type ClientState = {
+	bootstrapStatus: ClientBootstrapStatus;
+	connected: boolean;
+};
+
+export const useClientState = (
+	client: Client<ClientRouterConstraint>['client'],
+): ClientState => {
+	const { subscribe, getSnapshot } = useMemo(() => {
+		let snapshot: ClientState = {
+			bootstrapStatus: client.bootstrapStatus,
+			connected: client.ws.connected(),
+		};
+
+		const recompute = () => {
+			const next: ClientState = {
+				bootstrapStatus: client.bootstrapStatus,
+				connected: client.ws.connected(),
+			};
+			if (
+				next.bootstrapStatus !== snapshot.bootstrapStatus ||
+				next.connected !== snapshot.connected
+			) {
+				snapshot = next;
+			}
+		};
+
+		return {
+			subscribe: (cb: () => void) => {
+				return client.addEventListener((event) => {
+					if (
+						event.type === 'BOOTSTRAP_STATUS_CHANGE' ||
+						event.type === 'CONNECTION_STATE_CHANGE'
+					) {
+						recompute();
+						cb();
+					}
+				});
+			},
+			getSnapshot: () => snapshot,
+		};
+	}, [client]);
+
+	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 };
 
 export const useLoadData = (

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -168,6 +168,19 @@ export type OptimisticMutationUndoneEvent = {
   pendingMutations: number;
 };
 
+export type ClientBootstrapStatus = "pending" | "local" | "remote";
+
+export type BootstrapStatusChangeEvent = {
+  type: "BOOTSTRAP_STATUS_CHANGE";
+  bootstrapStatus: ClientBootstrapStatus;
+};
+
+const BOOTSTRAP_STATUS_RANK: Record<ClientBootstrapStatus, number> = {
+  pending: 0,
+  local: 1,
+  remote: 2,
+};
+
 export type ClientEvents =
   | ConnectionStateChangeEvent
   | MessageReceivedEvent
@@ -183,7 +196,8 @@ export type ClientEvents =
   | QuerySubscriptionTriggeredEvent
   | StoreStateUpdatedEvent
   | OptimisticMutationAppliedEvent
-  | OptimisticMutationUndoneEvent;
+  | OptimisticMutationUndoneEvent
+  | BootstrapStatusChangeEvent;
 
 class CustomQueryCall<TOutput> implements PromiseLike<TOutput> {
   public constructor(
@@ -233,12 +247,18 @@ class InnerClient implements QueryExecutor {
     }
   > = {};
 
+  private _bootstrapStatus: ClientBootstrapStatus = "pending";
+  private storageLoadedCount = 0;
+  private readonly expectedStorageLoads: number;
+
   public constructor(opts: WebSocketClientOptions) {
     this.url = opts.url;
     this.logger = createLogger({
       level: opts.logLevel ?? LogLevel.INFO,
     });
     this.optimisticMutations = opts.optimisticMutations;
+    this.expectedStorageLoads =
+      opts.storage === false ? 0 : Object.keys(opts.schema).length;
 
     this.store = new OptimisticStore(
       opts.schema,
@@ -269,6 +289,13 @@ class InnerClient implements QueryExecutor {
           resource,
           itemCount,
         });
+        this.storageLoadedCount += 1;
+        if (
+          this.expectedStorageLoads > 0 &&
+          this.storageLoadedCount >= this.expectedStorageLoads
+        ) {
+          this.setBootstrapStatus("local");
+        }
       },
       (query) => {
         this.emitEvent({
@@ -434,6 +461,8 @@ class InnerClient implements QueryExecutor {
           resource: parsedSyncData.resource,
           itemCount: parsedSyncData.data.length,
         });
+
+        this.setBootstrapStatus("remote");
       }
     } catch (e) {
       this.logger.error("Error parsing message from the server:", e);
@@ -741,6 +770,19 @@ class InnerClient implements QueryExecutor {
     });
   }
 
+  public get bootstrapStatus(): ClientBootstrapStatus {
+    return this._bootstrapStatus;
+  }
+
+  private setBootstrapStatus(next: ClientBootstrapStatus) {
+    if (
+      BOOTSTRAP_STATUS_RANK[next] <= BOOTSTRAP_STATUS_RANK[this._bootstrapStatus]
+    )
+      return;
+    this._bootstrapStatus = next;
+    this.emitEvent({ type: "BOOTSTRAP_STATUS_CHANGE", bootstrapStatus: next });
+  }
+
   public addEventListener(listener: (event: ClientEvents) => void) {
     this.eventListeners.add(listener);
     return () => {
@@ -783,6 +825,7 @@ class InnerClient implements QueryExecutor {
 export type Client<TRouter extends ClientRouterConstraint> = {
   client: {
     ws: WebSocketClient;
+    readonly bootstrapStatus: ClientBootstrapStatus;
     addEventListener: (listener: (event: ClientEvents) => void) => () => void;
     load: (query: RawQueryRequest | CustomQueryRequest) => () => void;
   };
@@ -820,6 +863,9 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
   return {
     client: {
       ws: ogClient.ws,
+      get bootstrapStatus() {
+        return ogClient.bootstrapStatus;
+      },
       load: (query: RawQueryRequest) => {
         return ogClient.load(query);
       },

--- a/packages/live-state/test/client/react.test.tsx
+++ b/packages/live-state/test/client/react.test.tsx
@@ -9,7 +9,11 @@ import {
   vi,
 } from "vitest";
 import { QueryBuilder } from "../../src/core/query";
-import { useLiveQuery, useLoadData } from "../../src/client/react";
+import {
+  useClientState,
+  useLiveQuery,
+  useLoadData,
+} from "../../src/client/react";
 import { Client } from "../../src/client/websocket/client";
 import { AnyRouter } from "../../src/server";
 
@@ -308,5 +312,96 @@ describe("useLoadData", () => {
     unmount();
 
     expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useClientState", () => {
+  type Listener = (event: any) => void;
+
+  const makeMockClient = (initial: {
+    bootstrapStatus?: "pending" | "local" | "remote";
+    connected?: boolean;
+  } = {}) => {
+    let bootstrapStatus = initial.bootstrapStatus ?? "pending";
+    let connected = initial.connected ?? false;
+    const listeners = new Set<Listener>();
+
+    const client = {
+      get bootstrapStatus() {
+        return bootstrapStatus;
+      },
+      ws: { connected: () => connected },
+      addEventListener: (cb: Listener) => {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+    };
+
+    const emit = (event: any) => {
+      for (const cb of listeners) cb(event);
+    };
+
+    return {
+      client,
+      emit,
+      setBootstrapStatus: (s: typeof bootstrapStatus) => {
+        bootstrapStatus = s;
+      },
+      setConnected: (c: boolean) => {
+        connected = c;
+      },
+    };
+  };
+
+  test("returns initial state", () => {
+    const { client } = makeMockClient({
+      bootstrapStatus: "local",
+      connected: true,
+    });
+
+    const { result } = renderHook(() => useClientState(client as any));
+
+    expect(result.current).toEqual({
+      bootstrapStatus: "local",
+      connected: true,
+    });
+  });
+
+  test("updates when bootstrap status changes", () => {
+    const ctx = makeMockClient();
+
+    const { result } = renderHook(() => useClientState(ctx.client as any));
+
+    expect(result.current.bootstrapStatus).toBe("pending");
+
+    ctx.setBootstrapStatus("remote");
+    ctx.emit({ type: "BOOTSTRAP_STATUS_CHANGE", bootstrapStatus: "remote" });
+
+    expect(result.current.bootstrapStatus).toBe("remote");
+  });
+
+  test("updates when connection state changes", () => {
+    const ctx = makeMockClient({ connected: false });
+
+    const { result } = renderHook(() => useClientState(ctx.client as any));
+
+    expect(result.current.connected).toBe(false);
+
+    ctx.setConnected(true);
+    ctx.emit({ type: "CONNECTION_STATE_CHANGE", open: true });
+
+    expect(result.current.connected).toBe(true);
+  });
+
+  test("ignores unrelated events", () => {
+    const ctx = makeMockClient();
+
+    const { result } = renderHook(() => useClientState(ctx.client as any));
+    const before = result.current;
+
+    ctx.emit({ type: "MESSAGE_RECEIVED", message: {} });
+
+    // Same reference — no re-render
+    expect(result.current).toBe(before);
   });
 });

--- a/packages/live-state/test/client/status.test.ts
+++ b/packages/live-state/test/client/status.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	type ClientEvents,
+	createClient,
+} from '../../src/client/websocket/client';
+import { createSchema, id, object, string } from '../../src/schema';
+
+class MockWebSocket {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+
+	readyState = MockWebSocket.CLOSED;
+	url: string;
+	eventListeners: Record<string, Array<(event: any) => void>> = {};
+
+	send = vi.fn();
+	close = vi.fn(() => {
+		this.readyState = MockWebSocket.CLOSED;
+		this.dispatchEvent(new CloseEvent('close'));
+	});
+
+	constructor(url: string) {
+		this.url = url;
+		this.readyState = MockWebSocket.CONNECTING;
+	}
+
+	addEventListener(event: string, callback: (event: any) => void): void {
+		(this.eventListeners[event] ??= []).push(callback);
+	}
+
+	removeEventListener(event: string, callback: (event: any) => void): void {
+		this.eventListeners[event] = (this.eventListeners[event] ?? []).filter(
+			(cb) => cb !== callback,
+		);
+	}
+
+	dispatchEvent(event: Event): boolean {
+		(this.eventListeners[event.type] ?? []).forEach((listener) =>
+			listener(event),
+		);
+		return true;
+	}
+
+	simulateOpen(): void {
+		this.readyState = MockWebSocket.OPEN;
+		this.dispatchEvent(new Event('open'));
+	}
+
+	simulateMessage(data: any): void {
+		this.dispatchEvent(new MessageEvent('message', { data }));
+	}
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+const posts = object('posts', {
+	id: id(),
+	title: string(),
+});
+
+const schema = createSchema({ posts });
+
+type TestRouter = {
+	routes: {
+		posts: {
+			resourceSchema: typeof posts;
+			customMutations: {};
+			customQueries: {};
+		};
+	};
+};
+
+const makeClient = async () => {
+	const client = createClient<TestRouter>({
+		url: 'ws://localhost:1234',
+		schema,
+		storage: false,
+		connection: { autoConnect: false, autoReconnect: false },
+	});
+	await client.client.ws.connect();
+	const ws = (client.client.ws as any).ws as MockWebSocket;
+	ws.simulateOpen();
+	return { client, ws };
+};
+
+const syncReply = (resource: string, data: any[] = []) =>
+	JSON.stringify({
+		type: 'REPLY',
+		id: `reply-${Math.random()}`,
+		data: { resource, data },
+	});
+
+describe('client bootstrap status', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		vi.clearAllTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('with storage: false, starts pending and goes straight to remote on first sync REPLY', async () => {
+		const { client, ws } = await makeClient();
+
+		expect(client.client.bootstrapStatus).toBe('pending');
+
+		const events: ClientEvents[] = [];
+		client.client.addEventListener((e) => events.push(e));
+
+		ws.simulateMessage(syncReply('posts', []));
+
+		expect(client.client.bootstrapStatus).toBe('remote');
+		const statusEvents = events.filter((e) => e.type === 'BOOTSTRAP_STATUS_CHANGE');
+		expect(statusEvents).toEqual([
+			{ type: 'BOOTSTRAP_STATUS_CHANGE', bootstrapStatus: 'remote' },
+		]);
+
+		client.client.ws.disconnect();
+	});
+
+	test('subsequent sync REPLYs do not emit further STATUS_CHANGE events', async () => {
+		const { client, ws } = await makeClient();
+
+		const events: ClientEvents[] = [];
+		client.client.addEventListener((e) => events.push(e));
+
+		ws.simulateMessage(syncReply('posts', []));
+		ws.simulateMessage(syncReply('posts', []));
+		ws.simulateMessage(syncReply('posts', []));
+
+		const statusEvents = events.filter((e) => e.type === 'BOOTSTRAP_STATUS_CHANGE');
+		expect(statusEvents).toHaveLength(1);
+		expect(client.client.bootstrapStatus).toBe('remote');
+
+		client.client.ws.disconnect();
+	});
+
+	test('custom-query REPLY (matched by replyHandlers) does not advance status', async () => {
+		const { client, ws } = await makeClient();
+
+		expect(client.client.bootstrapStatus).toBe('pending');
+
+		// Issue a custom query so its id is registered in replyHandlers.
+		// CustomQueryCall is PromiseLike — .then() triggers the actual send.
+		const queryPromise = (client.store.query.posts as any)
+			.somePostsQuery({})
+			.then((v: any) => v);
+
+		const sentRaw = ws.send.mock.calls.at(-1)?.[0];
+		expect(sentRaw).toBeDefined();
+		const sent = JSON.parse(sentRaw as string);
+		expect(sent.type).toBe('CUSTOM_QUERY');
+
+		ws.simulateMessage(
+			JSON.stringify({ type: 'REPLY', id: sent.id, data: { ok: true } }),
+		);
+
+		await expect(queryPromise).resolves.toEqual({ ok: true });
+
+		// Custom-query REPLY took the replyHandlers branch and returned early —
+		// status must remain pending.
+		expect(client.client.bootstrapStatus).toBe('pending');
+
+		client.client.ws.disconnect();
+	});
+});


### PR DESCRIPTION
## Summary
Related to #149 

- New `bootstrapStatus` (`\"pending\" | \"local\" | \"remote\"`) on the websocket client, with monotonic transitions and a `BOOTSTRAP_STATUS_CHANGE` event. `\"local\"` means the IndexedDB cache has hydrated; `\"remote\"` means the server has delivered at least one initial sync `REPLY`.
- New `useClientState(client)` React hook returning reactive `{ bootstrapStatus, connected }`.
- Foundation for #149 — consumers can now distinguish \"still syncing\" from \"empty result\". Wiring this into `useLiveQuery`'s return shape is left for a follow-up.

## Test plan
- [x] `pnpm typecheck --filter=\"./packages/*\"`
- [x] `pnpm test --filter=\"./packages/*\"` (new tests pass; only pre-existing flaky `Multi-Client Mutation Sync` e2e fails on `main` too)
- [ ] Manual smoke in an example app: log `BOOTSTRAP_STATUS_CHANGE` events on cold load (expect `pending → local → remote`) and warm load (`pending → remote` is acceptable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a React hook for accessing client bootstrap status and connection state, enabling developers to monitor state initialization progress and real-time connectivity in their applications.

* **Tests**
  * Added comprehensive test coverage for bootstrap status transitions and connection state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->