### PR TITLE
fix: restore card-group relation when broadcast precedes reply

### DIFF
--- a/examples/ls-imp/src/index.ts
+++ b/examples/ls-imp/src/index.ts
@@ -19,7 +19,7 @@ import { schema } from "./schema";
  * A few procedures keep an artificial delay so the difference is obvious.
  */
 
-const publicRoute = routeFactory();
+const publicRoute = routeFactory<typeof schema>();
 
 const SERVER_DELAY_MS = 2_000;
 const delay = (ms = SERVER_DELAY_MS) => new Promise((r) => setTimeout(r, ms));

--- a/examples/ls-imp/src/index.ts
+++ b/examples/ls-imp/src/index.ts
@@ -69,6 +69,14 @@ export const routerImpl = router({
           return { success: true, groupId };
         }),
 
+        // [LIVE QUERY] returns an UNRESOLVED query builder (no `.get()`), so the
+        // client can subscribe to it: `store.query.groups.listGroups()` is a
+        // loadable that feeds the store and stays live. Use it with useLoadData
+        // (or useLiveQuery) instead of the default collection query.
+        listGroups: query().handler(async ({ db }) =>
+          db.groups.where({}).include({ cards: true }),
+        ),
+
         getStats: query().handler(async ({ db }) => {
           const allGroups = await db.find(schema.groups, {
             include: { cards: true },

--- a/examples/storefront/src/app/page.tsx
+++ b/examples/storefront/src/app/page.tsx
@@ -8,7 +8,10 @@ import { DndProvider } from "./dnd-context";
 import { client, store } from "./live-client";
 
 export default function Store(): JSX.Element {
-  useLoadData(client, store.query.groups.include({ cards: true }));
+  // Load via a custom query procedure (returns an unresolved builder server-side),
+  // instead of the default collection query. Data still lands in the `groups`
+  // store, so Board's `useLiveQuery(store.query.groups)` renders it as usual.
+  useLoadData(client, store.query.groups.listGroups());
 
   const isConnected = useSyncExternalStore(
     (cb) => {

--- a/packages/live-state/src/client/websocket/store.ts
+++ b/packages/live-state/src/client/websocket/store.ts
@@ -234,6 +234,7 @@ export class OptimisticStore {
 
     const prevValue =
       this.optimisticRawObjPool[routeName]?.[mutation.resourceId];
+    let undidMatchingOptimistic = false;
 
     if (optimistic) {
       this.optimisticMutationStack[routeName] ??=
@@ -280,6 +281,7 @@ export class OptimisticStore {
               { optimisticMutationId: entry.mutationId, resourceId: mutation.resourceId },
             );
             this.undoMutation(routeName, entry.mutationId);
+            undidMatchingOptimistic = true;
             matched = true;
             break;
           }
@@ -303,6 +305,7 @@ export class OptimisticStore {
                 },
               );
               this.undoMutation(routeName, entry.mutationId);
+              undidMatchingOptimistic = true;
               matched = true;
               break;
             }
@@ -339,11 +342,15 @@ export class OptimisticStore {
 
     this.kvStorage.setMeta("mutationStack", this.optimisticMutationStack);
 
+    const relationPrevValue = undidMatchingOptimistic
+      ? this.optimisticRawObjPool[routeName]?.[mutation.resourceId]
+      : prevValue;
+
     this.updateRawObjPool(
       routeName,
       mutation.resourceId,
       mutation.payload,
-      prevValue,
+      relationPrevValue,
     );
   }
 

--- a/packages/live-state/src/server/storage/index.ts
+++ b/packages/live-state/src/server/storage/index.ts
@@ -1,3 +1,4 @@
+import { QueryBuilder, type QueryExecutor } from "../../core/query";
 import { Storage } from "./interface";
 import {
 	createServerDB,
@@ -6,4 +7,12 @@ import {
 } from "./server-query-builder";
 import { SQLStorage } from "./sql-storage";
 
-export { Storage, SQLStorage, createServerDB, type ServerDB, type ServerCollection };
+export {
+	Storage,
+	SQLStorage,
+	createServerDB,
+	type ServerDB,
+	type ServerCollection,
+	QueryBuilder,
+	type QueryExecutor,
+};

--- a/packages/live-state/test/_utils/schema.ts
+++ b/packages/live-state/test/_utils/schema.ts
@@ -11,7 +11,7 @@ import {
   object,
   reference,
   string,
-} from "@live-state/sync";
+} from "../../src";
 
 const group = object("groups", {
   id: id(),

--- a/packages/live-state/test/client/optimistic-card-repro.test.ts
+++ b/packages/live-state/test/client/optimistic-card-repro.test.ts
@@ -1,0 +1,451 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { defineOptimisticMutations } from '../../src/client/optimistic';
+import { createClient } from '../../src/client/websocket/client';
+import { schema } from '../_utils/schema';
+
+class MockWebSocket {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+
+	readyState = MockWebSocket.CLOSED;
+	url: string;
+	eventListeners: Record<string, Array<(event: any) => void>> = {};
+
+	send = vi.fn();
+	close = vi.fn(() => {
+		this.readyState = MockWebSocket.CLOSED;
+		this.dispatchEvent(new CloseEvent('close'));
+	});
+
+	constructor(url: string) {
+		this.url = url;
+		this.readyState = MockWebSocket.CONNECTING;
+	}
+
+	addEventListener(event: string, callback: (event: any) => void): void {
+		if (!this.eventListeners[event]) {
+			this.eventListeners[event] = [];
+		}
+		this.eventListeners[event].push(callback);
+	}
+
+	removeEventListener(event: string, callback: (event: any) => void): void {
+		if (this.eventListeners[event]) {
+			this.eventListeners[event] = this.eventListeners[event].filter(
+				(cb) => cb !== callback,
+			);
+		}
+	}
+
+	dispatchEvent(event: Event): boolean {
+		const listeners = this.eventListeners[event.type] || [];
+		listeners.forEach((listener) => listener(event));
+		return true;
+	}
+
+	simulateOpen(): void {
+		this.readyState = MockWebSocket.OPEN;
+		this.dispatchEvent(new Event('open'));
+	}
+
+	simulateMessage(data: any): void {
+		this.dispatchEvent(new MessageEvent('message', { data }));
+	}
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+type TestRouter = {
+	routes: {
+		groups: {
+			resourceSchema: (typeof schema)['groups'];
+			customMutations: {
+				createGroup: {
+					_type: 'mutation';
+					inputValidator: StandardSchemaV1<any, { id: string; name: string }>;
+					handler: () => void;
+				};
+				listGroups: {
+					_type: 'query';
+					inputValidator: StandardSchemaV1<any, void>;
+					handler: () => void;
+				};
+			};
+			customQueries: {};
+		};
+		cards: {
+			resourceSchema: (typeof schema)['cards'];
+			customMutations: {
+				createCard: {
+					_type: 'mutation';
+					inputValidator: StandardSchemaV1<
+						any,
+						{ id: string; name: string; groupId: string }
+					>;
+					handler: () => void;
+				};
+			};
+			customQueries: {};
+		};
+	};
+};
+
+const optimisticMutations = defineOptimisticMutations<TestRouter, typeof schema>({
+	groups: {
+		createGroup: ({ input, storage }) => {
+			storage.groups.insert({ id: input.id, name: input.name });
+		},
+	},
+	cards: {
+		createCard: ({ input, storage }) => {
+			storage.cards.insert({
+				id: input.id,
+				name: input.name,
+				counter: 0,
+				groupId: input.groupId,
+			});
+		},
+	},
+});
+
+describe('optimistic createCard with group include (storefront repro)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('card appears in parent group include after optimistic createCard', async () => {
+		const client = createClient<TestRouter>({
+			url: 'ws://localhost:1234',
+			schema,
+			storage: false,
+			optimisticMutations,
+			connection: { autoConnect: false, autoReconnect: false },
+		});
+
+		await client.client.ws.connect();
+		const ws = (client.client.ws as any).ws as MockWebSocket;
+		ws.simulateOpen();
+
+		const groupId = 'group-1';
+		const existingCardId = 'card-existing';
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: 'sub-1',
+				type: 'REPLY',
+				data: {
+					resource: 'groups',
+					data: [
+						{
+							id: { value: groupId, _meta: { timestamp: '2026-01-01' } },
+							name: { value: 'Group 1', _meta: { timestamp: '2026-01-01' } },
+							cards: {
+								value: [
+									{
+										value: {
+											id: {
+												value: existingCardId,
+												_meta: { timestamp: '2026-01-01' },
+											},
+											name: {
+												value: 'Existing',
+												_meta: { timestamp: '2026-01-01' },
+											},
+											counter: {
+												value: 0,
+												_meta: { timestamp: '2026-01-01' },
+											},
+											groupId: {
+												value: groupId,
+												_meta: { timestamp: '2026-01-01' },
+											},
+										},
+									},
+								],
+							},
+						},
+					],
+				},
+			}),
+		);
+
+		const before = client.store.query.groups
+			.one(groupId)
+			.include({ cards: true })
+			.get();
+
+		const newCardId = 'card-new';
+		let mutationError: unknown;
+		try {
+			client.store.mutate.cards.createCard({
+				id: newCardId,
+				name: 'New Card',
+				groupId,
+			});
+		} catch (e) {
+			mutationError = e;
+		}
+
+		const after = client.store.query.groups
+			.one(groupId)
+			.include({ cards: true })
+			.get();
+
+		const cardDirect = client.store.query.cards.one(newCardId).get();
+
+		expect(mutationError).toBeUndefined();
+		expect(cardDirect).toEqual(
+			expect.objectContaining({ id: newCardId, name: 'New Card' }),
+		);
+		expect(after?.cards).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: newCardId }),
+				expect.objectContaining({ id: existingCardId }),
+			]),
+		);
+
+		client.client.ws.disconnect();
+	});
+
+	test('card persists in group include after server reply and broadcast', async () => {
+		const client = createClient<TestRouter>({
+			url: 'ws://localhost:1234',
+			schema,
+			storage: false,
+			optimisticMutations,
+			connection: { autoConnect: false, autoReconnect: false },
+		});
+
+		await client.client.ws.connect();
+		const ws = (client.client.ws as any).ws as MockWebSocket;
+		ws.simulateOpen();
+
+		const groupId = 'group-1';
+		const newCardId = 'card-new';
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: 'sub-1',
+				type: 'REPLY',
+				data: {
+					resource: 'groups',
+					data: [
+						{
+							id: { value: groupId, _meta: { timestamp: '2026-01-01' } },
+							name: { value: 'Group 1', _meta: { timestamp: '2026-01-01' } },
+							cards: { value: [] },
+						},
+					],
+				},
+			}),
+		);
+
+		const mutationPromise = client.store.mutate.cards.createCard({
+			id: newCardId,
+			name: 'New Card',
+			groupId,
+		});
+
+		const sentMessage = JSON.parse(ws.send.mock.calls.at(-1)?.[0] as string);
+
+		const afterOptimistic = client.store.query.groups
+			.one(groupId)
+			.include({ cards: true })
+			.get();
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: sentMessage.id,
+				type: 'REPLY',
+				data: { id: newCardId },
+			}),
+		);
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: 'broadcast-1',
+				type: 'MUTATE',
+				resource: 'cards',
+				resourceId: newCardId,
+				procedure: 'INSERT',
+				meta: { originMutationId: sentMessage.id },
+				payload: {
+					name: { value: 'New Card', _meta: { timestamp: '2026-01-01' } },
+					counter: { value: 0, _meta: { timestamp: '2026-01-01' } },
+					groupId: { value: groupId, _meta: { timestamp: '2026-01-01' } },
+				},
+			}),
+		);
+
+		await mutationPromise;
+
+		const afterConfirm = client.store.query.groups
+			.one(groupId)
+			.include({ cards: true })
+			.get();
+
+		const cardDirect = client.store.query.cards.one(newCardId).get();
+
+		expect(afterOptimistic?.cards).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: newCardId })]),
+		);
+		expect(afterConfirm?.cards).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: newCardId })]),
+		);
+		expect(cardDirect).toEqual(
+			expect.objectContaining({ id: newCardId, name: 'New Card' }),
+		);
+
+		client.client.ws.disconnect();
+	});
+
+	test('card persists when broadcast arrives before reply', async () => {
+		const client = createClient<TestRouter>({
+			url: 'ws://localhost:1234',
+			schema,
+			storage: false,
+			optimisticMutations,
+			connection: { autoConnect: false, autoReconnect: false },
+		});
+
+		await client.client.ws.connect();
+		const ws = (client.client.ws as any).ws as MockWebSocket;
+		ws.simulateOpen();
+
+		const groupId = 'group-1';
+		const newCardId = 'card-new';
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: 'sub-1',
+				type: 'REPLY',
+				data: {
+					resource: 'groups',
+					data: [
+						{
+							id: { value: groupId, _meta: { timestamp: '2026-01-01' } },
+							name: { value: 'Group 1', _meta: { timestamp: '2026-01-01' } },
+							cards: { value: [] },
+						},
+					],
+				},
+			}),
+		);
+
+		const mutationPromise = client.store.mutate.cards.createCard({
+			id: newCardId,
+			name: 'New Card',
+			groupId,
+		});
+
+		const sentMessage = JSON.parse(ws.send.mock.calls.at(-1)?.[0] as string);
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: 'broadcast-1',
+				type: 'MUTATE',
+				resource: 'cards',
+				resourceId: newCardId,
+				procedure: 'INSERT',
+				meta: { originMutationId: sentMessage.id },
+				payload: {
+					name: { value: 'New Card', _meta: { timestamp: '2026-01-01' } },
+					counter: { value: 0, _meta: { timestamp: '2026-01-01' } },
+					groupId: { value: groupId, _meta: { timestamp: '2026-01-01' } },
+				},
+			}),
+		);
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: sentMessage.id,
+				type: 'REPLY',
+				data: { id: newCardId },
+			}),
+		);
+
+		await mutationPromise;
+
+		const after = client.store.query.groups
+			.one(groupId)
+			.include({ cards: true })
+			.get();
+		const cardDirect = client.store.query.cards.one(newCardId).get();
+
+		expect(after?.cards).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: newCardId })]),
+		);
+
+		client.client.ws.disconnect();
+	});
+
+	test('card disappears if reply confirms but broadcast never arrives', async () => {
+		const client = createClient<TestRouter>({
+			url: 'ws://localhost:1234',
+			schema,
+			storage: false,
+			optimisticMutations,
+			connection: { autoConnect: false, autoReconnect: false },
+		});
+
+		await client.client.ws.connect();
+		const ws = (client.client.ws as any).ws as MockWebSocket;
+		ws.simulateOpen();
+
+		const groupId = 'group-1';
+		const newCardId = 'card-new';
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: 'sub-1',
+				type: 'REPLY',
+				data: {
+					resource: 'groups',
+					data: [
+						{
+							id: { value: groupId, _meta: { timestamp: '2026-01-01' } },
+							name: { value: 'Group 1', _meta: { timestamp: '2026-01-01' } },
+							cards: { value: [] },
+						},
+					],
+				},
+			}),
+		);
+
+		const mutationPromise = client.store.mutate.cards.createCard({
+			id: newCardId,
+			name: 'New Card',
+			groupId,
+		});
+
+		const sentMessage = JSON.parse(ws.send.mock.calls.at(-1)?.[0] as string);
+
+		ws.simulateMessage(
+			JSON.stringify({
+				id: sentMessage.id,
+				type: 'REPLY',
+				data: { id: newCardId },
+			}),
+		);
+
+		await mutationPromise;
+
+		const after = client.store.query.groups
+			.one(groupId)
+			.include({ cards: true })
+			.get();
+
+		expect(after?.cards ?? []).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: newCardId })]),
+		);
+
+		client.client.ws.disconnect();
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes optimistic `createCard` in the storefront example: cards no longer disappear from a group's `cards` include when the server INSERT broadcast arrives before the mutation REPLY.
- After reconciling optimistic state on broadcast, relation merging now uses the current pool value instead of a stale pre-undo `prevValue`, so unchanged FK fields (e.g. `groupId`) still re-establish graph links.
- Adds `listGroups` custom live query to the example router and switches the storefront to load data via `useLoadData(store.query.groups.listGroups())`.
- Adds regression tests covering optimistic create, reply/broadcast ordering, and broadcast-before-reply race.

## Test plan
- [x] `pnpm exec vitest run packages/live-state/test/client/optimistic-card-repro.test.ts`
- [x] `pnpm test --filter="./packages/live-state"`
- [ ] Manual: run `pnpm dev:basic-example`, click **Add Card (optimistic)** on a group, confirm card appears and stays after server confirmation


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live query procedure for groups, enabling reactive group data subscriptions.

* **Improvements**
  * Enhanced optimistic mutation handling for related data, ensuring consistency across various server response timing scenarios.

* **Tests**
  * Added comprehensive test coverage for optimistic mutation behavior with related data dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->