### PR TITLE
feat: split MUTATE request from SYNC server delta (#160)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,34 @@
+# live-state/sync
+
+The shared language of `@live-state/sync` — a real-time sync engine with a client store and ORM. This file is a glossary, not a spec.
+
+## Language
+
+### Mutations
+
+**Mutation**:
+A client→server request to change data, carried by the `MUTATE` message (client→server only). Going forward, the only kind is a **Custom Mutation** — an explicitly defined procedure (via `withProcedures`) with its own input schema, handler, and typed reply. Every `MUTATE` receives a `REPLY` (or `REJECT`).
+_Avoid_: Default mutation (being removed), `insert`/`update` as protocol procedures.
+
+**Custom Mutation**:
+A mutation defined explicitly on a route with `withProcedures({ mutation })`. Has full handler control over `db` (ServerDB), any input schema, any return type, and optional optimistic support via `defineOptimisticMutations`.
+
+**Default Mutation**:
+*(Deprecated, being removed.)* The built-in `insert`/`update` procedures auto-generated on a `Route`, with declarative authorization, lifecycle hooks, and automatic optimistic updates. The removal plan retires this entire concept as a client API.
+
+### Sync
+
+**Sync Delta**:
+A server→client `SYNC` message describing a field-level change to one resource: `{ resourceId, op: "INSERT" | "UPDATE", payload: { <field>: { value, _meta: { timestamp } } }, meta }`. Emitted by `notifySubscribers` (and the query engine's scope-change emitters) for *every* committed storage write regardless of which mutation caused it. This is the field-level CRDT format that keeps subscribed clients consistent. `op` is a storage-operation marker (not a client procedure), retained because client optimistic reconciliation still matches on it.
+_Avoid_: calling this a "mutation" or "default mutation" — it is a delta broadcast, not a request. (`SYNC` is now a distinct server→client message; it no longer shares the `MUTATE` type — see ADR-0001.)
+
+**Optimistic Mutation**:
+A client-side handler (registered via `defineOptimisticMutations`) that predicts a Custom Mutation's effect locally for instant UI, reconciled or rolled back when the server's Sync Delta or rejection arrives. Opt-in and defined separately from the mutation.
+
+### Merge vs Encode
+
+**Merge** (`mergeMutation`):
+The CRDT merge that folds a field-level payload into existing state. Used on both server (applying writes) and client (applying Sync Deltas). Core to sync — not tied to any mutation kind.
+
+**Encode** (`encodeMutation`):
+Converts a plain input object into the field-level `{ value, _meta }` payload shape. Only ever served the Default Mutation request path; retired with it.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,4 +31,4 @@ A client-side handler (registered via `defineOptimisticMutations`) that predicts
 The CRDT merge that folds a field-level payload into existing state. Used on both server (applying writes) and client (applying Sync Deltas). Core to sync — not tied to any mutation kind.
 
 **Encode** (`encodeMutation`):
-Converts a plain input object into the field-level `{ value, _meta }` payload shape. Only ever served the Default Mutation request path; retired with it.
+Converts a plain input object into the field-level `{ value, _meta }` payload shape. Deprecated alongside Default Mutation, but still used in the legacy server insert/update compatibility path.

--- a/docs/adr/0001-split-mutation-request-from-sync-delta.md
+++ b/docs/adr/0001-split-mutation-request-from-sync-delta.md
@@ -31,4 +31,4 @@ The field-level CRDT `mergeMutation` logic is unchanged and shared by server and
 
 - Removing Default Mutations is now cleanly scoped to the client→server request side.
 - The conditional REPLY-skip logic in the WebSocket transport disappears: every `MUTATE` replies unconditionally.
-- This is a breaking wire-protocol change (client and server must upgrade together) and ships as a major/minor version bump.
+- This is a breaking wire-protocol change (client and server must upgrade together) and requires a major version bump.

--- a/docs/adr/0001-split-mutation-request-from-sync-delta.md
+++ b/docs/adr/0001-split-mutation-request-from-sync-delta.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+---
+
+# Split the mutation request from the sync delta in the wire protocol
+
+## Context
+
+The `MUTATE` message type and its `defaultMutationSchema` were doing double duty. They were simultaneously:
+
+1. **A client→server request** — the (deprecated) `INSERT`/`UPDATE` procedures a client sends to change data.
+2. **The server→client sync delta** — a `type: "MUTATE"` message (`resourceId` + field-level `{ value, _meta }` payload) is emitted for *every* committed storage write, including writes caused by Custom Mutations, and pushed to subscribed clients. There are **two producers**: `sql-storage.ts` `buildMutation`/`notifySubscribers` (storage writes) and `core/query-engine/index.ts` (objects moving into/out of a live query's scope, e.g. `sendInsertsForTree`). Applied on the client at `client.ts` → `store.addMutation`.
+
+This overload made the "remove default mutations" plan read as if deleting the client request also deleted the sync format — it does not, and deleting the schema would have broken all sync.
+
+## Decision
+
+Split the two concepts in the protocol:
+
+- **`MUTATE`** becomes client→server only, carrying Custom Mutation procedures, and always receives a `REPLY` (or `REJECT`).
+- A distinct **`SYNC`** server→client message carries the field-level delta. The schema formerly named `defaultMutationSchema` / `DefaultMutationMessage` is **renamed/repurposed into the Sync Delta schema, not deleted**. It retains an `op: "INSERT" | "UPDATE"` marker (a storage-operation indicator, not a client procedure) because client optimistic reconciliation still matches on it.
+
+The field-level CRDT `mergeMutation` logic is unchanged and shared by server and client; only the message naming/typing is split.
+
+## Considered options
+
+- **Keep the `MUTATE` overload, delete only the client request path.** Rejected: leaves the sync broadcast misnamed as a "mutation" and preserves the conceptual confusion that produced a buggy removal plan.
+- **Drop the `op` marker from the delta.** Deferred: requires rewriting reconciliation to key solely on `meta.originMutationId`; a separate, riskier change.
+
+## Consequences
+
+- Removing Default Mutations is now cleanly scoped to the client→server request side.
+- The conditional REPLY-skip logic in the WebSocket transport disappears: every `MUTATE` replies unconditionally.
+- This is a breaking wire-protocol change (client and server must upgrade together) and ships as a major/minor version bump.

--- a/packages/live-state/benchmark/benchmark.ts
+++ b/packages/live-state/benchmark/benchmark.ts
@@ -117,7 +117,7 @@ interface BenchmarkOptions {
 }
 
 const calculateStats = (
-  times: number[]
+  times: number[],
 ): Omit<BenchmarkResult, "mode" | "iterations" | "throughput"> => {
   const sorted = [...times].sort((a, b) => a - b);
   const totalTime = times.reduce((sum, time) => sum + time, 0);
@@ -177,7 +177,7 @@ class BenchmarkRunner {
     // Clean up all tables
     try {
       await this.pool.query(
-        "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE"
+        "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE",
       );
     } catch (error) {
       // Ignore errors if tables don't exist yet
@@ -232,7 +232,7 @@ class BenchmarkRunner {
         if (this.wsClient!.client.ws.connected()) {
           this.wsClient!.client.ws.removeEventListener(
             "connectionChange",
-            listener
+            listener,
           );
           resolve();
         }
@@ -260,7 +260,7 @@ class BenchmarkRunner {
     if (this.pool) {
       try {
         await this.pool.query(
-          "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE"
+          "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE",
         );
       } catch (error) {
         // Ignore errors during cleanup
@@ -344,7 +344,7 @@ class BenchmarkRunner {
    * Queries orgs with nested includes: orgs -> posts -> comments -> author
    */
   async benchmarkNestedIncludeQuery(
-    iterations: number
+    iterations: number,
   ): Promise<BenchmarkResult> {
     const times: number[] = [];
 
@@ -381,7 +381,7 @@ class BenchmarkRunner {
    * the latency between sending the mutation and receiving it on the client
    */
   async benchmarkIncrementalQueryLatency(
-    iterations: number
+    iterations: number,
   ): Promise<BenchmarkResult> {
     const times: number[] = [];
 
@@ -400,7 +400,7 @@ class BenchmarkRunner {
             },
           },
         })
-        .buildQueryRequest()
+        .buildQueryRequest(),
     );
 
     // Track pending mutations by resourceId
@@ -408,11 +408,7 @@ class BenchmarkRunner {
 
     // Set up event listener to track when mutations are received
     const eventUnsubscribe = this.wsClient!.client.addEventListener((event) => {
-      if (
-        event.type === "MESSAGE_RECEIVED" &&
-        event.message.type === "MUTATE"
-      ) {
-        console.log("Mutation received:", event.message);
+      if (event.type === "MESSAGE_RECEIVED" && event.message.type === "SYNC") {
         const resourceId = event.message.resourceId;
         if (resourceId && pendingMutations.has(resourceId)) {
           const pending = pendingMutations.get(resourceId)!;
@@ -431,7 +427,7 @@ class BenchmarkRunner {
 
     if (orgs.length === 0 || users.length === 0 || posts.length === 0) {
       throw new Error(
-        "Database must be primed with data before running incremental query latency benchmark"
+        "Database must be primed with data before running incremental query latency benchmark",
       );
     }
 
@@ -482,7 +478,7 @@ class BenchmarkRunner {
       // Drop all data
       try {
         await this.pool.query(
-          "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE"
+          "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE",
         );
       } catch (error) {
         // Ignore errors
@@ -497,7 +493,7 @@ class BenchmarkRunner {
       // Drop all data
       try {
         await this.pool.query(
-          "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE"
+          "TRUNCATE TABLE orgs, orgs_meta, users, users_meta, posts, posts_meta, comments, comments_meta RESTART IDENTITY CASCADE",
         );
       } catch (error) {
         // Ignore errors
@@ -547,11 +543,13 @@ const main = async () => {
     "incremental-query-latency";
   const iterations =
     parseInt(
-      args.find((arg) => arg.startsWith("--iterations="))?.split("=")[1] || "10"
+      args.find((arg) => arg.startsWith("--iterations="))?.split("=")[1] ||
+        "10",
     ) || 10;
   const dataSize =
     parseInt(
-      args.find((arg) => arg.startsWith("--data-size="))?.split("=")[1] || "100"
+      args.find((arg) => arg.startsWith("--data-size="))?.split("=")[1] ||
+        "100",
     ) || 100;
 
   console.log("Live-State Benchmark Suite");

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -577,6 +577,7 @@ class InnerClient implements QueryExecutor {
       id: mutationId,
       type: "MUTATE",
       resource: routeName,
+      resourceId,
       procedure,
       payload: encodedPayload,
     };

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -7,10 +7,10 @@ import type {
 import {
   type ClientMessage,
   type clQueryMsgSchema,
-  type DefaultMutationMessage,
   type MutationMessage,
   type ServerMessage,
   serverMessageSchema,
+  type SyncDeltaMessage,
   syncReplyDataSchema,
 } from "../../core/schemas/web-socket";
 import { generateId } from "../../core/utils";
@@ -278,7 +278,7 @@ class InnerClient implements QueryExecutor {
           ?.flat()
           ?.forEach((m) => {
             if (customMutationIds.has(m.id)) return;
-            this.sendWsMessage(m);
+            this.sendWsMessage(this.syncDeltaToMutationMessage(m));
           });
 
         this.replayCustomMutationStack();
@@ -345,10 +345,10 @@ class InnerClient implements QueryExecutor {
                   mutationId: m.id,
                   resource: m.resource,
                   resourceId: m.resourceId,
-                  procedure: m.procedure ?? "UNKNOWN",
+                  procedure: m.op ?? "UNKNOWN",
                   optimistic: true,
                 });
-                this.sendWsMessage(m);
+                this.sendWsMessage(this.syncDeltaToMutationMessage(m));
               });
           },
         );
@@ -380,25 +380,22 @@ class InnerClient implements QueryExecutor {
         message: parsedMessage,
       });
 
-      if (parsedMessage.type === "MUTATE") {
-        const { resource, id, resourceId, procedure } =
-          parsedMessage as DefaultMutationMessage;
+      if (parsedMessage.type === "SYNC") {
+        const { resource, id, resourceId, op } =
+          parsedMessage as SyncDeltaMessage;
 
         this.emitEvent({
           type: "MUTATION_RECEIVED",
           mutationId: id,
           resource,
           resourceId,
-          procedure: procedure ?? "UNKNOWN",
+          procedure: op ?? "UNKNOWN",
         });
 
         try {
-          this.store.addMutation(
-            resource,
-            parsedMessage as DefaultMutationMessage,
-          );
+          this.store.addMutation(resource, parsedMessage as SyncDeltaMessage);
         } catch (e) {
-          this.logger.error("Error merging mutation from the server:", e);
+          this.logger.error("Error merging sync delta from the server:", e);
         }
       } else if (parsedMessage.type === "REJECT") {
         if (this.replyHandlers[parsedMessage.id]) {
@@ -534,6 +531,21 @@ class InnerClient implements QueryExecutor {
     return this.store.subscribe(query, callback);
   }
 
+  /**
+   * Converts a locally-stored optimistic sync delta back into the client→server
+   * MUTATE request used to replay default insert/update mutations on reconnect.
+   */
+  private syncDeltaToMutationMessage(m: SyncDeltaMessage): MutationMessage {
+    return {
+      id: m.id,
+      type: "MUTATE",
+      resource: m.resource,
+      procedure: m.op,
+      payload: m.payload,
+      resourceId: m.resourceId,
+    };
+  }
+
   /** @deprecated Use custom mutations instead. Default insert/update mutations will be removed in a future version. */
   public mutate(
     routeName: string,
@@ -543,27 +555,40 @@ class InnerClient implements QueryExecutor {
       Omit<Simplify<LiveObjectMutationInput<LiveObjectAny>>["value"], "id">
     >,
   ) {
-    const mutationMessage: DefaultMutationMessage = {
-      id: generateId(),
+    const mutationId = generateId();
+    const encodedPayload = this.store.schema[routeName].encodeMutation(
+      "set",
+      payload as LiveObjectMutationInput<LiveObjectAny>,
+      new Date().toISOString(),
+    );
+
+    // Optimistic state is reconciled by the server's SYNC broadcast.
+    const optimisticDelta: SyncDeltaMessage = {
+      id: mutationId,
+      type: "SYNC",
+      resource: routeName,
+      payload: encodedPayload,
+      resourceId,
+      op: procedure,
+    };
+
+    // The client→server request remains a MUTATE message.
+    const mutationMessage: MutationMessage = {
+      id: mutationId,
       type: "MUTATE",
       resource: routeName,
-      payload: this.store.schema[routeName].encodeMutation(
-        "set",
-        payload as LiveObjectMutationInput<LiveObjectAny>,
-        new Date().toISOString(),
-      ),
-      resourceId,
       procedure,
+      payload: encodedPayload,
     };
 
     const pendingMutations =
       (this.store.optimisticMutationStack[routeName]?.length ?? 0) + 1;
 
-    this.store?.addMutation(routeName, mutationMessage, true);
+    this.store?.addMutation(routeName, optimisticDelta, true);
 
     this.emitEvent({
       type: "OPTIMISTIC_MUTATION_APPLIED",
-      mutationId: mutationMessage.id,
+      mutationId,
       resource: routeName,
       resourceId,
       procedure,
@@ -572,7 +597,7 @@ class InnerClient implements QueryExecutor {
 
     this.emitEvent({
       type: "MUTATION_SENT",
-      mutationId: mutationMessage.id,
+      mutationId,
       resource: routeName,
       resourceId,
       procedure,
@@ -580,6 +605,20 @@ class InnerClient implements QueryExecutor {
     });
 
     this.sendWsMessage(mutationMessage);
+
+    // Every MUTATE now receives a REPLY; the optimistic state is still
+    // reconciled by the SYNC broadcast, so just swallow the acknowledgement.
+    this.replyHandlers[mutationId] = {
+      timeoutHandle: setTimeout(() => {
+        delete this.replyHandlers[mutationId];
+      }, 5000),
+      handler: () => {
+        delete this.replyHandlers[mutationId];
+      },
+      reject: () => {
+        delete this.replyHandlers[mutationId];
+      },
+    };
   }
 
   public genericMutate(routeName: string, procedure: string, payload: any) {
@@ -626,12 +665,12 @@ class InnerClient implements QueryExecutor {
     };
 
     if (defaultMutationFallback) {
-      const defaultOptimisticMessage: DefaultMutationMessage = {
+      const defaultOptimisticMessage: SyncDeltaMessage = {
         id: mutationMessage.id,
-        type: "MUTATE",
+        type: "SYNC",
         resource: routeName,
         resourceId: defaultMutationFallback.id,
-        procedure: procedure === "insert" ? "INSERT" : "UPDATE",
+        op: procedure === "insert" ? "INSERT" : "UPDATE",
         payload: defaultMutationFallback.encoded,
       };
       this.store?.addMutation(routeName, defaultOptimisticMessage, true);
@@ -640,7 +679,7 @@ class InnerClient implements QueryExecutor {
         mutationId: mutationMessage.id,
         resource: routeName,
         resourceId: defaultMutationFallback.id,
-        procedure: defaultOptimisticMessage.procedure,
+        procedure: defaultOptimisticMessage.op,
         pendingMutations:
           (this.store.optimisticMutationStack[routeName]?.length ?? 0),
       });
@@ -746,12 +785,12 @@ class InnerClient implements QueryExecutor {
         const mutationId = generateId();
         const timestamp = new Date().toISOString();
 
-        const mutationMessage: DefaultMutationMessage = {
+        const mutationMessage: SyncDeltaMessage = {
           id: mutationId,
-          type: "MUTATE",
+          type: "SYNC",
           resource: op.resource,
           resourceId: op.id,
-          procedure: op.type === "insert" ? "INSERT" : "UPDATE",
+          op: op.type === "insert" ? "INSERT" : "UPDATE",
           payload: this.store.schema[op.resource].encodeMutation(
             "set",
             op.data as LiveObjectMutationInput<LiveObjectAny>,

--- a/packages/live-state/src/client/websocket/storage.ts
+++ b/packages/live-state/src/client/websocket/storage.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: too much work to fix - PRs welcome */
 import { type IDBPDatabase, openDB } from "idb";
-import type { DefaultMutationMessage } from "../../core/schemas/web-socket";
+import type { SyncDeltaMessage } from "../../core/schemas/web-socket";
 import type { Schema } from "../../schema";
 import { hash } from "../../utils";
 
@@ -8,7 +8,7 @@ const META_KEY = "__meta";
 const DATABASES_KEY = "databases";
 
 export class KVStorage {
-  private db?: IDBPDatabase<Record<string, DefaultMutationMessage["payload"]>>;
+  private db?: IDBPDatabase<Record<string, SyncDeltaMessage["payload"]>>;
 
   public async init(schema: Schema<any>, name: string) {
     if (typeof window === "undefined") return;
@@ -72,14 +72,14 @@ export class KVStorage {
 
   public async get(
     resourceType: string
-  ): Promise<Record<string, DefaultMutationMessage["payload"]>> {
+  ): Promise<Record<string, SyncDeltaMessage["payload"]>> {
     return (await this.getAll(this.db, resourceType)) ?? {};
   }
 
   public getOne(
     resourceType: string,
     id: string
-  ): Promise<DefaultMutationMessage["payload"] | undefined> {
+  ): Promise<SyncDeltaMessage["payload"] | undefined> {
     if (!this.db) return new Promise((resolve) => resolve(undefined));
 
     return this.db.get(resourceType, id);
@@ -88,7 +88,7 @@ export class KVStorage {
   public set(
     resourceType: string,
     id: string,
-    value: DefaultMutationMessage["payload"]
+    value: SyncDeltaMessage["payload"]
   ) {
     return this.db?.put(resourceType, value, id);
   }

--- a/packages/live-state/src/client/websocket/store.ts
+++ b/packages/live-state/src/client/websocket/store.ts
@@ -1,8 +1,8 @@
 import fastDeepEqual from "fast-deep-equal";
 import type { RawQueryRequest } from "../../core/schemas/core-protocol";
 import type {
-  DefaultMutationMessage,
   MutationMessage,
+  SyncDeltaMessage,
 } from "../../core/schemas/web-socket";
 import {
   type IncludeClause,
@@ -28,7 +28,7 @@ type RawObjPool = Record<
 
 export class OptimisticStore {
   private rawObjPool: RawObjPool = {} as RawObjPool;
-  public optimisticMutationStack: Record<string, DefaultMutationMessage[]> = {};
+  public optimisticMutationStack: Record<string, SyncDeltaMessage[]> = {};
   public customMutationStack: MutationMessage[] = [];
   private optimisticObjGraph: ObjectGraph;
   private optimisticRawObjPool: RawObjPool = {} as RawObjPool;
@@ -223,7 +223,7 @@ export class OptimisticStore {
 
   public addMutation(
     routeName: string,
-    mutation: DefaultMutationMessage,
+    mutation: SyncDeltaMessage,
     optimistic: boolean = false,
   ) {
     const schema = this.schema[routeName];
@@ -238,7 +238,7 @@ export class OptimisticStore {
 
     if (optimistic) {
       this.optimisticMutationStack[routeName] ??=
-        [] as DefaultMutationMessage[];
+        [] as SyncDeltaMessage[];
       this.optimisticMutationStack[routeName].push(mutation);
     } else {
       this.optimisticMutationStack[routeName] =
@@ -253,7 +253,7 @@ export class OptimisticStore {
           mutationId: mutation.id,
           resource: routeName,
           resourceId: mutation.resourceId,
-          procedure: mutation.procedure,
+          op: mutation.op,
           originMutationId: originId ?? "(none)",
           customMutationIndexKeys: Object.keys(this.customMutationIndex),
           optimisticStackSize: this.optimisticMutationStack[routeName]?.length ?? 0,
@@ -274,7 +274,7 @@ export class OptimisticStore {
 
           if (
             optMutation.resourceId === mutation.resourceId &&
-            optMutation.procedure === mutation.procedure
+            optMutation.op === mutation.op
           ) {
             this.logger.debug(
               "Removing optimistic mutation (resourceId match)",
@@ -293,7 +293,7 @@ export class OptimisticStore {
         if (!matched) {
           for (const entry of matchingEntries) {
             const optMutation = this.optimisticMutationStack[routeName]?.find(
-              (m) => m.id === entry.mutationId && m.procedure === mutation.procedure,
+              (m) => m.id === entry.mutationId && m.op === mutation.op,
             );
             if (optMutation) {
               this.logger.debug(
@@ -478,7 +478,7 @@ export class OptimisticStore {
 
   public loadConsolidatedState(
     resourceType: string,
-    data: DefaultMutationMessage["payload"][],
+    data: SyncDeltaMessage["payload"][],
   ) {
     data.forEach((payload) => {
       const id = payload.id?.value as string | undefined;
@@ -495,10 +495,10 @@ export class OptimisticStore {
 
       this.addMutation(resourceType, {
         id,
-        type: "MUTATE",
+        type: "SYNC",
         resource: resourceType,
         resourceId: id,
-        procedure: "INSERT",
+        op: "INSERT",
         payload: cleanedPayload,
       });
     });
@@ -506,14 +506,14 @@ export class OptimisticStore {
 
   private extractNestedRelations(
     resourceType: string,
-    payload: DefaultMutationMessage["payload"],
+    payload: SyncDeltaMessage["payload"],
   ): {
-    cleanedPayload: DefaultMutationMessage["payload"];
-    nestedMutations: DefaultMutationMessage[];
+    cleanedPayload: SyncDeltaMessage["payload"];
+    nestedMutations: SyncDeltaMessage[];
   } {
     const schema = this.schema[resourceType];
-    const cleanedPayload: DefaultMutationMessage["payload"] = { ...payload };
-    const nestedMutations: DefaultMutationMessage[] = [];
+    const cleanedPayload: SyncDeltaMessage["payload"] = { ...payload };
+    const nestedMutations: SyncDeltaMessage[] = [];
 
     if (!schema?.relations) {
       return { cleanedPayload, nestedMutations };
@@ -538,7 +538,7 @@ export class OptimisticStore {
 
           const nestedPayload = {
             ...nestedData,
-          } as DefaultMutationMessage["payload"];
+          } as SyncDeltaMessage["payload"];
           const {
             cleanedPayload: cleanedNestedPayload,
             nestedMutations: deeperMutations,
@@ -548,10 +548,10 @@ export class OptimisticStore {
 
           nestedMutations.push({
             id: nestedId,
-            type: "MUTATE",
+            type: "SYNC",
             resource: targetResource,
             resourceId: nestedId,
-            procedure: "INSERT",
+            op: "INSERT",
             payload: cleanedNestedPayload,
           });
 
@@ -570,7 +570,7 @@ export class OptimisticStore {
 
               const nestedPayload = {
                 ...item.value,
-              } as DefaultMutationMessage["payload"];
+              } as SyncDeltaMessage["payload"];
               const {
                 cleanedPayload: cleanedNestedPayload,
                 nestedMutations: deeperMutations,
@@ -580,10 +580,10 @@ export class OptimisticStore {
 
               nestedMutations.push({
                 id: nestedId,
-                type: "MUTATE",
+                type: "SYNC",
                 resource: targetResource,
                 resourceId: nestedId,
-                procedure: "INSERT",
+                op: "INSERT",
                 payload: cleanedNestedPayload,
               });
             }
@@ -600,7 +600,7 @@ export class OptimisticStore {
   private updateRawObjPool(
     routeName: string,
     resourceId: string,
-    payload: DefaultMutationMessage["payload"],
+    payload: SyncDeltaMessage["payload"],
     prevValue?: MaterializedLiveType<LiveObjectAny>,
   ) {
     if (!this.schema[routeName]) return;

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -966,18 +966,21 @@ export class QueryEngine {
   private sendInsertsForTree(
     queryNode: QueryNode,
     data: any,
-    resourceName: string
+    resourceName: string,
+    meta?: SyncDelta["meta"]
   ): void {
     const id = data?.value?.id?.value as string | undefined;
     if (!id) return;
 
-    // Send INSERT for this object
+    // Send INSERT for this object. Carry the source mutation's meta so the
+    // originating client can reconcile optimistic state via originMutationId.
     const insertMutation: SyncDelta = {
       op: "INSERT",
       resource: resourceName,
       resourceId: id,
       type: "SYNC",
       payload: data.value,
+      meta,
     };
 
     for (const subscription of Array.from(queryNode.subscriptions)) {
@@ -1017,10 +1020,15 @@ export class QueryEngine {
       const relatedItems = relatedData.value;
       if (Array.isArray(relatedItems)) {
         for (const item of relatedItems) {
-          this.sendInsertsForTree(childQueryNode, item, childResource);
+          this.sendInsertsForTree(childQueryNode, item, childResource, meta);
         }
       } else if (relatedItems && typeof relatedItems === "object") {
-        this.sendInsertsForTree(childQueryNode, relatedItems, childResource);
+        this.sendInsertsForTree(
+          childQueryNode,
+          relatedItems,
+          childResource,
+          meta
+        );
       }
     }
   }
@@ -1234,7 +1242,8 @@ export class QueryEngine {
                 this.sendInsertsForTree(
                   queryNode,
                   results[0],
-                  mutation.resource
+                  mutation.resource,
+                  mutation.meta
                 );
               });
             }

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -10,20 +10,20 @@ import type { Storage } from "../../server";
 import { Batcher } from "../../server/storage/batcher";
 import { applyWhere, extractIncludeFromWhere, isSubQueryInclude, type Logger } from "../../utils";
 import type {
-  DefaultMutation,
   RawQueryRequest,
+  SyncDelta,
 } from "../schemas/core-protocol";
 import { mergeWhereClauses, toPromiseLike } from "../utils";
 import type { DataRouter, DataSource, QueryStep } from "./types";
 import { hashStep } from "./utils";
 
-export type MutationHandler = (mutation: DefaultMutation) => void;
+export type SyncDeltaHandler = (delta: SyncDelta) => void;
 
 interface QueryNode {
   hash: string;
   queryStep: QueryStep;
   trackedObjects: Set<string>;
-  subscriptions: Set<MutationHandler>;
+  subscriptions: Set<SyncDeltaHandler>;
   parentQuery?: string;
   relationName?: string;
   childQueries: Set<string>;
@@ -271,7 +271,7 @@ export class QueryEngine {
 
   subscribe(
     query: RawQueryRequest,
-    callback: MutationHandler,
+    callback: SyncDeltaHandler,
     context: any = {}
   ): () => void {
     const queryPlan = this.breakdownQuery({ query, context });
@@ -972,11 +972,11 @@ export class QueryEngine {
     if (!id) return;
 
     // Send INSERT for this object
-    const insertMutation: DefaultMutation = {
-      procedure: "INSERT",
+    const insertMutation: SyncDelta = {
+      op: "INSERT",
       resource: resourceName,
       resourceId: id,
-      type: "MUTATE",
+      type: "SYNC",
       payload: data.value,
     };
 
@@ -1026,10 +1026,10 @@ export class QueryEngine {
   }
 
   public handleMutation(
-    mutation: DefaultMutation,
+    mutation: SyncDelta,
     entityValue: MaterializedLiveType<LiveObjectAny>
   ) {
-    if (mutation.procedure === "INSERT") {
+    if (mutation.op === "INSERT") {
       if (this.objectNodes.has(mutation.resourceId)) return;
 
       const objValue = inferValue(entityValue);
@@ -1104,7 +1104,7 @@ export class QueryEngine {
 
       return;
     }
-    if (mutation.procedure === "UPDATE") {
+    if (mutation.op === "UPDATE") {
       const objValue = inferValue(entityValue);
 
       if (!objValue) return;
@@ -1247,7 +1247,7 @@ export class QueryEngine {
   }
 
   getMatchingQueries(
-    mutation: DefaultMutation,
+    mutation: SyncDelta,
     objValue: any
   ): PromiseLike<string[]> {
     const queriesToCheck: QueryNode[] = [];

--- a/packages/live-state/src/core/schemas/core-protocol.ts
+++ b/packages/live-state/src/core/schemas/core-protocol.ts
@@ -61,15 +61,13 @@ export const syncDeltaSchema = z.object({
   id: z.string().optional(),
   type: z.literal("SYNC"),
   resource: z.string(),
-  resourceId: z.string().optional(),
+  resourceId: z.string(),
   op: z.enum(["INSERT", "UPDATE"]),
   payload: mutationPayloadSchema,
   meta: mutationMetaSchema,
 });
 
-export type SyncDelta = Omit<z.infer<typeof syncDeltaSchema>, "resourceId"> & {
-  resourceId: string;
-};
+export type SyncDelta = z.infer<typeof syncDeltaSchema>;
 
 export const mutationSchema = genericMutationSchema;
 

--- a/packages/live-state/src/core/schemas/core-protocol.ts
+++ b/packages/live-state/src/core/schemas/core-protocol.ts
@@ -51,23 +51,27 @@ export const genericMutationSchema = baseMutationSchema.extend({
 
 export type GenericMutation = z.infer<typeof genericMutationSchema>;
 
-export const defaultMutationSchema = baseMutationSchema.extend({
-  procedure: z.enum(["INSERT", "UPDATE"]),
+/**
+ * Server→client field-level sync delta. Carries a committed storage write to
+ * subscribed clients. `op` is a storage-operation marker (not a client
+ * procedure) retained because client optimistic reconciliation still matches
+ * on it. See ADR-0001.
+ */
+export const syncDeltaSchema = z.object({
+  id: z.string().optional(),
+  type: z.literal("SYNC"),
+  resource: z.string(),
+  resourceId: z.string().optional(),
+  op: z.enum(["INSERT", "UPDATE"]),
   payload: mutationPayloadSchema,
   meta: mutationMetaSchema,
 });
 
-export type DefaultMutation = Omit<
-  z.infer<typeof defaultMutationSchema>,
-  "resourceId"
-> & {
+export type SyncDelta = Omit<z.infer<typeof syncDeltaSchema>, "resourceId"> & {
   resourceId: string;
 };
 
-export const mutationSchema = z.union([
-  defaultMutationSchema,
-  genericMutationSchema,
-]);
+export const mutationSchema = genericMutationSchema;
 
 export type RawMutationRequest = z.infer<typeof mutationSchema>;
 

--- a/packages/live-state/src/core/schemas/http.ts
+++ b/packages/live-state/src/core/schemas/http.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import {
-  defaultMutationSchema,
   genericMutationSchema,
   querySchema,
+  syncDeltaSchema,
 } from "./core-protocol";
 
 export const httpQuerySchema = querySchema.omit({
@@ -20,11 +20,11 @@ export const httpGenericMutationSchema = genericMutationSchema
     meta: genericMutationSchema.shape.meta,
   });
 
-export const httpDefaultMutationSchema = defaultMutationSchema.omit({
+export const httpDefaultMutationSchema = syncDeltaSchema.omit({
   id: true,
   type: true,
   resource: true,
-  procedure: true,
+  op: true,
 });
 
 export const httpMutationSchema = z.union([

--- a/packages/live-state/src/core/schemas/http.ts
+++ b/packages/live-state/src/core/schemas/http.ts
@@ -20,12 +20,17 @@ export const httpGenericMutationSchema = genericMutationSchema
     meta: genericMutationSchema.shape.meta,
   });
 
-export const httpDefaultMutationSchema = syncDeltaSchema.omit({
-  id: true,
-  type: true,
-  resource: true,
-  op: true,
-});
+export const httpDefaultMutationSchema = syncDeltaSchema
+  .omit({
+    id: true,
+    type: true,
+    resource: true,
+    op: true,
+  })
+  .extend({
+    // resourceId may be supplied via the URL path / payload id instead of the body.
+    resourceId: z.string().optional(),
+  });
 
 export const httpMutationSchema = z.union([
   httpDefaultMutationSchema,

--- a/packages/live-state/src/core/schemas/web-socket.ts
+++ b/packages/live-state/src/core/schemas/web-socket.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 import {
 	customQuerySchema,
-	defaultMutationSchema,
 	genericMutationSchema,
 	queryPayloadSchema,
 	querySchema,
+	syncDeltaSchema,
 } from './core-protocol';
 
 export const msgId = z.string();
@@ -46,25 +46,11 @@ export const clCustomQueryMsgSchema = z.object({
 
 export type CustomQueryMessage = z.infer<typeof clCustomQueryMsgSchema>;
 
-export const defaultMutationMsgSchema = defaultMutationSchema.extend({
-	id: msgId,
-});
-
-export type DefaultMutationMessage = Omit<
-	z.infer<typeof defaultMutationMsgSchema>,
-	'resourceId'
-> & {
-	resourceId: string;
-};
-
 export const genericMutationMsgSchema = genericMutationSchema.extend({
 	id: msgId,
 });
 
-export const mutationMsgSchema = z.union([
-	genericMutationMsgSchema,
-	defaultMutationMsgSchema,
-]);
+export const mutationMsgSchema = genericMutationMsgSchema;
 
 export type MutationMessage = z.infer<typeof mutationMsgSchema>;
 
@@ -95,10 +81,21 @@ export const svReplyMsgSchema = z.object({
 	data: z.any(),
 });
 
+export const syncDeltaMsgSchema = syncDeltaSchema.extend({
+	id: msgId,
+});
+
+export type SyncDeltaMessage = Omit<
+	z.infer<typeof syncDeltaMsgSchema>,
+	'resourceId'
+> & {
+	resourceId: string;
+};
+
 export const serverMessageSchema = z.union([
 	svRejectMsgSchema,
 	svReplyMsgSchema,
-	defaultMutationMsgSchema,
+	syncDeltaMsgSchema,
 ]);
 
 export type ServerMessage = z.infer<typeof serverMessageSchema>;

--- a/packages/live-state/src/core/schemas/web-socket.ts
+++ b/packages/live-state/src/core/schemas/web-socket.ts
@@ -85,12 +85,7 @@ export const syncDeltaMsgSchema = syncDeltaSchema.extend({
 	id: msgId,
 });
 
-export type SyncDeltaMessage = Omit<
-	z.infer<typeof syncDeltaMsgSchema>,
-	'resourceId'
-> & {
-	resourceId: string;
-};
+export type SyncDeltaMessage = z.infer<typeof syncDeltaMsgSchema>;
 
 export const serverMessageSchema = z.union([
 	svRejectMsgSchema,

--- a/packages/live-state/src/server/index.ts
+++ b/packages/live-state/src/server/index.ts
@@ -2,8 +2,8 @@
 import { QueryEngine } from "../core/query-engine";
 import type { QueryStep as CoreQueryStep } from "../core/query-engine/types";
 import type {
-  DefaultMutation,
   RawQueryRequest,
+  SyncDelta,
 } from "../core/schemas/core-protocol";
 import type { PromiseOrSync } from "../core/utils";
 import { mergeWhereClauses } from "../core/utils";
@@ -234,7 +234,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
 
   public async handleQuery(opts: {
     req: QueryRequest;
-    subscription?: (mutation: DefaultMutation) => void;
+    subscription?: (mutation: SyncDelta) => void;
   }): Promise<QueryResult<any>> {
     await this.ensureInitialized();
 
@@ -295,7 +295,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
 
   public async handleCustomQuery(opts: {
     req: QueryProcedureRequest;
-    subscription?: (mutation: DefaultMutation) => void;
+    subscription?: (mutation: SyncDelta) => void;
   }): Promise<any> {
     await this.ensureInitialized();
 
@@ -370,7 +370,7 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
   }
 
   /** @internal */
-  public notifySubscribers(mutation: DefaultMutation, entityData: any) {
+  public notifySubscribers(mutation: SyncDelta, entityData: any) {
     this.queryEngine.handleMutation(mutation, entityData);
   }
 

--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -7,8 +7,8 @@ import {
   type Selectable,
 } from "kysely";
 import type {
-  DefaultMutation,
   RawQueryRequest,
+  SyncDelta,
 } from "../../core/schemas/core-protocol";
 import { generateId } from "../../core/utils";
 import {
@@ -38,7 +38,7 @@ export class SQLStorage extends Storage {
   private logger?: Logger;
   private server?: Server<any, any>;
   private mutationStack: Array<{
-    mutation: DefaultMutation;
+    mutation: SyncDelta;
     entityData: MaterializedLiveType<any>;
   }> = [];
 
@@ -568,7 +568,7 @@ export class SQLStorage extends Storage {
       const savepointName = Math.random().toString(36).substring(2, 15);
       const parentStack = this.mutationStack;
       const nestedStack: Array<{
-        mutation: DefaultMutation;
+        mutation: SyncDelta;
         entityData: MaterializedLiveType<any>;
       }> = [];
       this.mutationStack = nestedStack;
@@ -628,7 +628,7 @@ export class SQLStorage extends Storage {
     }
 
     const transactionStack: Array<{
-      mutation: DefaultMutation;
+      mutation: SyncDelta;
       entityData: MaterializedLiveType<any>;
     }> = [];
     const previousStack = this.mutationStack;
@@ -657,7 +657,7 @@ export class SQLStorage extends Storage {
                 id: mutation.id,
                 resource: mutation.resource,
                 resourceId: mutation.resourceId,
-                procedure: mutation.procedure,
+                op: mutation.op,
                 hasMeta: !!mutation.meta,
                 originMutationId: mutation.meta?.originMutationId ?? "(none)",
               })),
@@ -684,7 +684,7 @@ export class SQLStorage extends Storage {
                   id: mutation.id,
                   resource: mutation.resource,
                   resourceId: mutation.resourceId,
-                  procedure: mutation.procedure,
+                  op: mutation.op,
                   hasMeta: !!mutation.meta,
                   originMutationId: mutation.meta?.originMutationId ?? "(none)",
                 })),
@@ -946,11 +946,11 @@ export class SQLStorage extends Storage {
   private buildMutation<T extends LiveObjectAny>(
     resourceName: string,
     resourceId: string,
-    procedure: "INSERT" | "UPDATE",
+    op: "INSERT" | "UPDATE",
     value: MaterializedLiveType<T>,
     mutationId?: string,
     originMutationId?: string,
-  ): DefaultMutation | null {
+  ): SyncDelta | null {
     const payload: Record<
       string,
       { value: any; _meta?: { timestamp: string } }
@@ -972,17 +972,17 @@ export class SQLStorage extends Storage {
 
     return {
       id: mutationId ?? generateId(),
-      type: "MUTATE",
+      type: "SYNC",
       resource: resourceName,
       resourceId,
-      procedure,
+      op,
       payload,
       meta: originMutationId ? { originMutationId } : undefined,
     };
   }
 
   private trackMutation(
-    mutation: DefaultMutation,
+    mutation: SyncDelta,
     entityData: MaterializedLiveType<any>,
   ): void {
     if (this.db.isTransaction) {
@@ -993,20 +993,20 @@ export class SQLStorage extends Storage {
   }
 
   private notifyMutations(
-    mutations: DefaultMutation[],
+    mutations: SyncDelta[],
     entityData: MaterializedLiveType<any>,
   ): void;
   private notifyMutations(
     mutationEntries: Array<{
-      mutation: DefaultMutation;
+      mutation: SyncDelta;
       entityData: MaterializedLiveType<any>;
     }>,
   ): void;
   private notifyMutations(
     mutationsOrEntries:
-      | DefaultMutation[]
+      | SyncDelta[]
       | Array<{
-          mutation: DefaultMutation;
+          mutation: SyncDelta;
           entityData: MaterializedLiveType<any>;
         }>,
     entityData?: MaterializedLiveType<any>,
@@ -1014,13 +1014,13 @@ export class SQLStorage extends Storage {
     if (!this.server) return;
 
     if (entityData !== undefined) {
-      const mutations = mutationsOrEntries as DefaultMutation[];
+      const mutations = mutationsOrEntries as SyncDelta[];
       for (const mutation of mutations) {
         this.server.notifySubscribers(mutation, entityData);
       }
     } else {
       const entries = mutationsOrEntries as Array<{
-        mutation: DefaultMutation;
+        mutation: SyncDelta;
         entityData: MaterializedLiveType<any>;
       }>;
       for (const { mutation, entityData: data } of entries) {

--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -1,6 +1,5 @@
 import cookie from "cookie";
 import qs from "qs";
-import type { DefaultMutation } from "../../core/schemas/core-protocol";
 import {
   type HttpMutation,
   httpDefaultMutationSchema,
@@ -267,7 +266,8 @@ export const httpTransportLayer = (
               input: inputOverride ?? body.payload,
               context: initialContext,
               resourceId:
-                resourceIdOverride ?? (body as DefaultMutation).resourceId,
+                resourceIdOverride ??
+                (body as { resourceId?: string }).resourceId,
               procedure: mutationProcedure,
               queryParams: {},
               meta: (body as any).meta,

--- a/packages/live-state/src/server/transport-layers/web-socket.ts
+++ b/packages/live-state/src/server/transport-layers/web-socket.ts
@@ -2,10 +2,7 @@
 import cookie from "cookie";
 import { parse } from "qs";
 import type WebSocket from "ws";
-import type {
-  DefaultMutation,
-  GenericMutation,
-} from "../../core/schemas/core-protocol";
+import type { GenericMutation } from "../../core/schemas/core-protocol";
 import {
   clientMessageSchema,
   type ServerMessage,
@@ -206,9 +203,8 @@ export const webSocketAdapter = (server: Server<AnyRouter, any>) => {
               .procedure;
             let mutationProcedure = originalProcedure;
             let mutationInput: any = parsedMessage.payload;
-            let mutationResourceId: string | undefined = (
-              parsedMessage as DefaultMutation
-            ).resourceId;
+            let mutationResourceId: string | undefined =
+              parsedMessage.resourceId;
 
             // TODO: Remove generic insert/update shape resolution when default mutations are removed.
             if (
@@ -266,20 +262,11 @@ export const webSocketAdapter = (server: Server<AnyRouter, any>) => {
               },
             });
 
-            if (
-              (originalProcedure &&
-                originalProcedure !== "INSERT" &&
-                originalProcedure !== "UPDATE") ||
-              (mutationProcedure !== originalProcedure &&
-                (mutationProcedure === "INSERT" ||
-                  mutationProcedure === "UPDATE"))
-            ) {
-              reply({
-                id: parsedMessage.id,
-                type: "REPLY",
-                data: result,
-              });
-            }
+            reply({
+              id: parsedMessage.id,
+              type: "REPLY",
+              data: result,
+            });
           } catch (e) {
             reply({
               id: parsedMessage.id,

--- a/packages/live-state/test/bench/mutation-broadcast-latency.bench.ts
+++ b/packages/live-state/test/bench/mutation-broadcast-latency.bench.ts
@@ -71,7 +71,7 @@ function measureMutationLatency(
     eventUnsubscribe = receiver.client.addEventListener((event) => {
       if (
         event.type === "MESSAGE_RECEIVED" &&
-        event.message.type === "MUTATE" &&
+        event.message.type === "SYNC" &&
         event.message.resourceId === resourceId &&
         !resolved
       ) {

--- a/packages/live-state/test/bench/websocket-client.bench.ts
+++ b/packages/live-state/test/bench/websocket-client.bench.ts
@@ -9,7 +9,7 @@ import {
 	object,
 } from "../../src/schema";
 import { OptimisticStore } from "../../src/client/websocket/store";
-import type { DefaultMutationMessage } from "../../src/core/schemas/web-socket";
+import type { SyncDeltaMessage } from "../../src/core/schemas/web-socket";
 import { generateId } from "../../src/core/utils";
 import { createLogger, LogLevel } from "../../src/utils";
 
@@ -106,15 +106,15 @@ function createMutation(
 	resource: string,
 	resourceId: string,
 	payload: Record<string, unknown>,
-	procedure: "INSERT" | "UPDATE" = "INSERT"
-): DefaultMutationMessage {
+	op: "INSERT" | "UPDATE" = "INSERT"
+): SyncDeltaMessage {
 	const timestamp = new Date().toISOString();
 	return {
 		id: generateId(),
-		type: "MUTATE",
+		type: "SYNC",
 		resource,
 		resourceId,
-		procedure,
+		op,
 		payload: Object.fromEntries(
 			Object.entries(payload).map(([k, v]) => [
 				k,

--- a/packages/live-state/test/client/broadcast-optimistic-cleanup.test.ts
+++ b/packages/live-state/test/client/broadcast-optimistic-cleanup.test.ts
@@ -147,16 +147,16 @@ const makeOptimisticMutations = () =>
 const makeBroadcast = (
 	id: string,
 	resourceId: string,
-	procedure: 'INSERT' | 'UPDATE',
+	op: 'INSERT' | 'UPDATE',
 	payload: Record<string, any>,
 	originMutationId?: string,
 ) =>
 	JSON.stringify({
-		type: 'MUTATE',
+		type: 'SYNC',
 		id,
 		resource: 'posts',
 		resourceId,
-		procedure,
+		op,
 		payload: Object.fromEntries(
 			Object.entries(payload).map(([k, v]) => [
 				k,

--- a/packages/live-state/test/client/optimistic-card-repro.test.ts
+++ b/packages/live-state/test/client/optimistic-card-repro.test.ts
@@ -271,10 +271,10 @@ describe('optimistic createCard with group include (storefront repro)', () => {
 		ws.simulateMessage(
 			JSON.stringify({
 				id: 'broadcast-1',
-				type: 'MUTATE',
+				type: 'SYNC',
 				resource: 'cards',
 				resourceId: newCardId,
-				procedure: 'INSERT',
+				op: 'INSERT',
 				meta: { originMutationId: sentMessage.id },
 				payload: {
 					name: { value: 'New Card', _meta: { timestamp: '2026-01-01' } },
@@ -350,10 +350,10 @@ describe('optimistic createCard with group include (storefront repro)', () => {
 		ws.simulateMessage(
 			JSON.stringify({
 				id: 'broadcast-1',
-				type: 'MUTATE',
+				type: 'SYNC',
 				resource: 'cards',
 				resourceId: newCardId,
-				procedure: 'INSERT',
+				op: 'INSERT',
 				meta: { originMutationId: sentMessage.id },
 				payload: {
 					name: { value: 'New Card', _meta: { timestamp: '2026-01-01' } },

--- a/packages/live-state/test/client/websocket/store.test.ts
+++ b/packages/live-state/test/client/websocket/store.test.ts
@@ -10,7 +10,7 @@ import {
 import { ObjectGraph } from "../../../src/client/websocket/obj-graph";
 import { KVStorage } from "../../../src/client/websocket/storage";
 import { OptimisticStore } from "../../../src/client/websocket/store";
-import { DefaultMutationMessage } from "../../../src/core/schemas/web-socket";
+import { SyncDeltaMessage } from "../../../src/core/schemas/web-socket";
 import {
   createRelations,
   id,
@@ -139,7 +139,7 @@ describe("OptimisticStore", () => {
       users: [
         {
           id: "mut1",
-          type: "MUTATE",
+          type: "SYNC",
           resource: "users",
           resourceId: "user1",
           payload: {},
@@ -435,9 +435,9 @@ describe("OptimisticStore", () => {
       mockLogger,
     );
 
-    const mutation: DefaultMutationMessage = {
+    const mutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user1",
       payload: {
@@ -469,9 +469,9 @@ describe("OptimisticStore", () => {
     );
 
     // Add optimistic mutation first
-    const optimisticMutation: DefaultMutationMessage = {
+    const optimisticMutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user1",
       payload: {
@@ -482,9 +482,9 @@ describe("OptimisticStore", () => {
     store.optimisticMutationStack["users"] = [optimisticMutation];
 
     // Add server mutation with same id
-    const serverMutation: DefaultMutationMessage = {
+    const serverMutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user1",
       payload: {
@@ -519,9 +519,9 @@ describe("OptimisticStore", () => {
       mockLogger,
     );
 
-    const mutation: DefaultMutationMessage = {
+    const mutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "nonexistent",
       resourceId: "item1",
       payload: {},
@@ -539,9 +539,9 @@ describe("OptimisticStore", () => {
       mockLogger,
     );
 
-    const mutation: DefaultMutationMessage = {
+    const mutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "posts",
       resourceId: "post1",
       payload: {
@@ -581,9 +581,9 @@ describe("OptimisticStore", () => {
       mockLogger,
     );
 
-    const mutation: DefaultMutationMessage = {
+    const mutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "posts",
       resourceId: "post1",
       payload: {
@@ -632,9 +632,9 @@ describe("OptimisticStore", () => {
     // Subscribe to the users resource to set up the listener
     store.subscribe({ resource: "users" }, listener);
 
-    const mutation: DefaultMutationMessage = {
+    const mutation: SyncDeltaMessage = {
       id: "mut1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user1",
       payload: {
@@ -675,19 +675,19 @@ describe("OptimisticStore", () => {
     expect(addMutationSpy).toHaveBeenCalledTimes(2);
     expect(addMutationSpy).toHaveBeenCalledWith("users", {
       id: "user1",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user1",
       payload: data[0],
-      procedure: "INSERT",
+      op: "INSERT",
     });
     expect(addMutationSpy).toHaveBeenCalledWith("users", {
       id: "user2",
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user2",
       payload: data[1],
-      procedure: "INSERT",
+      op: "INSERT",
     });
   });
 
@@ -1023,15 +1023,15 @@ describe("OptimisticStore", () => {
     });
 
     test("should undo optimistic mutation", () => {
-      const mutation: DefaultMutationMessage = {
+      const mutation: SyncDeltaMessage = {
         id: "mut1",
-        type: "MUTATE",
+        type: "SYNC",
         resource: "users",
         resourceId: "user1",
         payload: {
           name: { value: "John", _meta: { timestamp: "2023-01-01" } },
         },
-        procedure: "UPDATE",
+        op: "UPDATE",
       };
 
       // Add optimistic mutation

--- a/packages/live-state/test/e2e/query-engine.test.ts
+++ b/packages/live-state/test/e2e/query-engine.test.ts
@@ -558,7 +558,7 @@ describe("Query Engine Functional Requirements", () => {
       expect(mutations.length).toBe(1);
       expect(mutations[0].resource).toBe("posts");
       expect(mutations[0].resourceId).toBe(newPostId);
-      expect(mutations[0].procedure).toBe("INSERT");
+      expect(mutations[0].op).toBe("INSERT");
       expect(mutations[0].payload.title.value).toBe(newPostTitle);
 
       if (result.unsubscribe) {
@@ -722,7 +722,7 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(mutations.length).toBe(1);
-      expect(mutations[0].procedure).toBe("UPDATE");
+      expect(mutations[0].op).toBe("UPDATE");
       expect(mutations[0].resourceId).toBe(postId1);
       expect(mutations[0].payload.title.value).toBe(updatedTitle);
       expect(mutations[0].payload.likes.value).toBe(updatedLikes);
@@ -769,7 +769,7 @@ describe("Query Engine Functional Requirements", () => {
 
       // Should receive INSERT mutation (object now matches)
       expect(mutations.length).toBe(1);
-      expect(mutations[0].procedure).toBe("INSERT");
+      expect(mutations[0].op).toBe("INSERT");
       expect(mutations[0].resourceId).toBe(postId2);
       expect(mutations[0].payload.likes.value).toBe(15);
 
@@ -815,7 +815,7 @@ describe("Query Engine Functional Requirements", () => {
 
       // Should receive UPDATE mutation (object no longer matches)
       expect(mutations.length).toBe(1);
-      expect(mutations[0].procedure).toBe("UPDATE");
+      expect(mutations[0].op).toBe("UPDATE");
       expect(mutations[0].resourceId).toBe(postId3);
       expect(mutations[0].payload.likes.value).toBe(5);
 
@@ -860,7 +860,7 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(mutations.length).toBe(1);
-      expect(mutations[0].procedure).toBe("UPDATE");
+      expect(mutations[0].op).toBe("UPDATE");
       expect(mutations[0].payload.likes.value).toBe(5);
 
       // Transition 2: Non-matching -> Matching
@@ -871,7 +871,7 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(mutations.length).toBe(2);
-      expect(mutations[1].procedure).toBe("INSERT");
+      expect(mutations[1].op).toBe("INSERT");
       expect(mutations[1].payload.likes.value).toBe(15);
 
       if (result.unsubscribe) {
@@ -915,7 +915,7 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(mutations.length).toBe(1);
-      expect(mutations[0].procedure).toBe("UPDATE");
+      expect(mutations[0].op).toBe("UPDATE");
       expect(mutations[0].payload.authorId.value).toBe(userId2);
 
       // Change post author back to John Doe (matches again)
@@ -926,7 +926,7 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(mutations.length).toBe(2);
-      expect(mutations[1].procedure).toBe("INSERT");
+      expect(mutations[1].op).toBe("INSERT");
       expect(mutations[1].payload.authorId.value).toBe(userId1);
 
       if (result.unsubscribe) {
@@ -985,7 +985,7 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(query1Mutations.length).toBe(1);
-      expect(query1Mutations[0].procedure).toBe("UPDATE");
+      expect(query1Mutations[0].op).toBe("UPDATE");
       expect(query2Mutations.length).toBe(0);
 
       // Update postId3 to likes = 25 (matches both)
@@ -996,9 +996,9 @@ describe("Query Engine Functional Requirements", () => {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(query1Mutations.length).toBe(2);
-      expect(query1Mutations[1].procedure).toBe("UPDATE");
+      expect(query1Mutations[1].op).toBe("UPDATE");
       expect(query2Mutations.length).toBe(1);
-      expect(query2Mutations[0].procedure).toBe("INSERT");
+      expect(query2Mutations[0].op).toBe("INSERT");
 
       if (result1.unsubscribe) {
         result1.unsubscribe();
@@ -1054,7 +1054,7 @@ describe("Query Engine Functional Requirements", () => {
       expect(mutations.length).toBe(1);
       expect(mutations[0].resource).toBe("comments");
       expect(mutations[0].resourceId).toBe(newCommentId);
-      expect(mutations[0].procedure).toBe("INSERT");
+      expect(mutations[0].op).toBe("INSERT");
 
       if (result.unsubscribe) {
         result.unsubscribe();
@@ -1096,7 +1096,7 @@ describe("Query Engine Functional Requirements", () => {
       expect(mutations.length).toBe(1);
       expect(mutations[0].resource).toBe("users");
       expect(mutations[0].resourceId).toBe(userId1);
-      expect(mutations[0].procedure).toBe("UPDATE");
+      expect(mutations[0].op).toBe("UPDATE");
 
       if (result.unsubscribe) {
         result.unsubscribe();
@@ -1148,7 +1148,7 @@ describe("Query Engine Functional Requirements", () => {
         (m) => m.resource === "orgs" && m.resourceId === orgId1
       );
       expect(orgMutation).toBeDefined();
-      expect(orgMutation!.procedure).toBe("UPDATE");
+      expect(orgMutation!.op).toBe("UPDATE");
 
       if (result.unsubscribe) {
         result.unsubscribe();
@@ -1208,7 +1208,7 @@ describe("Query Engine Functional Requirements", () => {
         (m) => m.resource === "posts" && m.resourceId === postId3
       );
       expect(postMutation).toBeDefined();
-      expect(postMutation!.procedure).toBe("INSERT");
+      expect(postMutation!.op).toBe("INSERT");
       expect(postMutation!.payload.authorId.value).toBe(userId1);
 
       if (result.unsubscribe) {
@@ -1263,7 +1263,7 @@ describe("Query Engine Functional Requirements", () => {
         (m) => m.resource === "posts" && m.resourceId === postId1
       );
       expect(postMutation).toBeDefined();
-      expect(postMutation!.procedure).toBe("UPDATE");
+      expect(postMutation!.op).toBe("UPDATE");
       expect(postMutation!.payload.authorId.value).toBe(userId3);
 
       // Verify subsequent updates to out-of-scope object don't trigger notifications
@@ -1335,7 +1335,7 @@ describe("Query Engine Functional Requirements", () => {
         (m) => m.resource === "posts" && m.resourceId === postId3
       );
       expect(postMutation).toBeDefined();
-      expect(postMutation!.procedure).toBe("INSERT");
+      expect(postMutation!.op).toBe("INSERT");
 
       // Should receive INSERTs for all comments on the post
       for (const commentId of post3CommentIds) {
@@ -1343,7 +1343,7 @@ describe("Query Engine Functional Requirements", () => {
           (m) => m.resource === "comments" && m.resourceId === commentId
         );
         expect(commentMutation).toBeDefined();
-        expect(commentMutation!.procedure).toBe("INSERT");
+        expect(commentMutation!.op).toBe("INSERT");
         expect(commentMutation!.payload.postId.value).toBe(postId3);
       }
 
@@ -1404,7 +1404,7 @@ describe("Query Engine Functional Requirements", () => {
         (m) => m.resource === "comments" && m.resourceId === commentId1
       );
       expect(commentMutation).toBeDefined();
-      expect(commentMutation!.procedure).toBe("UPDATE");
+      expect(commentMutation!.op).toBe("UPDATE");
       expect(commentMutation!.payload.postId.value).toBe(postId4);
 
       // Verify subsequent updates to out-of-scope comment don't trigger notifications
@@ -1511,9 +1511,9 @@ describe("Query Engine Functional Requirements", () => {
       expect(client2Mutations.length).toBe(2);
       expect(client3Mutations.length).toBe(2);
 
-      expect(client1Mutations[1].procedure).toBe("UPDATE");
-      expect(client2Mutations[1].procedure).toBe("UPDATE");
-      expect(client3Mutations[1].procedure).toBe("UPDATE");
+      expect(client1Mutations[1].op).toBe("UPDATE");
+      expect(client2Mutations[1].op).toBe("UPDATE");
+      expect(client3Mutations[1].op).toBe("UPDATE");
 
       if (result1.unsubscribe) {
         result1.unsubscribe();
@@ -1632,8 +1632,8 @@ describe("Query Engine Functional Requirements", () => {
 
       expect(authorUpdate1).toBeDefined();
       expect(authorUpdate2).toBeDefined();
-      expect(authorUpdate1!.procedure).toBe("UPDATE");
-      expect(authorUpdate2!.procedure).toBe("UPDATE");
+      expect(authorUpdate1!.op).toBe("UPDATE");
+      expect(authorUpdate2!.op).toBe("UPDATE");
 
       if (result1.unsubscribe) {
         result1.unsubscribe();

--- a/packages/live-state/test/server/transport-layers/web-socket.test.ts
+++ b/packages/live-state/test/server/transport-layers/web-socket.test.ts
@@ -223,7 +223,7 @@ describe("webSocketAdapter", () => {
     });
   });
 
-  test("should handle MUTATE message with default mutation", async () => {
+  test("should reply to MUTATE message with default insert/update procedure", async () => {
     wsHandler(mockWebSocket, mockRequest);
 
     const messageHandler = (mockWebSocket.on as Mock).mock.calls.find(
@@ -271,8 +271,17 @@ describe("webSocketAdapter", () => {
       }),
     });
 
-    // Should not send reply for default mutations
-    expect(mockWebSocket.send).not.toHaveBeenCalled();
+    // Every MUTATE now receives a reply unconditionally
+    expect(mockWebSocket.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: "msg-1",
+        type: "REPLY",
+        data: {
+          data: { name: "John Updated" },
+          acceptedValues: { name: "John Updated" },
+        },
+      }),
+    );
   });
 
   test("should handle MUTATE message with custom procedure", async () => {
@@ -527,7 +536,7 @@ describe("webSocketAdapter", () => {
 
     // Try to propagate mutation without resourceId
     const mutation = {
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       payload: {
         name: {
@@ -542,10 +551,10 @@ describe("webSocketAdapter", () => {
       subscriptionHandler(mutation);
     }
 
-    // Should not propagate MUTATE messages because resourceId is missing
+    // Should not propagate SYNC messages because resourceId is missing
     const forwardedMutations = (ws.send as Mock).mock.calls
       .map((call) => JSON.parse(call[0] as string))
-      .filter((message) => message.type === "MUTATE");
+      .filter((message) => message.type === "SYNC");
 
     expect(forwardedMutations).toHaveLength(0);
   });
@@ -577,7 +586,7 @@ describe("webSocketAdapter", () => {
 
     // Try to propagate mutation without payload
     const mutation = {
-      type: "MUTATE",
+      type: "SYNC",
       resource: "users",
       resourceId: "user1",
       // Missing payload
@@ -587,10 +596,10 @@ describe("webSocketAdapter", () => {
       subscriptionHandler(mutation);
     }
 
-    // Should not propagate MUTATE messages because payload is missing
+    // Should not propagate SYNC messages because payload is missing
     const forwardedMutations = (ws.send as Mock).mock.calls
       .map((call) => JSON.parse(call[0] as string))
-      .filter((message) => message.type === "MUTATE");
+      .filter((message) => message.type === "SYNC");
 
     expect(forwardedMutations).toHaveLength(0);
   });


### PR DESCRIPTION
Closes #160 — splits the overloaded `MUTATE` message into a client→server request and a server→client `SYNC` delta, per [ADR-0001](docs/adr/0001-split-mutation-request-from-sync-delta.md).

## What changed

**Protocol (`core/schemas/`)**
- `core-protocol.ts`: renamed `defaultMutationSchema`→`syncDeltaSchema` / `DefaultMutation`→`SyncDelta`, with `type: "SYNC"` and the storage-op marker renamed `procedure`→`op`. `mutationSchema` is now just the generic (custom-procedure) mutation, so `MUTATE` is client→server only.
- `web-socket.ts`: added `syncDeltaMsgSchema`/`SyncDeltaMessage` to the server-message union; the client mutation union is generic-only.
- `http.ts`: HTTP default-mutation body derived from `syncDeltaSchema`.

**Server producers**
- `sql-storage.ts` `buildMutation` emits `type: "SYNC"`/`op` for every committed write.
- `query-engine/index.ts`: scope-change emitters (`sendInsertsForTree` + INSERT/UPDATE sites) emit `SYNC`; `DefaultMutation`→`SyncDelta`, `MutationHandler`→`SyncDeltaHandler`.
- `web-socket.ts` transport: deleted the conditional REPLY-skip branch — every `MUTATE` now replies unconditionally.

**Client**
- `client.ts` applies incoming `SYNC` deltas (replaced the `MUTATE` branch); optimistic local representations use `SyncDeltaMessage`. The deprecated `mutate()` sends a proper `MUTATE` wire request (separate from its optimistic delta) and swallows the new reply; reconnect replay converts stored deltas back to `MUTATE`.
- `store.ts`/`storage.ts`: renamed types and matching logic to `op`.

`mergeMutation` is **untouched** on both server and client.

**Docs**: updated `CONTEXT.md` glossary (Mutation / Sync Delta entries) to match the shipped split.

## Acceptance criteria
- [x] Core protocol exposes `syncDeltaSchema`/`SyncDelta` and a `SYNC`-typed server message; `MUTATE` is client→server only
- [x] `notifySubscribers` emits `SYNC` for every committed write
- [x] Query engine scope-change emitters emit `SYNC`; `DefaultMutation`/`MutationHandler` renamed
- [x] Client applies incoming `SYNC` deltas
- [x] Every client `MUTATE` receives a `REPLY`/`REJECT`; REPLY-skip branch removed
- [x] `mergeMutation` untouched
- [x] Tests assert the `SYNC` shape and unconditional reply
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` pass for `./packages/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
- Added protocol terminology glossary defining mutation types, sync deltas, and optimistic reconciliation patterns
- Documented WebSocket protocol evolution with architecture decision record

**Breaking Changes**
- WebSocket protocol redesigned: client mutation requests (`MUTATE`) now separate from server sync messages (`SYNC`), each with distinct semantics and guaranteed replies
- Coordinated client/server version upgrades required for compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->