### PR TITLE
refactor(examples): rebuild examples on custom procedures only

### DIFF
--- a/examples/complex-relations/src/router.ts
+++ b/examples/complex-relations/src/router.ts
@@ -1,10 +1,17 @@
-import { routeFactory, router, createMiddleware } from "@live-state/sync/server";
+import { createMiddleware, routeFactory, router } from "@live-state/sync/server";
+import { z } from "zod";
 
-import { schema } from "./schema";
 import { generateId } from "../../../packages/live-state/src/core/utils";
+import { schema } from "./schema";
 
 /*
  * Routes
+ *
+ * This example uses ONLY custom procedures for every write — there are no
+ * default `insert`/`update` mutations. Authorization that used to live in the
+ * declarative `insert`/`update` handlers is now done inline inside each mutation
+ * handler. Read-level authorization (query filtering) still lives on the route,
+ * since that is not a mutation.
  */
 
 type AppContext = { user: string };
@@ -22,58 +29,111 @@ const authMiddleware = createMiddleware<Record<string, any>, AppContext>(
 
 const protectedRoute = routeFactory<typeof schema>().use(authMiddleware);
 
+/**
+ * Throws unless `userId` is an admin of `organizationId`. Replaces the
+ * declarative `update.preMutation` / `read` authorization the route used to
+ * carry for posts.
+ */
+const assertOrgAdmin = async (
+  db: any,
+  userId: string,
+  organizationId: string,
+) => {
+  const memberships = await db.userOrganizations
+    .where({ userId, organizationId, role: "admin" })
+    .get();
+  if (Object.keys(memberships ?? {}).length === 0) {
+    throw new Error("Unauthorized: must be an admin of the organization");
+  }
+};
+
 export const appRouter = router({
   schema,
   routes: {
     users: protectedRoute
       .collectionRoute(schema.users)
-      .withMutations(({ mutation }) => ({
-        setup: mutation().handler(async ({ req, db }) => {
+      .withProcedures(({ mutation }) => ({
+        // Seeds a user + organization + membership + first post.
+        setup: mutation().handler(async ({ db }) => {
           const userId = generateId();
           const organizationId = generateId();
 
-          await db.insert(schema.users, {
-            id: userId,
-            name: "John Doe",
-          });
-
-          await db.insert(schema.organizations, {
+          await db.users.insert({ id: userId, name: "John Doe" });
+          await db.organizations.insert({
             id: organizationId,
             name: "Organization",
           });
-
-          await db.insert(schema.userOrganizations, {
+          await db.userOrganizations.insert({
             id: generateId(),
             userId,
             organizationId,
             role: "admin",
           });
-
-          await db.insert(schema.posts, {
+          await db.posts.insert({
             id: generateId(),
             title: "Post 1",
             authorId: userId,
             organizationId,
           });
 
-          return {
-            success: true,
-          };
+          return { success: true, userId, organizationId };
+        }),
+
+        createUser: mutation(z.object({ name: z.string() })).handler(
+          async ({ req, db }) => {
+            return db.users.insert({
+              id: generateId(),
+              name: req.input.name,
+            });
+          },
+        ),
+      })),
+    organizations: protectedRoute
+      .collectionRoute(schema.organizations)
+      .withProcedures(({ mutation }) => ({
+        // Creating an org also makes the caller its admin.
+        createOrganization: mutation(z.object({ name: z.string() })).handler(
+          async ({ req, db }) => {
+            const organizationId = generateId();
+            const organization = await db.organizations.insert({
+              id: organizationId,
+              name: req.input.name,
+            });
+            await db.userOrganizations.insert({
+              id: generateId(),
+              userId: req.context.user,
+              organizationId,
+              role: "admin",
+            });
+            return organization;
+          },
+        ),
+      })),
+    userOrganizations: protectedRoute
+      .collectionRoute(schema.userOrganizations)
+      .withProcedures(({ mutation }) => ({
+        // Only an admin of the org may add new members.
+        addMember: mutation(
+          z.object({
+            userId: z.string(),
+            organizationId: z.string(),
+            role: z.string(),
+          }),
+        ).handler(async ({ req, db }) => {
+          await assertOrgAdmin(db, req.context.user, req.input.organizationId);
+          return db.userOrganizations.insert({
+            id: generateId(),
+            userId: req.input.userId,
+            organizationId: req.input.organizationId,
+            role: req.input.role,
+          });
         }),
       })),
-    organizations: protectedRoute.collectionRoute(schema.organizations),
-    userOrganizations: protectedRoute.collectionRoute(schema.userOrganizations),
-    posts: protectedRoute.collectionRoute(schema.posts, {
-      read: ({ ctx }) => ({
-        organization: {
-          userOrganizations: {
-            userId: ctx.user,
-            role: "admin",
-          },
-        },
-      }),
-      update: {
-        preMutation: ({ ctx }) => ({
+    posts: protectedRoute
+      .collectionRoute(schema.posts, {
+        // Read authorization stays declarative — it filters queries, it is not
+        // a mutation. Members only see posts of orgs where they are admins.
+        read: ({ ctx }) => ({
           organization: {
             userOrganizations: {
               userId: ctx.user,
@@ -81,16 +141,29 @@ export const appRouter = router({
             },
           },
         }),
-        postMutation: ({ ctx }) => ({
-          organization: {
-            userOrganizations: {
-              userId: ctx.user,
-              role: "admin",
-            },
-          },
+      })
+      .withProcedures(({ mutation }) => ({
+        createPost: mutation(
+          z.object({ title: z.string(), organizationId: z.string() }),
+        ).handler(async ({ req, db }) => {
+          await assertOrgAdmin(db, req.context.user, req.input.organizationId);
+          return db.posts.insert({
+            id: generateId(),
+            title: req.input.title,
+            authorId: req.context.user,
+            organizationId: req.input.organizationId,
+          });
         }),
-      },
-    }),
+
+        updatePost: mutation(
+          z.object({ id: z.string(), title: z.string() }),
+        ).handler(async ({ req, db }) => {
+          const post = await db.posts.one(req.input.id).get();
+          if (!post) throw new Error("Post not found");
+          await assertOrgAdmin(db, req.context.user, post.organizationId);
+          return db.posts.update(req.input.id, { title: req.input.title });
+        }),
+      })),
   },
 });
 

--- a/examples/ls-imp/src/index.ts
+++ b/examples/ls-imp/src/index.ts
@@ -6,9 +6,23 @@ import { schema } from "./schema";
 
 /*
  * Routes
+ *
+ * Every write goes through an explicitly-defined custom procedure — there are no
+ * default `insert`/`update` mutations in use here. Some of these procedures have
+ * matching optimistic handlers registered on the client (see the storefront's
+ * `live-client.ts`) and some intentionally do NOT, so the two behaviours can be
+ * compared side by side. Each procedure is tagged below:
+ *
+ *   [OPTIMISTIC]     -> client applies the change instantly, then reconciles.
+ *   [NON-OPTIMISTIC] -> UI waits for the server round-trip before updating.
+ *
+ * A few procedures keep an artificial delay so the difference is obvious.
  */
 
 const publicRoute = routeFactory();
+
+const SERVER_DELAY_MS = 2_000;
+const delay = (ms = SERVER_DELAY_MS) => new Promise((r) => setTimeout(r, ms));
 
 export const routerImpl = router({
   schema,
@@ -16,66 +30,48 @@ export const routerImpl = router({
     groups: publicRoute
       .collectionRoute(schema.groups)
       .withProcedures(({ mutation, query }) => ({
-        hello: mutation(z.string()).handler(async ({ req }) => {
-          return {
-            message: `Hello ${req.input}`,
-          };
-        }),
-        customFind: mutation(z.string().optional()).handler(
-          async ({ req, db }) => {
-            return db.find(schema.groups, {
-              where: {
-                ...(req.input ? { id: req.input } : {}),
-              },
-              include: {
-                cards: true,
-              },
-            });
-          },
-        ),
-        customFindOne: mutation(z.string()).handler(async ({ req, db }) => {
-          const result = await db.findOne(schema.cards, req.input!, {
-            include: {
-              group: true,
-            },
+        // [OPTIMISTIC] new group shows up immediately, confirmed after the delay.
+        createGroup: mutation(
+          z.object({ id: z.string(), name: z.string() }),
+        ).handler(async ({ req, db }) => {
+          await delay();
+          return db.groups.insert({
+            id: req.input.id,
+            name: req.input.name,
           });
+        }),
 
-          return result;
+        // [NON-OPTIMISTIC] rename only lands after the server replies — the UI
+        // lags by the delay on purpose so the contrast with createGroup is clear.
+        renameGroup: mutation(
+          z.object({ id: z.string(), name: z.string() }),
+        ).handler(async ({ req, db }) => {
+          await delay();
+          return db.groups.update(req.input.id, { name: req.input.name });
         }),
-        customInsert: mutation(z.string()).handler(async ({ req, db }) => {
-          return db.insert(schema.groups, {
+
+        // Seeds a group with a couple of cards. Handy for resetting the demo.
+        seed: mutation().handler(async ({ db }) => {
+          const groupId = generateId();
+          await db.groups.insert({ id: groupId, name: "Seeded group" });
+          await db.cards.insert({
             id: generateId(),
-            name: req.input!,
+            name: "Card A",
+            counter: 0,
+            groupId,
           });
-        }),
-        customUpdate: mutation(z.string()).handler(async ({ req, db }) => {
-          return db.update(schema.groups, req.input!, {
-            name: "Updated",
+          await db.cards.insert({
+            id: generateId(),
+            name: "Card B",
+            counter: 0,
+            groupId,
           });
+          return { success: true, groupId };
         }),
-        transaction: mutation().handler(async ({ req, db }) => {
-          return db.transaction(async ({ trx, commit, rollback }) => {
-            await trx.insert(schema.groups, {
-              id: generateId(),
-              name: "Transaction",
-            });
-            const rand = Math.random();
-            if (rand < 0.25) {
-              throw new Error("Transaction failed");
-            } else if (rand >= 0.25 && rand < 0.5) {
-              await rollback();
-              return "Transaction rolled back";
-            } else {
-              await commit();
-              return "Transaction successful";
-            }
-          });
-        }),
+
         getStats: query().handler(async ({ db }) => {
           const allGroups = await db.find(schema.groups, {
-            include: {
-              cards: true,
-            },
+            include: { cards: true },
           });
 
           const totalGroups = Object.keys(allGroups).length;
@@ -96,14 +92,13 @@ export const routerImpl = router({
               totalGroups > 0 ? (totalCards / totalGroups).toFixed(2) : "0.00",
           };
         }),
+
         searchByName: query(z.string().min(1)).handler(async ({ req, db }) => {
           const allGroups = await db.find(schema.groups, {
-            include: {
-              cards: true,
-            },
+            include: { cards: true },
           });
 
-          const searchTerm = req.input!.toLowerCase();
+          const searchTerm = req.input.toLowerCase();
           const matchingGroups = Object.values(allGroups).filter((group) =>
             group.name.toLowerCase().includes(searchTerm),
           );
@@ -116,39 +111,67 @@ export const routerImpl = router({
             {} as Record<string, (typeof matchingGroups)[0]>,
           );
         }),
-        createGroup: mutation(
-          z.object({ id: z.string(), name: z.string() }),
-        ).handler(async ({ req, db }) => {
-          await new Promise((r) => setTimeout(r, 4_000));
-          return db.groups.insert({
-            id: req.input!.id,
-            name: req.input!.name,
-          });
-        }),
       })),
     cards: publicRoute
       .collectionRoute(schema.cards)
       .withProcedures(({ mutation }) => ({
-        incrementCounter: mutation(z.object({ cardId: z.string() })).handler(
-          async ({ req, db }) => {
-            await new Promise((r) => setTimeout(r, 4_000));
-            const card = await db.cards.one(req.input!.cardId).get();
-            if (!card) throw new Error("Card not found");
-            return db.cards.update(req.input!.cardId, {
-              counter: card.counter + 1,
-            });
-          },
-        ),
-        decrementCounter: mutation(z.object({ cardId: z.string() })).handler(
-          async ({ req, db }) => {
-            await new Promise((r) => setTimeout(r, 4_000));
-            const card = await db.cards.one(req.input!.cardId).get();
-            if (!card) throw new Error("Card not found");
-            return db.cards.update(req.input!.cardId, {
-              counter: card.counter - 1,
-            });
-          },
-        ),
+        // [OPTIMISTIC] card appears instantly inside its group.
+        createCard: mutation(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            groupId: z.string(),
+          }),
+        ).handler(async ({ req, db }) => {
+          return db.cards.insert({
+            id: req.input.id,
+            name: req.input.name,
+            counter: 0,
+            groupId: req.input.groupId,
+          });
+        }),
+
+        // [OPTIMISTIC] counter bumps up immediately despite the server delay.
+        incrementCounter: mutation(
+          z.object({ cardId: z.string() }),
+        ).handler(async ({ req, db }) => {
+          await delay();
+          const card = await db.cards.one(req.input.cardId).get();
+          if (!card) throw new Error("Card not found");
+          return db.cards.update(req.input.cardId, {
+            counter: card.counter + 1,
+          });
+        }),
+
+        // [NON-OPTIMISTIC] same operation, but with no optimistic handler — the
+        // counter only changes after the delay so you can feel the round-trip.
+        decrementCounter: mutation(
+          z.object({ cardId: z.string() }),
+        ).handler(async ({ req, db }) => {
+          await delay();
+          const card = await db.cards.one(req.input.cardId).get();
+          if (!card) throw new Error("Card not found");
+          return db.cards.update(req.input.cardId, {
+            counter: card.counter - 1,
+          });
+        }),
+
+        // [OPTIMISTIC] drag-and-drop needs instant feedback to feel right.
+        moveCard: mutation(
+          z.object({ cardId: z.string(), groupId: z.string() }),
+        ).handler(async ({ req, db }) => {
+          return db.cards.update(req.input.cardId, {
+            groupId: req.input.groupId,
+          });
+        }),
+
+        // [NON-OPTIMISTIC] rename waits for the server.
+        renameCard: mutation(
+          z.object({ cardId: z.string(), name: z.string() }),
+        ).handler(async ({ req, db }) => {
+          await delay();
+          return db.cards.update(req.input.cardId, { name: req.input.name });
+        }),
       })),
   },
 });

--- a/examples/storefront/src/app/board.tsx
+++ b/examples/storefront/src/app/board.tsx
@@ -1,5 +1,3 @@
-// import { client, useLiveData, useSubscribe } from "./live-client";
-
 import { useLiveQuery } from "@live-state/sync/client";
 import { memo } from "react";
 import { ulid } from "ulid";
@@ -18,9 +16,9 @@ export function Board(): JSX.Element {
       {Object.values(groups ?? {}).map((group) => (
         <MemoItem key={group.id} groupId={group.id} />
       ))}
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2 w-sm shrink-0">
+        {/* [OPTIMISTIC] new group appears instantly, confirmed ~2s later. */}
         <Button
-          className="w-sm"
           onClick={() => {
             store.mutate.groups.createGroup({
               id: ulid().toLowerCase(),
@@ -30,103 +28,68 @@ export function Board(): JSX.Element {
         >
           Add Group (optimistic)
         </Button>
+
+        {/* [NON-OPTIMISTIC] same op over the fetch client, no optimism — the
+            group only shows up after the server replies. */}
         <Button
-          className="w-sm"
+          variant="outline"
           onClick={() => {
-            client.mutate.groups.insert({
+            client.mutate.groups.createGroup({
               id: ulid().toLowerCase(),
               name: `New Group ${Object.keys(groups ?? {}).length + 1} (fetch)`,
             });
           }}
         >
-          Add Group (fetch)
+          Add Group (fetch, no optimism)
         </Button>
+
+        {/* [NON-OPTIMISTIC] rename the first group — lags by the server delay. */}
         <Button
-          className="w-sm"
+          variant="outline"
           onClick={() => {
-            client.query.groups.get().then((res) => {
-              const group = Object.entries(res)[0];
-
-              if (!group) {
-                return;
-              }
-
-              client.mutate.groups.update(group[0], {
-                name: `Updated Group ${Math.random().toString(36).substring(2, 15)} (fetch)`,
-              });
+            const first = Object.values(groups ?? {})[0];
+            if (!first) return;
+            store.mutate.groups.renameGroup({
+              id: first.id,
+              name: `Renamed ${Math.random().toString(36).substring(2, 8)}`,
             });
           }}
         >
-          Update Group (fetch)
+          Rename first group (non-optimistic)
         </Button>
+
         <Button
-          className="w-sm"
+          variant="secondary"
           onClick={() => {
-            client.query.groups
-              .include({ cards: { include: { group: true } } })
-              .get()
-              .then((res) => console.log("fetch", res));
-            console.log("store", store.query.groups.include({ cards: { include: { group: true } } }).get());
+            store.mutate.groups.seed();
           }}
         >
-          Get Groups
+          Seed demo data
         </Button>
+
+        <div className="mt-4 border-t pt-2 text-xs text-muted-foreground">
+          Diagnostics
+        </div>
+
         <Button
-          className="w-sm"
-          onClick={() => {
-            client.mutate.groups.hello("Pedro").then((res) => console.log(res));
-          }}
-        >
-          Custom mutation (fetch)
-        </Button>
-        <Button
-          className="w-sm"
-          onClick={() => {
-            client.query.groups.getStats().then((res) => {
-              console.log("Groups stats (fetch):", res);
-              alert(
-                `Stats:\nTotal Groups: ${res.totalGroups}\nTotal Cards: ${res.totalCards}\nGroups with Cards: ${res.groupsWithCards}\nAverage Cards per Group: ${res.averageCardsPerGroup}`
-              );
-            });
-          }}
-        >
-          Get Stats (fetch query)
-        </Button>
-        <Button
-          className="w-sm"
+          variant="ghost"
           onClick={() => {
             store.query.groups.getStats().then((res) => {
-              console.log("Groups stats (ws):", res);
               alert(
-                `Stats:\nTotal Groups: ${res.totalGroups}\nTotal Cards: ${res.totalCards}\nGroups with Cards: ${res.groupsWithCards}\nAverage Cards per Group: ${res.averageCardsPerGroup}`
+                `Stats:\nTotal Groups: ${res.totalGroups}\nTotal Cards: ${res.totalCards}\nGroups with Cards: ${res.groupsWithCards}\nAverage Cards per Group: ${res.averageCardsPerGroup}`,
               );
             });
           }}
         >
           Get Stats (ws query)
         </Button>
+
         <Button
-          className="w-sm"
-          onClick={() => {
-            const searchTerm = prompt("Enter search term:");
-            if (searchTerm) {
-              client.query.groups.searchByName(searchTerm).then((res) => {
-                console.log("Search results (fetch):", res);
-                const count = Object.keys(res).length;
-                alert(`Found ${count} group(s) matching "${searchTerm}"`);
-              });
-            }
-          }}
-        >
-          Search Groups (fetch query)
-        </Button>
-        <Button
-          className="w-sm"
+          variant="ghost"
           onClick={() => {
             const searchTerm = prompt("Enter search term:");
             if (searchTerm) {
               store.query.groups.searchByName(searchTerm).then((res) => {
-                console.log("Search results (ws):", res);
                 const count = Object.keys(res).length;
                 alert(`Found ${count} group(s) matching "${searchTerm}"`);
               });

--- a/examples/storefront/src/app/card.tsx
+++ b/examples/storefront/src/app/card.tsx
@@ -56,19 +56,37 @@ export const Card = ({
 
       <div className="flex gap-2 items-center">
         <p className="text-lg border bg-muted p-2 rounded-lg">{card.counter}</p>
+        {/* [OPTIMISTIC] counter bumps instantly. */}
         <Button
+          title="Increment (optimistic)"
           onClick={() => {
             store.mutate.cards.incrementCounter({ cardId });
           }}
         >
           +
         </Button>
+        {/* [NON-OPTIMISTIC] counter only changes after the server delay. */}
         <Button
+          variant="outline"
+          title="Decrement (non-optimistic)"
           onClick={() => {
             store.mutate.cards.decrementCounter({ cardId });
           }}
         >
           -
+        </Button>
+        {/* [NON-OPTIMISTIC] rename waits for the server. */}
+        <Button
+          variant="outline"
+          title="Rename (non-optimistic)"
+          onClick={() => {
+            store.mutate.cards.renameCard({
+              cardId,
+              name: `${card.name} *`,
+            });
+          }}
+        >
+          ✎
         </Button>
       </div>
     </div>

--- a/examples/storefront/src/app/dnd-context.tsx
+++ b/examples/storefront/src/app/dnd-context.tsx
@@ -27,8 +27,8 @@ export function DndProvider({ children }: { children: ReactNode }) {
       const newGroupId = over.id as string;
       const cardId = active.id as string;
 
-      // Update the card's groupId in the store
-      store.mutate.cards.update(cardId, { groupId: newGroupId });
+      // [OPTIMISTIC] move the card to the new group with instant feedback.
+      store.mutate.cards.moveCard({ cardId, groupId: newGroupId });
     }
 
     setActiveId(null);

--- a/examples/storefront/src/app/group.tsx
+++ b/examples/storefront/src/app/group.tsx
@@ -40,17 +40,30 @@ export const Group = ({ groupId }: { groupId: string }) => {
       {Object.values(group.cards ?? {}).map((card) => (
         <MemoItem key={card.id} cardId={card.id} />
       ))}
+      {/* [OPTIMISTIC] card appears instantly inside this group. */}
       <Button
         onClick={() => {
-          store.mutate.cards.insert({
+          store.mutate.cards.createCard({
             id: ulid().toLowerCase(),
             name: "New Card",
-            counter: 0,
             groupId: group.id,
           });
         }}
       >
-        Add Card
+        Add Card (optimistic)
+      </Button>
+
+      {/* [NON-OPTIMISTIC] rename lags by the server delay on purpose. */}
+      <Button
+        variant="outline"
+        onClick={() => {
+          store.mutate.groups.renameGroup({
+            id: group.id,
+            name: `${group.name} *`,
+          });
+        }}
+      >
+        Rename group (non-optimistic)
       </Button>
     </div>
   );

--- a/examples/storefront/src/app/live-client.ts
+++ b/examples/storefront/src/app/live-client.ts
@@ -6,6 +6,15 @@ import { type Router } from "@repo/ls-impl";
 import { schema } from "@repo/ls-impl/schema";
 import { LogLevel } from "@live-state/sync";
 
+/*
+ * Optimistic handlers are registered for ONLY a subset of the custom mutations.
+ * Anything not listed here runs without optimism — the UI waits for the server
+ * round-trip (the server adds an artificial delay to most procedures so the
+ * difference is easy to see).
+ *
+ *   Optimistic:      createGroup, createCard, incrementCounter, moveCard
+ *   Non-optimistic:  renameGroup, decrementCounter, renameCard, seed
+ */
 const optimisticMutations = defineOptimisticMutations<Router, typeof schema>({
   groups: {
     createGroup: ({ input, storage }) => {
@@ -16,6 +25,14 @@ const optimisticMutations = defineOptimisticMutations<Router, typeof schema>({
     },
   },
   cards: {
+    createCard: ({ input, storage }) => {
+      storage.cards.insert({
+        id: input.id,
+        name: input.name,
+        counter: 0,
+        groupId: input.groupId,
+      });
+    },
     incrementCounter: ({ input, storage }) => {
       const card = storage.cards.one(input.cardId).get();
       if (card) {
@@ -24,13 +41,10 @@ const optimisticMutations = defineOptimisticMutations<Router, typeof schema>({
         });
       }
     },
-    decrementCounter: ({ input, storage }) => {
-      const card = storage.cards.one(input.cardId).get();
-      if (card) {
-        storage.cards.update(input.cardId, {
-          counter: card.counter - 1,
-        });
-      }
+    moveCard: ({ input, storage }) => {
+      storage.cards.update(input.cardId, {
+        groupId: input.groupId,
+      });
     },
   },
 });


### PR DESCRIPTION
## Summary

Rebuilds the example apps so every write goes through an explicitly-defined **custom procedure** — no default `insert`/`update` mutations. This makes the examples a usable testbed for custom procedures with and without optimistic updates, and aligns them with the planned removal of default mutations.

## Changes

**Shared router — `examples/ls-imp/src/index.ts`**
- All writes are now custom procedures, each tagged `[OPTIMISTIC]` or `[NON-OPTIMISTIC]`.
- Groups: `createGroup` (optimistic), `renameGroup` (non-optimistic), `seed`, plus `getStats`/`searchByName` queries.
- Cards: `createCard` (optimistic), `incrementCounter` (optimistic), `decrementCounter` (non-optimistic — same op as increment, left un-optimistic for contrast), `moveCard` (optimistic), `renameCard` (non-optimistic).
- Most procedures keep a ~2s artificial delay so the optimistic-vs-not difference is visible.

**Client — `examples/storefront/src/app/live-client.ts`**
- Optimistic handlers registered for **only** `createGroup`, `createCard`, `incrementCounter`, `moveCard`. The rest run without optimism on purpose.

**Storefront UI** (`board.tsx`, `group.tsx`, `card.tsx`, `dnd-context.tsx`)
- All `mutate.*.insert/update` calls replaced with custom procedures; buttons relabelled so each path is identifiable. Drag-and-drop uses optimistic `moveCard`.

**`examples/complex-relations/src/router.ts`**
- Default mutations + declarative post update authorization converted to custom procedures with inline auth (`createPost`, `updatePost`, `addMember`, `createOrganization`, `createUser`) via an `assertOrgAdmin` helper. Read-level query filtering stays declarative on the route.

## How to test

Run the api server + storefront. Optimistic actions update the UI instantly then reconcile after ~2s; non-optimistic ones visibly wait for the round-trip. Clearest A/B: a card's `+` (instant) vs `−` (delayed).

## Verification

- `pnpm typecheck` passes for `@repo/ls-impl`, `storefront`, `complex-relations`, and `api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group search and diagnostics functionality to example applications
  * Introduced optimistic mutation patterns with improved user interactions (card moves, renaming)

* **Refactor**
  * Updated router example with explicit authorization handling in mutations
  * Streamlined card and group management with clearer action interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->