### PR TITLE
fix: WS generic insert/update shape routes to default mutation (#154)

### DIFF
--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -590,7 +590,29 @@ class InnerClient implements QueryExecutor {
       procedure,
     );
 
-    if (!isConnected && !optimisticHandler) {
+    // TODO: Remove default-insert/update fallback optimistic when default mutations are removed.
+    const isDefaultMutationAlias =
+      (procedure === "insert" || procedure === "update") && !optimisticHandler;
+    const defaultMutationFallback =
+      isDefaultMutationAlias && this.store.schema[routeName]
+        ? (() => {
+            const rawPayload = (payload ?? {}) as Record<string, any>;
+            const { id, ...input } = rawPayload;
+            if (typeof id !== "string") return undefined;
+            try {
+              const encoded = this.store.schema[routeName].encodeMutation(
+                "set",
+                input as LiveObjectMutationInput<LiveObjectAny>,
+                new Date().toISOString(),
+              );
+              return { id, input, encoded };
+            } catch {
+              return undefined;
+            }
+          })()
+        : undefined;
+
+    if (!isConnected && !optimisticHandler && !defaultMutationFallback) {
       throw new Error("WebSocket not connected");
     }
 
@@ -603,7 +625,34 @@ class InnerClient implements QueryExecutor {
       meta: { timestamp: new Date().toISOString() },
     };
 
-    if (optimisticHandler) {
+    if (defaultMutationFallback) {
+      const defaultOptimisticMessage: DefaultMutationMessage = {
+        id: mutationMessage.id,
+        type: "MUTATE",
+        resource: routeName,
+        resourceId: defaultMutationFallback.id,
+        procedure: procedure === "insert" ? "INSERT" : "UPDATE",
+        payload: defaultMutationFallback.encoded,
+      };
+      this.store?.addMutation(routeName, defaultOptimisticMessage, true);
+      this.emitEvent({
+        type: "OPTIMISTIC_MUTATION_APPLIED",
+        mutationId: mutationMessage.id,
+        resource: routeName,
+        resourceId: defaultMutationFallback.id,
+        procedure: defaultOptimisticMessage.procedure,
+        pendingMutations:
+          (this.store.optimisticMutationStack[routeName]?.length ?? 0),
+      });
+      this.emitEvent({
+        type: "MUTATION_SENT",
+        mutationId: mutationMessage.id,
+        resource: routeName,
+        resourceId: defaultMutationFallback.id,
+        procedure,
+        optimistic: true,
+      });
+    } else if (optimisticHandler) {
       try {
         const { proxy, getOperations } = createOptimisticStorageProxy(
           this.store,

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -700,14 +700,34 @@ class InnerClient implements QueryExecutor {
       this.replyHandlers[mutationMessage.id] = {
         timeoutHandle: setTimeout(() => {
           delete this.replyHandlers[mutationMessage.id];
-          this.emitUndoEvents(
-            this.store.undoCustomMutation(mutationMessage.id),
-          );
+          // Default insert/update optimistic state lives under its own message
+          // id (no custom-mutation index), so roll it back directly on timeout.
+          if (defaultMutationFallback) {
+            const pendingMutations =
+              this.store.optimisticMutationStack[routeName]?.length ?? 0;
+            this.store.undoMutation(routeName, mutationMessage.id);
+            this.emitEvent({
+              type: "OPTIMISTIC_MUTATION_UNDONE",
+              mutationId: mutationMessage.id,
+              resource: routeName,
+              resourceId: defaultMutationFallback.id,
+              pendingMutations: Math.max(pendingMutations - 1, 0),
+            });
+          } else {
+            this.emitUndoEvents(
+              this.store.undoCustomMutation(mutationMessage.id),
+            );
+          }
           reject(new Error("Reply timeout"));
         }, 5000),
         handler: (data: any) => {
           delete this.replyHandlers[mutationMessage.id];
-          this.store.confirmCustomMutation(mutationMessage.id);
+          // Default insert/update optimistic state is reconciled by the server
+          // broadcast (matching the legacy default-mutation path), so leave it
+          // in place here; only custom mutations confirm via the index.
+          if (!defaultMutationFallback) {
+            this.store.confirmCustomMutation(mutationMessage.id);
+          }
           resolve(data);
         },
         reject,

--- a/packages/live-state/src/server/transport-layers/web-socket.ts
+++ b/packages/live-state/src/server/transport-layers/web-socket.ts
@@ -202,27 +202,82 @@ export const webSocketAdapter = (server: Server<AnyRouter, any>) => {
           const { resource } = parsedMessage;
           logger.debug("Received mutation from client:", parsedMessage);
           try {
+            const originalProcedure = (parsedMessage as GenericMutation)
+              .procedure;
+            let mutationProcedure = originalProcedure;
+            let mutationInput: any = parsedMessage.payload;
+            let mutationResourceId: string | undefined = (
+              parsedMessage as DefaultMutation
+            ).resourceId;
+
+            // TODO: Remove generic insert/update shape resolution when default mutations are removed.
+            if (
+              mutationProcedure === "insert" ||
+              mutationProcedure === "update"
+            ) {
+              const route = (server.router as any)?.routes?.[resource];
+              const hasCustomProcedure =
+                !!route?.customMutations?.[mutationProcedure];
+
+              if (!hasCustomProcedure) {
+                const rawPayload =
+                  (parsedMessage.payload ?? {}) as Record<string, any>;
+                const { id, ...rest } = rawPayload;
+                if (
+                  mutationProcedure === "update" &&
+                  typeof id !== "string"
+                ) {
+                  throw new Error(
+                    "Invalid mutation: payload.id is required for update",
+                  );
+                }
+                if (typeof id === "string") {
+                  mutationResourceId = id;
+                }
+                const collection = (server.schema as any)?.[resource];
+                if (
+                  collection &&
+                  typeof collection.encodeMutation === "function"
+                ) {
+                  const timestamp =
+                    (parsedMessage as GenericMutation).meta?.timestamp ??
+                    new Date().toISOString();
+                  mutationInput = collection.encodeMutation(
+                    "set",
+                    rest,
+                    timestamp,
+                  );
+                } else {
+                  mutationInput = rest;
+                }
+                mutationProcedure = mutationProcedure.toUpperCase();
+              }
+            }
+
             const result = await server.handleMutation({
               req: {
                 ...requestContext,
                 type: "MUTATE",
                 resource: resource,
-                input: parsedMessage.payload,
+                input: mutationInput,
                 context: {
                   messageId: parsedMessage.id,
                   ...((await initialContext) ?? {}),
                 },
-                resourceId: (parsedMessage as DefaultMutation).resourceId,
-                procedure: (parsedMessage as GenericMutation).procedure,
+                resourceId: mutationResourceId,
+                procedure: mutationProcedure,
                 queryParams: parsedQs,
                 meta: (parsedMessage as GenericMutation).meta,
               },
             });
 
             if (
-              (parsedMessage as GenericMutation).procedure &&
-              (parsedMessage as GenericMutation).procedure !== "INSERT" &&
-              (parsedMessage as GenericMutation).procedure !== "UPDATE"
+              (originalProcedure &&
+                originalProcedure !== "INSERT" &&
+                originalProcedure !== "UPDATE") ||
+              (mutationProcedure !== originalProcedure &&
+                (mutationProcedure === "INSERT" ||
+                  mutationProcedure === "UPDATE"))
             ) {
               reply({
                 id: parsedMessage.id,

--- a/packages/live-state/src/server/transport-layers/web-socket.ts
+++ b/packages/live-state/src/server/transport-layers/web-socket.ts
@@ -223,17 +223,12 @@ export const webSocketAdapter = (server: Server<AnyRouter, any>) => {
                 const rawPayload =
                   (parsedMessage.payload ?? {}) as Record<string, any>;
                 const { id, ...rest } = rawPayload;
-                if (
-                  mutationProcedure === "update" &&
-                  typeof id !== "string"
-                ) {
+                if (typeof id !== "string") {
                   throw new Error(
-                    "Invalid mutation: payload.id is required for update",
+                    `Invalid mutation: payload.id is required for ${mutationProcedure}`,
                   );
                 }
-                if (typeof id === "string") {
-                  mutationResourceId = id;
-                }
+                mutationResourceId = id;
                 const collection = (server.schema as any)?.[resource];
                 if (
                   collection &&

--- a/packages/live-state/test/server/transport-layers/web-socket.test.ts
+++ b/packages/live-state/test/server/transport-layers/web-socket.test.ts
@@ -314,6 +314,106 @@ describe("webSocketAdapter", () => {
     );
   });
 
+  test("should reshape generic insert/update with raw payload into default mutation when no custom procedure exists", async () => {
+    const encodeMutation = vi.fn().mockReturnValue({
+      name: {
+        value: "Alice",
+        _meta: { timestamp: "2023-01-03T00:00:00.000Z" },
+      },
+    });
+    (mockServer as any).schema.users.encodeMutation = encodeMutation;
+    (mockServer as any).router.routes.users.customMutations = {};
+
+    wsHandler(mockWebSocket, mockRequest);
+
+    const messageHandler = (mockWebSocket.on as Mock).mock.calls.find(
+      (call) => call[0] === "message",
+    )?.[1];
+
+    const mutateMessage = {
+      type: "MUTATE",
+      resource: "users",
+      procedure: "insert",
+      payload: { id: "user1", name: "Alice" },
+      meta: { timestamp: "2023-01-03T00:00:00.000Z" },
+      id: "msg-1",
+    };
+
+    (mockServer.handleMutation as Mock).mockResolvedValue({
+      data: { name: "Alice" },
+    });
+
+    await messageHandler(Buffer.from(JSON.stringify(mutateMessage)));
+
+    expect(encodeMutation).toHaveBeenCalledWith(
+      "set",
+      { name: "Alice" },
+      "2023-01-03T00:00:00.000Z",
+    );
+    expect(mockServer.handleMutation).toHaveBeenCalledWith({
+      req: expect.objectContaining({
+        type: "MUTATE",
+        resource: "users",
+        procedure: "INSERT",
+        resourceId: "user1",
+        input: {
+          name: {
+            value: "Alice",
+            _meta: { timestamp: "2023-01-03T00:00:00.000Z" },
+          },
+        },
+      }),
+    });
+
+    expect(mockWebSocket.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "msg-1",
+        type: "REPLY",
+        data: { data: { name: "Alice" } },
+      }),
+    );
+  });
+
+  test("should keep generic insert procedure when a custom mutation exists", async () => {
+    const customHandler = vi.fn();
+    (mockServer as any).router.routes.users.customMutations = {
+      insert: { handler: customHandler },
+    };
+
+    wsHandler(mockWebSocket, mockRequest);
+
+    const messageHandler = (mockWebSocket.on as Mock).mock.calls.find(
+      (call) => call[0] === "message",
+    )?.[1];
+
+    const mutateMessage = {
+      type: "MUTATE",
+      resource: "users",
+      procedure: "insert",
+      payload: { id: "user1", name: "Alice" },
+      id: "msg-1",
+    };
+
+    (mockServer.handleMutation as Mock).mockResolvedValue({ ok: true });
+
+    await messageHandler(Buffer.from(JSON.stringify(mutateMessage)));
+
+    expect(mockServer.handleMutation).toHaveBeenCalledWith({
+      req: expect.objectContaining({
+        procedure: "insert",
+        input: { id: "user1", name: "Alice" },
+      }),
+    });
+
+    expect(mockWebSocket.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "msg-1",
+        type: "REPLY",
+        data: { ok: true },
+      }),
+    );
+  });
+
   test("should handle MUTATE message error", async () => {
     wsHandler(mockWebSocket, mockRequest);
 


### PR DESCRIPTION
## Summary

- Fixes #154 — WS `client.x.insert(...)` no longer triggers `REJECT: Unknown procedure: insert`.
- Mirrors the HTTP fix from #152 at the WebSocket transport: when `procedure: "insert"`/`"update"` arrives with no matching custom mutation on the route, reshape into the default mutation form (extract `id` → `resourceId`, encode payload, uppercase procedure) so `route.handleMutation` routes through `handleSet`. A `REPLY` is now sent for the reshaped case so the client's awaiting `genericMutate` promise resolves.
- Client `genericMutate` now applies a default optimistic mutation locally for `insert`/`update` when no custom optimistic handler is registered, preserving the local-store population the prior post-rejection fallback provided.

## Test plan

- [x] `pnpm typecheck --filter="./packages/*"`
- [x] `pnpm lint --filter="./packages/*" -- --diagnostic-level error`
- [x] `pnpm test --filter="./packages/*"` (893 passed, 7 skipped)
- [x] Added WS transport tests: reshape generic `insert` into default `INSERT` when no custom procedure exists; pass through `procedure: "insert"` unchanged when a custom mutation is registered.
- [x] Existing e2e `should fallback to legacy default mutation when custom insert/update does not exist` still passes (now via the new path, not via the post-REJECT retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insert/update mutations now get a default optimistic fallback when no custom handler exists, giving immediate local updates and faster feedback.
* **Bug Fixes**
  * Server-side mutation handling normalizes generic insert/update payloads and suppresses unnecessary replies when normalization changes the procedure.
* **Tests**
  * Added tests covering normalized mutation handling and preservation of custom mutation routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->