### PR TITLE
fix: HTTP generic insert/update shape routes to default mutation (#152)

### DIFF
--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -215,6 +215,15 @@ export const httpTransportLayer = (
               if (!hasCustomProcedure) {
                 const rawPayload = (body.payload ?? {}) as Record<string, any>;
                 const { id, ...rest } = rawPayload;
+                if (procedure === "update" && typeof id !== "string") {
+                  return Response.json(
+                    {
+                      message: "Invalid mutation: payload.id is required for update",
+                      code: "INVALID_REQUEST",
+                    },
+                    { status: 400 }
+                  );
+                }
                 resourceIdOverride =
                   typeof id === "string" ? id : undefined;
                 const collection = (server.schema as any)?.[resource];

--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -165,13 +165,15 @@ export const httpTransportLayer = (
 
           let body: HttpMutation;
           let mutationProcedure = procedure;
+          let resourceIdOverride: string | undefined;
+          let inputOverride: any;
 
           if (procedure === "insert" || procedure === "update") {
             // TODO: Remove dual parsing (legacy default + generic) when default mutations are removed.
             const defaultResult = httpDefaultMutationSchema.safeParse(rawBody);
+            mutationProcedure = procedure.toUpperCase();
             if (defaultResult.success) {
               body = defaultResult.data;
-              mutationProcedure = procedure.toUpperCase();
             } else {
               const hasGenericMutationShape =
                 typeof rawBody === "object" &&
@@ -202,6 +204,35 @@ export const httpTransportLayer = (
               }
 
               body = genericResult.data;
+
+              const route = (server.router as any)?.routes?.[resource];
+              const customProcedureName =
+                procedure === "insert" ? "insert" : "update";
+              const hasCustomProcedure = !!route?.customMutations?.[
+                customProcedureName
+              ];
+
+              if (!hasCustomProcedure) {
+                const rawPayload = (body.payload ?? {}) as Record<string, any>;
+                const { id, ...rest } = rawPayload;
+                resourceIdOverride =
+                  typeof id === "string" ? id : undefined;
+                const collection = (server.schema as any)?.[resource];
+                if (
+                  collection &&
+                  typeof collection.encodeMutation === "function"
+                ) {
+                  const timestamp =
+                    (body as any).meta?.timestamp ?? new Date().toISOString();
+                  inputOverride = collection.encodeMutation(
+                    "set",
+                    rest,
+                    timestamp
+                  );
+                } else {
+                  inputOverride = rest;
+                }
+              }
             }
           } else {
             const { success, data, error } =
@@ -224,9 +255,10 @@ export const httpTransportLayer = (
               ...baseRequestData,
               type: "MUTATE",
               resource: resource,
-              input: body.payload,
+              input: inputOverride ?? body.payload,
               context: initialContext,
-              resourceId: (body as DefaultMutation).resourceId,
+              resourceId:
+                resourceIdOverride ?? (body as DefaultMutation).resourceId,
               procedure: mutationProcedure,
               queryParams: {},
               meta: (body as any).meta,

--- a/packages/live-state/test/server/transport-layers/http.test.ts
+++ b/packages/live-state/test/server/transport-layers/http.test.ts
@@ -185,6 +185,40 @@ describe("httpTransportLayer", () => {
     });
   });
 
+  test("should handle POST request for insert mutation with generic shape", async () => {
+    const requestBody = {
+      payload: {
+        name: {
+          value: "John Generic",
+          _meta: { timestamp: "2023-01-01T00:00:00.000Z" },
+        },
+      },
+      meta: { timestamp: "2023-01-03T00:00:00.000Z" },
+    };
+
+    const request = new Request("http://localhost/users/insert", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(requestBody),
+    });
+
+    (mockServer.handleMutation as Mock).mockResolvedValue({
+      data: { name: "John Generic" },
+      acceptedValues: { name: "John Generic" },
+    });
+
+    const response = await httpHandler(request);
+
+    expect(response.status).toBe(200);
+    expect(mockServer.handleMutation).toHaveBeenCalledWith({
+      req: expect.objectContaining({
+        type: "MUTATE",
+        resource: "users",
+        procedure: "INSERT",
+      }),
+    });
+  });
+
   test("should handle POST request with custom mutation", async () => {
     const requestBody = {
       payload: { action: "approve" },


### PR DESCRIPTION
## Summary
- Fixes #152. The HTTP transport's generic-mutation fallback for `insert`/`update` left `mutationProcedure` lowercase, so `Server.handleMutation` threw `Unknown procedure: insert` whenever the fetch client sent the generic `{ payload, meta }` shape.
- Always uppercase `mutationProcedure` for `insert`/`update`, and when the route has no custom `insert`/`update` procedure, extract `resourceId` from `payload.id` and run the payload through `schema[resource].encodeMutation("set", ...)` so it reaches `handleSet` in the expected `{ value, _meta }` shape.
- When a custom `insert`/`update` procedure exists on the route, the raw payload is passed through unchanged so the custom handler receives its declared input.

## Test plan
- [x] `pnpm vitest run test/server/transport-layers/http.test.ts` (new generic-shape insert test added)
- [x] `pnpm vitest run test/e2e/procedure-only-routes.test.ts`
- [x] `pnpm vitest run test/e2e/custom-procedures.test.ts`
- [x] `pnpm typecheck --filter="./packages/*"`
- [x] `pnpm lint --filter="./packages/*" -- --diagnostic-level error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP mutation handling so insert/update requests can use optional overrides for resource ID and mutation input, ensuring timestamps and generic payload shapes are processed correctly.

* **Tests**
  * Added test coverage validating insert mutation request processing and end-to-end handling of generic request shapes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pedroscosta/live-state/pull/153)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->