### PR TITLE
feat: remove default-mutation client and transport path (#163)

### DIFF
--- a/packages/live-state/benchmark/benchmark.ts
+++ b/packages/live-state/benchmark/benchmark.ts
@@ -5,6 +5,7 @@
  */
 
 import { Pool } from "pg";
+import { z } from "zod";
 import express from "express";
 import expressWs from "express-ws";
 import {
@@ -93,7 +94,18 @@ const benchmarkRouter = router({
     orgs: publicRoute.collectionRoute(benchmarkSchema.orgs),
     users: publicRoute.collectionRoute(benchmarkSchema.users),
     posts: publicRoute.collectionRoute(benchmarkSchema.posts),
-    comments: publicRoute.collectionRoute(benchmarkSchema.comments),
+    comments: publicRoute
+      .collectionRoute(benchmarkSchema.comments)
+      .withProcedures(({ mutation }) => ({
+        insert: mutation(
+          z.object({
+            id: z.string(),
+            content: z.string(),
+            postId: z.string(),
+            authorId: z.string(),
+          })
+        ).handler(async ({ req, db }) => db.comments.insert(req.input)),
+      })),
   },
 });
 

--- a/packages/live-state/src/client/fetch/index.ts
+++ b/packages/live-state/src/client/fetch/index.ts
@@ -1,11 +1,7 @@
 import { stringify } from "qs";
 import { QueryBuilder, type QueryExecutor } from "../../core/query";
 import { consumeGeneratable } from "../../core/utils";
-import {
-  inferValue,
-  type LiveObjectAny,
-  type LiveObjectMutationInput,
-} from "../../schema";
+import { inferValue } from "../../schema";
 import type { ClientOptions } from "..";
 import type { Client, ClientRouterConstraint } from "../types";
 import { createObservable } from "../utils";
@@ -62,32 +58,6 @@ const safeFetch = async (
     });
   }
   return data;
-};
-
-const isUnknownProcedureError = (error: unknown): boolean => {
-  // TODO: Remove this helper when default mutation fallback is removed.
-  if (error instanceof Error && error.message.includes("Unknown procedure")) {
-    return true;
-  }
-
-  if (
-    error instanceof Error &&
-    typeof error.cause === "object" &&
-    error.cause !== null &&
-    ("message" in error.cause || "code" in error.cause)
-  ) {
-    const cause = error.cause as { message?: unknown; code?: unknown };
-    const causeMessage = cause.message;
-    const hasUnknownProcedureCode =
-      cause.code === "UNKNOWN_PROCEDURE" ||
-      cause.code === "unknown_procedure";
-    const hasUnknownProcedureMessage =
-      typeof causeMessage === "string" &&
-      causeMessage.includes("Unknown procedure");
-    return hasUnknownProcedureCode || hasUnknownProcedureMessage;
-  }
-
-  return false;
 };
 
 const serializeNullValues = (value: any): any => {
@@ -241,110 +211,6 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
         const [route, method] = path;
 
         const headers = (await consumeGeneratable(opts.credentials)) ?? {};
-
-        if (method === "insert") {
-          // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
-          try {
-            return await safeFetch(
-              `${opts.url}/${route}/${method}`,
-              {
-                method: "POST",
-                headers: {
-                  ...headers,
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  payload: argumentsList[0],
-                  meta: { timestamp: new Date().toISOString() },
-                }),
-              },
-              opts.fetchOptions,
-            );
-          } catch (error) {
-            if (!isUnknownProcedureError(error)) {
-              throw error;
-            }
-          }
-
-          const { id, ...input } = argumentsList[0] ?? {};
-          return await safeFetch(
-            `${opts.url}/${route}/insert`,
-            {
-              method: "POST",
-              headers: {
-                ...headers,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                resourceId: id,
-                payload: opts.schema[route].encodeMutation(
-                  "set",
-                  input as LiveObjectMutationInput<LiveObjectAny>,
-                  new Date().toISOString(),
-                ),
-              }),
-            },
-            opts.fetchOptions,
-          );
-        }
-
-        if (method === "update") {
-          // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
-          const customPayload =
-            argumentsList.length > 1 &&
-            typeof argumentsList[0] === "string" &&
-            typeof argumentsList[1] === "object" &&
-            argumentsList[1] !== null
-              ? { id: argumentsList[0], ...argumentsList[1] }
-              : argumentsList[0];
-
-          try {
-            return await safeFetch(
-              `${opts.url}/${route}/${method}`,
-              {
-                method: "POST",
-                headers: {
-                  ...headers,
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                  payload: customPayload,
-                  meta: { timestamp: new Date().toISOString() },
-                }),
-              },
-              opts.fetchOptions,
-            );
-          } catch (error) {
-            if (!isUnknownProcedureError(error)) {
-              throw error;
-            }
-          }
-
-          const [id, input] =
-            argumentsList.length > 1
-              ? argumentsList
-              : [argumentsList[0]?.id, argumentsList[0]];
-          const { id: _id, ...rest } = input ?? {};
-          return await safeFetch(
-            `${opts.url}/${route}/update`,
-            {
-              method: "POST",
-              headers: {
-                ...headers,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                resourceId: id,
-                payload: opts.schema[route].encodeMutation(
-                  "set",
-                  rest as LiveObjectMutationInput<LiveObjectAny>,
-                  new Date().toISOString(),
-                ),
-              }),
-            },
-            opts.fetchOptions,
-          );
-        }
 
         return await safeFetch(
           `${opts.url}/${route}/${method}`,

--- a/packages/live-state/src/client/types.ts
+++ b/packages/live-state/src/client/types.ts
@@ -1,13 +1,8 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import type { QueryBuilder } from "../core/query";
 import type { CustomQueryRequest } from "../core/schemas/core-protocol";
-import type { ConditionalPromise, Promisify } from "../core/utils";
-import type {
-  InferInsert,
-  InferLiveObject,
-  InferUpdate,
-  LiveObjectAny,
-} from "../schema";
+import type { Promisify } from "../core/utils";
+import type { InferLiveObject, LiveObjectAny } from "../schema";
 import type { Simplify } from "../utils";
 
 /**
@@ -121,34 +116,12 @@ type CollectionQueryType<
 
 type CollectionMutateType<
   TRoute extends ClientRouterConstraint["routes"][string],
-  TShouldAwait extends boolean,
-> = TRoute["resourceSchema"] extends LiveObjectAny
-  ? Omit<
-      {
-        /** @deprecated Use custom mutations instead. Default insert will be removed in a future version. */
-        insert: (
-          input: Simplify<InferInsert<TRoute["resourceSchema"]>>
-        ) => ConditionalPromise<void, TShouldAwait>;
-        /** @deprecated Use custom mutations instead. Default update will be removed in a future version. */
-        update: (
-          id: string,
-          value: Simplify<InferUpdate<TRoute["resourceSchema"]>>
-        ) => ConditionalPromise<void, TShouldAwait>;
-      },
-      // TODO: Remove default-mutation compatibility typing when default mutations are removed.
-      Extract<keyof TRoute["customMutations"], "insert" | "update">
-    > & {
-      [K2 in keyof TRoute["customMutations"]]: CustomMutationFunction<
-        InferSchema<TRoute["customMutations"][K2]["inputValidator"]>,
-        ReturnType<TRoute["customMutations"][K2]["handler"]>
-      >;
-    }
-  : {
-      [K2 in keyof TRoute["customMutations"]]: CustomMutationFunction<
-        InferSchema<TRoute["customMutations"][K2]["inputValidator"]>,
-        ReturnType<TRoute["customMutations"][K2]["handler"]>
-      >;
-    };
+> = {
+  [K2 in keyof TRoute["customMutations"]]: CustomMutationFunction<
+    InferSchema<TRoute["customMutations"][K2]["inputValidator"]>,
+    ReturnType<TRoute["customMutations"][K2]["handler"]>
+  >;
+};
 
 export type Client<
   TRouter extends ClientRouterConstraint,
@@ -161,9 +134,6 @@ export type Client<
     >;
   };
   mutate: {
-    [K in keyof TRouter["routes"]]: CollectionMutateType<
-      TRouter["routes"][K],
-      TShouldAwait
-    >;
+    [K in keyof TRouter["routes"]]: CollectionMutateType<TRouter["routes"][K]>;
   };
 };

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -19,13 +19,7 @@ import type {
   LiveObjectMutationInput,
   Schema,
 } from "../../schema";
-import {
-  createLogger,
-  hash,
-  type Logger,
-  LogLevel,
-  type Simplify,
-} from "../../utils";
+import { createLogger, hash, type Logger, LogLevel } from "../../utils";
 import type { ClientOptions } from "..";
 import {
   createOptimisticStorageProxy,
@@ -46,28 +40,6 @@ interface WebSocketClientOptions<TSchema extends Schema<any> = Schema<any>>
     maxReconnectAttempts?: number;
   };
 }
-
-const isUnknownProcedureError = (error: unknown): boolean => {
-  // TODO: Remove this helper when default mutation fallback is removed.
-  if (error instanceof Error && error.message.includes("Unknown procedure")) {
-    return true;
-  }
-
-  if (
-    error instanceof Error &&
-    typeof error.cause === "object" &&
-    error.cause !== null &&
-    "message" in error.cause
-  ) {
-    const causeMessage = (error.cause as { message?: unknown }).message;
-    return (
-      typeof causeMessage === "string" &&
-      causeMessage.includes("Unknown procedure")
-    );
-  }
-
-  return false;
-};
 
 export type ConnectionStateChangeEvent = {
   type: "CONNECTION_STATE_CHANGE";
@@ -264,23 +236,7 @@ class InnerClient implements QueryExecutor {
       opts.schema,
       opts.storage,
       this.logger,
-      (stack, _customStack, customIndex) => {
-        const customMutationIds = new Set<string>();
-        if (customIndex) {
-          for (const mutations of Object.values(customIndex)) {
-            for (const { mutationId } of mutations) {
-              customMutationIds.add(mutationId);
-            }
-          }
-        }
-
-        Object.values(stack)
-          ?.flat()
-          ?.forEach((m) => {
-            if (customMutationIds.has(m.id)) return;
-            this.sendWsMessage(this.syncDeltaToMutationMessage(m));
-          });
-
+      () => {
         this.replayCustomMutationStack();
       },
       (resource, itemCount) => {
@@ -332,26 +288,6 @@ class InnerClient implements QueryExecutor {
             ...query,
           });
         });
-
-        const customMutationIds = this.store.getCustomMutationMutationIds();
-
-        Object.values(this.store.optimisticMutationStack).forEach(
-          (mutations) => {
-            if (mutations)
-              mutations.forEach((m) => {
-                if (customMutationIds.has(m.id)) return;
-                this.emitEvent({
-                  type: "MUTATION_SENT",
-                  mutationId: m.id,
-                  resource: m.resource,
-                  resourceId: m.resourceId,
-                  procedure: m.op ?? "UNKNOWN",
-                  optimistic: true,
-                });
-                this.sendWsMessage(this.syncDeltaToMutationMessage(m));
-              });
-          },
-        );
 
         this.replayCustomMutationStack();
       }
@@ -531,97 +467,6 @@ class InnerClient implements QueryExecutor {
     return this.store.subscribe(query, callback);
   }
 
-  /**
-   * Converts a locally-stored optimistic sync delta back into the client→server
-   * MUTATE request used to replay default insert/update mutations on reconnect.
-   */
-  private syncDeltaToMutationMessage(m: SyncDeltaMessage): MutationMessage {
-    return {
-      id: m.id,
-      type: "MUTATE",
-      resource: m.resource,
-      procedure: m.op,
-      payload: m.payload,
-      resourceId: m.resourceId,
-    };
-  }
-
-  /** @deprecated Use custom mutations instead. Default insert/update mutations will be removed in a future version. */
-  public mutate(
-    routeName: string,
-    resourceId: string,
-    procedure: "INSERT" | "UPDATE",
-    payload: Partial<
-      Omit<Simplify<LiveObjectMutationInput<LiveObjectAny>>["value"], "id">
-    >,
-  ) {
-    const mutationId = generateId();
-    const encodedPayload = this.store.schema[routeName].encodeMutation(
-      "set",
-      payload as LiveObjectMutationInput<LiveObjectAny>,
-      new Date().toISOString(),
-    );
-
-    // Optimistic state is reconciled by the server's SYNC broadcast.
-    const optimisticDelta: SyncDeltaMessage = {
-      id: mutationId,
-      type: "SYNC",
-      resource: routeName,
-      payload: encodedPayload,
-      resourceId,
-      op: procedure,
-    };
-
-    // The client→server request remains a MUTATE message.
-    const mutationMessage: MutationMessage = {
-      id: mutationId,
-      type: "MUTATE",
-      resource: routeName,
-      resourceId,
-      procedure,
-      payload: encodedPayload,
-    };
-
-    const pendingMutations =
-      (this.store.optimisticMutationStack[routeName]?.length ?? 0) + 1;
-
-    this.store?.addMutation(routeName, optimisticDelta, true);
-
-    this.emitEvent({
-      type: "OPTIMISTIC_MUTATION_APPLIED",
-      mutationId,
-      resource: routeName,
-      resourceId,
-      procedure,
-      pendingMutations,
-    });
-
-    this.emitEvent({
-      type: "MUTATION_SENT",
-      mutationId,
-      resource: routeName,
-      resourceId,
-      procedure,
-      optimistic: true,
-    });
-
-    this.sendWsMessage(mutationMessage);
-
-    // Every MUTATE now receives a REPLY; the optimistic state is still
-    // reconciled by the SYNC broadcast, so just swallow the acknowledgement.
-    this.replyHandlers[mutationId] = {
-      timeoutHandle: setTimeout(() => {
-        delete this.replyHandlers[mutationId];
-      }, 5000),
-      handler: () => {
-        delete this.replyHandlers[mutationId];
-      },
-      reject: () => {
-        delete this.replyHandlers[mutationId];
-      },
-    };
-  }
-
   public genericMutate(routeName: string, procedure: string, payload: any) {
     const isConnected = this.ws?.connected();
 
@@ -630,29 +475,7 @@ class InnerClient implements QueryExecutor {
       procedure,
     );
 
-    // TODO: Remove default-insert/update fallback optimistic when default mutations are removed.
-    const isDefaultMutationAlias =
-      (procedure === "insert" || procedure === "update") && !optimisticHandler;
-    const defaultMutationFallback =
-      isDefaultMutationAlias && this.store.schema[routeName]
-        ? (() => {
-            const rawPayload = (payload ?? {}) as Record<string, any>;
-            const { id, ...input } = rawPayload;
-            if (typeof id !== "string") return undefined;
-            try {
-              const encoded = this.store.schema[routeName].encodeMutation(
-                "set",
-                input as LiveObjectMutationInput<LiveObjectAny>,
-                new Date().toISOString(),
-              );
-              return { id, input, encoded };
-            } catch {
-              return undefined;
-            }
-          })()
-        : undefined;
-
-    if (!isConnected && !optimisticHandler && !defaultMutationFallback) {
+    if (!isConnected && !optimisticHandler) {
       throw new Error("WebSocket not connected");
     }
 
@@ -665,34 +488,7 @@ class InnerClient implements QueryExecutor {
       meta: { timestamp: new Date().toISOString() },
     };
 
-    if (defaultMutationFallback) {
-      const defaultOptimisticMessage: SyncDeltaMessage = {
-        id: mutationMessage.id,
-        type: "SYNC",
-        resource: routeName,
-        resourceId: defaultMutationFallback.id,
-        op: procedure === "insert" ? "INSERT" : "UPDATE",
-        payload: defaultMutationFallback.encoded,
-      };
-      this.store?.addMutation(routeName, defaultOptimisticMessage, true);
-      this.emitEvent({
-        type: "OPTIMISTIC_MUTATION_APPLIED",
-        mutationId: mutationMessage.id,
-        resource: routeName,
-        resourceId: defaultMutationFallback.id,
-        procedure: defaultOptimisticMessage.op,
-        pendingMutations:
-          (this.store.optimisticMutationStack[routeName]?.length ?? 0),
-      });
-      this.emitEvent({
-        type: "MUTATION_SENT",
-        mutationId: mutationMessage.id,
-        resource: routeName,
-        resourceId: defaultMutationFallback.id,
-        procedure,
-        optimistic: true,
-      });
-    } else if (optimisticHandler) {
+    if (optimisticHandler) {
       try {
         const { proxy, getOperations } = createOptimisticStorageProxy(
           this.store,
@@ -740,34 +536,12 @@ class InnerClient implements QueryExecutor {
       this.replyHandlers[mutationMessage.id] = {
         timeoutHandle: setTimeout(() => {
           delete this.replyHandlers[mutationMessage.id];
-          // Default insert/update optimistic state lives under its own message
-          // id (no custom-mutation index), so roll it back directly on timeout.
-          if (defaultMutationFallback) {
-            const pendingMutations =
-              this.store.optimisticMutationStack[routeName]?.length ?? 0;
-            this.store.undoMutation(routeName, mutationMessage.id);
-            this.emitEvent({
-              type: "OPTIMISTIC_MUTATION_UNDONE",
-              mutationId: mutationMessage.id,
-              resource: routeName,
-              resourceId: defaultMutationFallback.id,
-              pendingMutations: Math.max(pendingMutations - 1, 0),
-            });
-          } else {
-            this.emitUndoEvents(
-              this.store.undoCustomMutation(mutationMessage.id),
-            );
-          }
+          this.emitUndoEvents(this.store.undoCustomMutation(mutationMessage.id));
           reject(new Error("Reply timeout"));
         }, 5000),
         handler: (data: any) => {
           delete this.replyHandlers[mutationMessage.id];
-          // Default insert/update optimistic state is reconciled by the server
-          // broadcast (matching the legacy default-mutation path), so leave it
-          // in place here; only custom mutations confirm via the index.
-          if (!defaultMutationFallback) {
-            this.store.confirmCustomMutation(mutationMessage.id);
-          }
+          this.store.confirmCustomMutation(mutationMessage.id);
           resolve(data);
         },
         reject,
@@ -1018,45 +792,6 @@ export const createClient = <TRouter extends ClientRouterConstraint>(
             throw new Error("Trying to access an invalid path");
 
           const [route, method] = path;
-
-          if (method === "insert") {
-            // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
-            return ogClient
-              .genericMutate(route, method, argumentsList[0])
-              .catch((error) => {
-                if (!isUnknownProcedureError(error)) {
-                  throw error;
-                }
-
-                const { id, ...input } = argumentsList[0] ?? {};
-                return ogClient.mutate(route, id, "INSERT", input);
-              });
-          }
-
-          if (method === "update") {
-            // TODO: Remove generic-first + legacy fallback path when default mutations are removed.
-            const customPayload =
-              argumentsList.length > 1 &&
-              typeof argumentsList[0] === "string" &&
-              typeof argumentsList[1] === "object" &&
-              argumentsList[1] !== null
-                ? { id: argumentsList[0], ...argumentsList[1] }
-                : argumentsList[0];
-
-            return ogClient
-              .genericMutate(route, method, customPayload)
-              .catch((error) => {
-                if (!isUnknownProcedureError(error)) {
-                  throw error;
-                }
-
-                const [id, input] =
-                  argumentsList.length > 1
-                    ? argumentsList
-                    : [argumentsList[0]?.id, argumentsList[0]];
-                return ogClient.mutate(route, id, "UPDATE", input);
-              });
-          }
 
           return ogClient.genericMutate(route, method, argumentsList[0]);
         },

--- a/packages/live-state/src/core/schemas/http.ts
+++ b/packages/live-state/src/core/schemas/http.ts
@@ -1,9 +1,5 @@
 import { z } from "zod";
-import {
-  genericMutationSchema,
-  querySchema,
-  syncDeltaSchema,
-} from "./core-protocol";
+import { genericMutationSchema, querySchema } from "./core-protocol";
 
 export const httpQuerySchema = querySchema.omit({
   resource: true,
@@ -20,21 +16,6 @@ export const httpGenericMutationSchema = genericMutationSchema
     meta: genericMutationSchema.shape.meta,
   });
 
-export const httpDefaultMutationSchema = syncDeltaSchema
-  .omit({
-    id: true,
-    type: true,
-    resource: true,
-    op: true,
-  })
-  .extend({
-    // resourceId may be supplied via the URL path / payload id instead of the body.
-    resourceId: z.string().optional(),
-  });
-
-export const httpMutationSchema = z.union([
-  httpDefaultMutationSchema,
-  httpGenericMutationSchema,
-]);
+export const httpMutationSchema = httpGenericMutationSchema;
 
 export type HttpMutation = z.infer<typeof httpMutationSchema>;

--- a/packages/live-state/src/server/transport-layers/http.ts
+++ b/packages/live-state/src/server/transport-layers/http.ts
@@ -2,7 +2,6 @@ import cookie from "cookie";
 import qs from "qs";
 import {
   type HttpMutation,
-  httpDefaultMutationSchema,
   httpGenericMutationSchema,
   httpQuerySchema,
 } from "../../core/schemas/http";
@@ -162,64 +161,19 @@ export const httpTransportLayer = (
           const resource = secondToLast;
           const rawBody = request.body ? await request.json() : {};
 
-          let body: HttpMutation;
-          let mutationProcedure = procedure;
-
-          if (procedure === "insert" || procedure === "update") {
-            // TODO: Remove dual parsing (legacy default + generic) when default mutations are removed.
-            const defaultResult = httpDefaultMutationSchema.safeParse(rawBody);
-            if (defaultResult.success) {
-              mutationProcedure = procedure.toUpperCase();
-              body = defaultResult.data;
-            } else {
-              const hasGenericMutationShape =
-                typeof rawBody === "object" &&
-                rawBody !== null &&
-                "payload" in rawBody &&
-                "meta" in rawBody;
-              if (!hasGenericMutationShape) {
-                return Response.json(
-                  {
-                    message: "Invalid mutation",
-                    code: "INVALID_REQUEST",
-                    details: defaultResult.error,
-                  },
-                  { status: 400 }
-                );
-              }
-
-              const genericResult = httpGenericMutationSchema.safeParse(rawBody);
-              if (!genericResult.success) {
-                return Response.json(
-                  {
-                    message: "Invalid mutation",
-                    code: "INVALID_REQUEST",
-                    details: genericResult.error,
-                  },
-                  { status: 400 }
-                );
-              }
-
-              body = genericResult.data;
-              // A custom mutation named `insert`/`update` is dispatched by its
-              // real (lowercase) name; the legacy `INSERT`/`UPDATE` alias is gone.
-              mutationProcedure = procedure;
-            }
-          } else {
-            const { success, data, error } =
-              httpGenericMutationSchema.safeParse(rawBody);
-            if (!success) {
-              return Response.json(
-                {
-                  message: "Invalid mutation",
-                  code: "INVALID_REQUEST",
-                  details: error,
-                },
-                { status: 400 }
-              );
-            }
-            body = data;
+          const { success, data, error } =
+            httpGenericMutationSchema.safeParse(rawBody);
+          if (!success) {
+            return Response.json(
+              {
+                message: "Invalid mutation",
+                code: "INVALID_REQUEST",
+                details: error,
+              },
+              { status: 400 }
+            );
           }
+          const body: HttpMutation = data;
 
           const result = await server.handleMutation({
             req: {
@@ -229,26 +183,15 @@ export const httpTransportLayer = (
               input: body.payload,
               context: initialContext,
               resourceId: (body as { resourceId?: string }).resourceId,
-              procedure: mutationProcedure,
+              procedure,
               queryParams: {},
-              meta: (body as any).meta,
+              meta: body.meta,
             },
           });
 
           return Response.json(result);
         } catch (e) {
           logger.error("Error parsing mutation from the client:", e);
-
-          if (
-            e instanceof Error &&
-            e.message.includes("Unknown procedure")
-          ) {
-            // TODO: Remove UNKNOWN_PROCEDURE compatibility response when default mutation fallback is removed.
-            return Response.json(
-              { message: e.message, code: "UNKNOWN_PROCEDURE" },
-              { status: 400 }
-            );
-          }
 
           return Response.json(
             { message: "Internal server error", code: "INTERNAL_SERVER_ERROR" },

--- a/packages/live-state/src/server/transport-layers/web-socket.ts
+++ b/packages/live-state/src/server/transport-layers/web-socket.ts
@@ -199,64 +199,18 @@ export const webSocketAdapter = (server: Server<AnyRouter, any>) => {
           const { resource } = parsedMessage;
           logger.debug("Received mutation from client:", parsedMessage);
           try {
-            const originalProcedure = (parsedMessage as GenericMutation)
-              .procedure;
-            let mutationProcedure = originalProcedure;
-            let mutationInput: any = parsedMessage.payload;
-            let mutationResourceId: string | undefined =
-              parsedMessage.resourceId;
-
-            // TODO: Remove generic insert/update shape resolution when default mutations are removed.
-            if (
-              mutationProcedure === "insert" ||
-              mutationProcedure === "update"
-            ) {
-              const route = (server.router as any)?.routes?.[resource];
-              const hasCustomProcedure =
-                !!route?.customMutations?.[mutationProcedure];
-
-              if (!hasCustomProcedure) {
-                const rawPayload =
-                  (parsedMessage.payload ?? {}) as Record<string, any>;
-                const { id, ...rest } = rawPayload;
-                if (typeof id !== "string") {
-                  throw new Error(
-                    `Invalid mutation: payload.id is required for ${mutationProcedure}`,
-                  );
-                }
-                mutationResourceId = id;
-                const collection = (server.schema as any)?.[resource];
-                if (
-                  collection &&
-                  typeof collection.encodeMutation === "function"
-                ) {
-                  const timestamp =
-                    (parsedMessage as GenericMutation).meta?.timestamp ??
-                    new Date().toISOString();
-                  mutationInput = collection.encodeMutation(
-                    "set",
-                    rest,
-                    timestamp,
-                  );
-                } else {
-                  mutationInput = rest;
-                }
-                mutationProcedure = mutationProcedure.toUpperCase();
-              }
-            }
-
             const result = await server.handleMutation({
               req: {
                 ...requestContext,
                 type: "MUTATE",
                 resource: resource,
-                input: mutationInput,
+                input: parsedMessage.payload,
                 context: {
                   messageId: parsedMessage.id,
                   ...((await initialContext) ?? {}),
                 },
-                resourceId: mutationResourceId,
-                procedure: mutationProcedure,
+                resourceId: parsedMessage.resourceId,
+                procedure: (parsedMessage as GenericMutation).procedure,
                 queryParams: parsedQs,
                 meta: (parsedMessage as GenericMutation).meta,
               },

--- a/packages/live-state/test/bench/mutation-broadcast-latency.bench.ts
+++ b/packages/live-state/test/bench/mutation-broadcast-latency.bench.ts
@@ -293,7 +293,8 @@ describe("live-state mutation broadcast latency benchmarks", () => {
         sender,
         receiver,
         () => {
-          sender.store.mutate.posts.update(postId, {
+          sender.store.mutate.posts.update({
+            id: postId,
             title: "Updated title",
             likes: 100,
           });

--- a/packages/live-state/test/bench/utils.ts
+++ b/packages/live-state/test/bench/utils.ts
@@ -1,4 +1,5 @@
 import { Pool } from "pg";
+import { z } from "zod";
 import express from "express";
 import expressWs from "express-ws";
 import {
@@ -86,8 +87,24 @@ export const benchmarkRouter = router({
   routes: {
     orgs: publicRoute.collectionRoute(benchmarkSchema.orgs),
     users: publicRoute.collectionRoute(benchmarkSchema.users),
-    posts: publicRoute.collectionRoute(benchmarkSchema.posts),
-    comments: publicRoute.collectionRoute(benchmarkSchema.comments),
+    posts: publicRoute
+      .collectionRoute(benchmarkSchema.posts)
+      .withProcedures(({ mutation }) => ({
+        update: mutation(
+          z.object({ id: z.string() }).and(z.record(z.string(), z.any()))
+        ).handler(
+          // biome-ignore lint/suspicious/noExplicitAny: generic req/ServerDB in bench helper
+          async ({ req, db }: any) => db.posts.update(req.input.id, req.input)
+        ),
+      })),
+    comments: publicRoute
+      .collectionRoute(benchmarkSchema.comments)
+      .withProcedures(({ mutation }) => ({
+        insert: mutation(z.record(z.string(), z.any())).handler(
+          // biome-ignore lint/suspicious/noExplicitAny: generic req/ServerDB in bench helper
+          async ({ req, db }: any) => db.comments.insert(req.input)
+        ),
+      })),
   },
 });
 

--- a/packages/live-state/test/client/fetch.test.ts
+++ b/packages/live-state/test/client/fetch.test.ts
@@ -468,8 +468,8 @@ describe("createClient", () => {
         credentials: async () => ({ Authorization: "Bearer token" }),
       });
 
-      const updateData = { name: "John Updated" };
-      await client.mutate.users.update("1", updateData);
+      const updateData = { id: "1", name: "John Updated" };
+      await client.mutate.users.update(updateData);
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:3000/users/update",
@@ -494,7 +494,7 @@ describe("createClient", () => {
       );
     });
 
-    test("should exclude id from update payload", async () => {
+    test("should forward the full update payload including id", async () => {
       const mockResponse = { success: true };
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -510,7 +510,7 @@ describe("createClient", () => {
       });
 
       const updateData = { id: "1", name: "John Updated" };
-      await client.mutate.users.update("1", updateData);
+      await client.mutate.users.update(updateData);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.payload).toHaveProperty("id", "1");
@@ -531,8 +531,8 @@ describe("createClient", () => {
         credentials: async () => ({}),
       });
 
-      const updateData = { title: "Updated Post" };
-      await client.mutate.posts.update("1", updateData);
+      const updateData = { id: "1", title: "Updated Post" };
+      await client.mutate.posts.update(updateData);
 
       expect(mockFetch).toHaveBeenCalledWith(
         "http://localhost:3000/posts/update",
@@ -819,8 +819,8 @@ describe("createClient", () => {
         credentials: async () => ({}),
       });
 
-      const updateData = { name: "John Updated" };
-      await client.mutate.users.update("1", updateData);
+      const updateData = { id: "1", name: "John Updated" };
+      await client.mutate.users.update(updateData);
 
       const body = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(body.payload.name).toBe("John Updated");

--- a/packages/live-state/test/e2e/e2e.test.ts
+++ b/packages/live-state/test/e2e/e2e.test.ts
@@ -573,7 +573,8 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 performs UPDATE mutation
-        client1.store.mutate.users.update(userId, {
+        client1.store.mutate.users.update({
+          id: userId,
           name: updatedName,
         });
 
@@ -1643,7 +1644,8 @@ describe("End-to-End Query Tests", () => {
 
         await new Promise((resolve) => setTimeout(resolve, 100));
 
-        orderWsClient.store.mutate.orders.update(orderId, {
+        orderWsClient.store.mutate.orders.update({
+          id: orderId,
           status: "delivered",
           priority: "high",
         });
@@ -2074,7 +2076,8 @@ describe("End-to-End Query Tests", () => {
           },
         };
 
-        productWsClient.store.mutate.products.update(productId, {
+        productWsClient.store.mutate.products.update({
+          id: productId,
           metadata: updatedMetadata,
         });
 

--- a/packages/live-state/test/server/transport-layers/http.test.ts
+++ b/packages/live-state/test/server/transport-layers/http.test.ts
@@ -179,7 +179,7 @@ describe("httpTransportLayer", () => {
           },
         },
         resourceId: "user1",
-        procedure: "INSERT",
+        procedure: "insert",
         meta: { timestamp: "2023-01-03T00:00:00.000Z" },
       }),
     });
@@ -214,7 +214,7 @@ describe("httpTransportLayer", () => {
       req: expect.objectContaining({
         type: "MUTATE",
         resource: "users",
-        procedure: "INSERT",
+        procedure: "insert",
       }),
     });
   });
@@ -251,18 +251,13 @@ describe("httpTransportLayer", () => {
     });
   });
 
-  test("should return 400 for invalid set mutation payload", async () => {
-    const requestBody = {
-      // Missing required fields for set mutation
-      payload: { name: "John" },
-    };
-
+  test("should return 400 for non-object mutation body", async () => {
     const request = new Request("http://localhost/users/insert", {
       method: "POST",
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(requestBody),
+      body: JSON.stringify("not-an-object"),
     });
 
     const response = await httpHandler(request);
@@ -374,19 +369,27 @@ describe("httpTransportLayer", () => {
     });
   });
 
-  test("should handle POST request without body", async () => {
-    const request = new Request("http://localhost/users/insert", {
+  test("should treat a POST request without body as a no-input mutation", async () => {
+    const request = new Request("http://localhost/users/doThing", {
       method: "POST",
       headers: {
         "content-type": "application/json",
       },
     });
 
-    const response = await httpHandler(request);
-    const responseData = await response.json();
+    (mockServer.handleMutation as Mock).mockResolvedValue({ ok: true });
 
-    expect(response.status).toBe(400);
-    expect(responseData.code).toBe("INVALID_REQUEST");
+    const response = await httpHandler(request);
+
+    expect(response.status).toBe(200);
+    expect(mockServer.handleMutation).toHaveBeenCalledWith({
+      req: expect.objectContaining({
+        type: "MUTATE",
+        resource: "users",
+        procedure: "doThing",
+        input: undefined,
+      }),
+    });
   });
 
   test("should return 500 for unexpected errors", async () => {

--- a/packages/live-state/test/server/transport-layers/web-socket.test.ts
+++ b/packages/live-state/test/server/transport-layers/web-socket.test.ts
@@ -323,66 +323,6 @@ describe("webSocketAdapter", () => {
     );
   });
 
-  test("should reshape generic insert/update with raw payload into default mutation when no custom procedure exists", async () => {
-    const encodeMutation = vi.fn().mockReturnValue({
-      name: {
-        value: "Alice",
-        _meta: { timestamp: "2023-01-03T00:00:00.000Z" },
-      },
-    });
-    (mockServer as any).schema.users.encodeMutation = encodeMutation;
-    (mockServer as any).router.routes.users.customMutations = {};
-
-    wsHandler(mockWebSocket, mockRequest);
-
-    const messageHandler = (mockWebSocket.on as Mock).mock.calls.find(
-      (call) => call[0] === "message",
-    )?.[1];
-
-    const mutateMessage = {
-      type: "MUTATE",
-      resource: "users",
-      procedure: "insert",
-      payload: { id: "user1", name: "Alice" },
-      meta: { timestamp: "2023-01-03T00:00:00.000Z" },
-      id: "msg-1",
-    };
-
-    (mockServer.handleMutation as Mock).mockResolvedValue({
-      data: { name: "Alice" },
-    });
-
-    await messageHandler(Buffer.from(JSON.stringify(mutateMessage)));
-
-    expect(encodeMutation).toHaveBeenCalledWith(
-      "set",
-      { name: "Alice" },
-      "2023-01-03T00:00:00.000Z",
-    );
-    expect(mockServer.handleMutation).toHaveBeenCalledWith({
-      req: expect.objectContaining({
-        type: "MUTATE",
-        resource: "users",
-        procedure: "INSERT",
-        resourceId: "user1",
-        input: {
-          name: {
-            value: "Alice",
-            _meta: { timestamp: "2023-01-03T00:00:00.000Z" },
-          },
-        },
-      }),
-    });
-
-    expect(mockWebSocket.send).toHaveBeenCalledWith(
-      JSON.stringify({
-        id: "msg-1",
-        type: "REPLY",
-        data: { data: { name: "Alice" } },
-      }),
-    );
-  });
-
   test("should keep generic insert procedure when a custom mutation exists", async () => {
     const customHandler = vi.fn();
     (mockServer as any).router.routes.users.customMutations = {

--- a/packages/live-state/test/types/client.test-d.ts
+++ b/packages/live-state/test/types/client.test-d.ts
@@ -198,35 +198,6 @@ describe("websocket client", () => {
     });
   });
 
-  test("should infer insert types", () => {
-    const userMutate = mutate.users.insert;
-    const postMutate = mutate.posts.insert;
-    const commentMutate = mutate.comments.insert;
-
-    expectTypeOf(userMutate)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; name: string }>();
-    expectTypeOf(postMutate)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; title: string; authorId: string }>();
-    expectTypeOf(commentMutate)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; content: string; postId: string }>();
-  });
-
-  test("should infer update types", () => {
-    const userMutate = mutate.users.update;
-    const postMutate = mutate.posts.update;
-    const commentMutate = mutate.comments.update;
-
-    expectTypeOf(userMutate).parameter(1).toEqualTypeOf<{ name?: string }>();
-    expectTypeOf(postMutate)
-      .parameter(1)
-      .toEqualTypeOf<{ title?: string; authorId?: string }>();
-    expectTypeOf(commentMutate)
-      .parameter(1)
-      .toEqualTypeOf<{ content?: string; postId?: string }>();
-  });
 });
 
 /*
@@ -837,93 +808,6 @@ describe("complex websocket client", () => {
     >();
   });
 
-  test("should infer complex insert types with defaults", () => {
-    const userMutate = complexMutate.complexUsers.insert;
-    const postMutate = complexMutate.complexPosts.insert;
-    const commentMutate = complexMutate.complexComments.insert;
-
-    // Nullable fields without explicit default now default to null, making them optional
-    expectTypeOf(userMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      name: string;
-      email?: string | null | undefined;
-      age?: number | null | undefined;
-      updatedAt?: Date | null | undefined;
-      tags?: string | null | undefined;
-      isActive?: boolean | undefined;
-      score?: number | undefined;
-      createdAt?: Date | undefined;
-      bio?: string | null | undefined;
-    }>();
-
-    expectTypeOf(postMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      title: string;
-      content?: string | null | undefined;
-      authorId: string;
-      rating?: number | null | undefined;
-      publishedAt?: Date | null | undefined;
-      updatedAt?: Date | null | undefined;
-      metadata?: string | null | undefined;
-      published?: boolean | undefined;
-      views?: number | undefined;
-      createdAt?: Date | undefined;
-    }>();
-
-    expectTypeOf(commentMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      content: string;
-      postId: string;
-      authorId: string;
-      updatedAt?: Date | null | undefined;
-      parentId?: string | null | undefined;
-      isApproved?: boolean | undefined;
-      likes?: number | undefined;
-      createdAt?: Date | undefined;
-    }>();
-  });
-
-  test("should infer complex update types", () => {
-    const userMutate = complexMutate.complexUsers.update;
-    const postMutate = complexMutate.complexPosts.update;
-    const commentMutate = complexMutate.complexComments.update;
-
-    expectTypeOf(userMutate).parameter(1).toEqualTypeOf<{
-      name?: string;
-      email?: string | null;
-      age?: number | null;
-      isActive?: boolean;
-      score?: number;
-      createdAt?: Date;
-      updatedAt?: Date | null;
-      bio?: string | null;
-      tags?: string | null;
-    }>();
-
-    expectTypeOf(postMutate).parameter(1).toEqualTypeOf<{
-      title?: string;
-      content?: string | null;
-      authorId?: string;
-      published?: boolean;
-      views?: number;
-      rating?: number | null;
-      publishedAt?: Date | null;
-      createdAt?: Date;
-      updatedAt?: Date | null;
-      metadata?: string | null;
-    }>();
-
-    expectTypeOf(commentMutate).parameter(1).toEqualTypeOf<{
-      content?: string;
-      postId?: string;
-      authorId?: string;
-      isApproved?: boolean;
-      likes?: number;
-      createdAt?: Date;
-      updatedAt?: Date | null;
-      parentId?: string | null;
-    }>();
-  });
 });
 
 /*
@@ -991,39 +875,6 @@ describe("edge cases and combinations", () => {
     >();
   });
 
-  test("should handle insert types with mixed nullable and default fields", () => {
-    const userMutate = edgeCaseMutate.edgeCaseUsers.insert;
-
-    // Nullable fields without explicit default now default to null, making them optional
-    expectTypeOf(userMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      email: string;
-      phone?: string | null | undefined;
-      score?: number | null | undefined;
-      deletedAt?: Date | null | undefined;
-      nickname?: string | null | undefined;
-      status?: string | undefined;
-      priority?: number | undefined;
-      verified?: boolean | undefined;
-      lastLogin?: Date | undefined;
-    }>();
-  });
-
-  test("should handle update types with mixed nullable and default fields", () => {
-    const userMutate = edgeCaseMutate.edgeCaseUsers.update;
-
-    expectTypeOf(userMutate).parameter(1).toEqualTypeOf<{
-      nickname?: string | null;
-      email?: string;
-      phone?: string | null;
-      status?: string;
-      priority?: number;
-      score?: number | null;
-      verified?: boolean;
-      lastLogin?: Date;
-      deletedAt?: Date | null;
-    }>();
-  });
 });
 
 /*
@@ -1119,36 +970,6 @@ describe("fetch client", () => {
         }[]
       >
     >();
-  });
-
-  test("should infer insert types", () => {
-    const userMutate = fetchClient.mutate.users.insert;
-    const postMutate = fetchClient.mutate.posts.insert;
-    const commentMutate = fetchClient.mutate.comments.insert;
-
-    expectTypeOf(userMutate)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; name: string }>();
-    expectTypeOf(postMutate)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; title: string; authorId: string }>();
-    expectTypeOf(commentMutate)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; content: string; postId: string }>();
-  });
-
-  test("should infer update types", () => {
-    const userMutate = fetchClient.mutate.users.update;
-    const postMutate = fetchClient.mutate.posts.update;
-    const commentMutate = fetchClient.mutate.comments.update;
-
-    expectTypeOf(userMutate).parameter(1).toEqualTypeOf<{ name?: string }>();
-    expectTypeOf(postMutate)
-      .parameter(1)
-      .toEqualTypeOf<{ title?: string; authorId?: string }>();
-    expectTypeOf(commentMutate)
-      .parameter(1)
-      .toEqualTypeOf<{ content?: string; postId?: string }>();
   });
 
   test("should handle query chaining", () => {
@@ -1746,92 +1567,6 @@ describe("complex fetch client", () => {
     >();
   });
 
-  test("should infer complex insert types with defaults", () => {
-    const userMutate = complexFetchClient.mutate.complexUsers.insert;
-    const postMutate = complexFetchClient.mutate.complexPosts.insert;
-    const commentMutate = complexFetchClient.mutate.complexComments.insert;
-
-    expectTypeOf(userMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      name: string;
-      isActive?: boolean | undefined;
-      score?: number | undefined;
-      createdAt?: Date | undefined;
-      email?: string | null | undefined;
-      age?: number | null | undefined;
-      updatedAt?: Date | null | undefined;
-      bio?: string | null | undefined;
-      tags?: string | null | undefined;
-    }>();
-
-    expectTypeOf(postMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      title: string;
-      authorId: string;
-      published?: boolean | undefined;
-      views?: number | undefined;
-      createdAt?: Date | undefined;
-      content?: string | null | undefined;
-      rating?: number | null | undefined;
-      publishedAt?: Date | null | undefined;
-      updatedAt?: Date | null | undefined;
-      metadata?: string | null | undefined;
-    }>();
-
-    expectTypeOf(commentMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      content: string;
-      postId: string;
-      authorId: string;
-      isApproved?: boolean | undefined;
-      likes?: number | undefined;
-      createdAt?: Date | undefined;
-      updatedAt?: Date | null | undefined;
-      parentId?: string | null | undefined;
-    }>();
-  });
-
-  test("should infer complex update types", () => {
-    const userMutate = complexFetchClient.mutate.complexUsers.update;
-    const postMutate = complexFetchClient.mutate.complexPosts.update;
-    const commentMutate = complexFetchClient.mutate.complexComments.update;
-
-    expectTypeOf(userMutate).parameter(1).toEqualTypeOf<{
-      name?: string;
-      email?: string | null;
-      age?: number | null;
-      isActive?: boolean;
-      score?: number;
-      createdAt?: Date;
-      updatedAt?: Date | null;
-      bio?: string | null;
-      tags?: string | null;
-    }>();
-
-    expectTypeOf(postMutate).parameter(1).toEqualTypeOf<{
-      title?: string;
-      content?: string | null;
-      authorId?: string;
-      published?: boolean;
-      views?: number;
-      rating?: number | null;
-      publishedAt?: Date | null;
-      createdAt?: Date;
-      updatedAt?: Date | null;
-      metadata?: string | null;
-    }>();
-
-    expectTypeOf(commentMutate).parameter(1).toEqualTypeOf<{
-      content?: string;
-      postId?: string;
-      authorId?: string;
-      isApproved?: boolean;
-      likes?: number;
-      createdAt?: Date;
-      updatedAt?: Date | null;
-      parentId?: string | null;
-    }>();
-  });
 });
 
 /*
@@ -1866,39 +1601,6 @@ describe("edge cases fetch client", () => {
     >();
   });
 
-  test("should handle insert types with mixed nullable and default fields", () => {
-    const userMutate = edgeCaseFetchClient.mutate.edgeCaseUsers.insert;
-
-    // Nullable fields without explicit default now default to null, making them optional
-    expectTypeOf(userMutate).parameter(0).toEqualTypeOf<{
-      id: string;
-      email: string;
-      phone?: string | null | undefined;
-      score?: number | null | undefined;
-      deletedAt?: Date | null | undefined;
-      nickname?: string | null | undefined;
-      status?: string | undefined;
-      priority?: number | undefined;
-      verified?: boolean | undefined;
-      lastLogin?: Date | undefined;
-    }>();
-  });
-
-  test("should handle update types with mixed nullable and default fields", () => {
-    const userMutate = edgeCaseFetchClient.mutate.edgeCaseUsers.update;
-
-    expectTypeOf(userMutate).parameter(1).toEqualTypeOf<{
-      nickname?: string | null;
-      email?: string;
-      phone?: string | null;
-      status?: string;
-      priority?: number;
-      score?: number | null;
-      verified?: boolean;
-      lastLogin?: Date;
-      deletedAt?: Date | null;
-    }>();
-  });
 });
 
 /*

--- a/packages/live-state/test/types/procedures.test-d.ts
+++ b/packages/live-state/test/types/procedures.test-d.ts
@@ -251,21 +251,10 @@ describe("custom mutations - websocket client", () => {
     >();
   });
 
-  test("should still have access to standard mutation methods", () => {
-    // Standard mutation methods should still work
-    const standardInsert = mutate.users.insert;
-    const standardUpdate = mutate.users.update;
-
-    expectTypeOf(standardInsert)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; name: string; email: string; age: number }>();
-
-    expectTypeOf(standardUpdate).parameter(0).toEqualTypeOf<string>();
-    expectTypeOf(standardUpdate).parameter(1).toEqualTypeOf<{
-      name?: string;
-      email?: string;
-      age?: number;
-    }>();
+  test("should expose the route's custom mutations", () => {
+    // Default insert/update were removed; the route's custom mutations remain.
+    expectTypeOf(mutate.users.createUserWithRole).toBeFunction();
+    expectTypeOf(mutate.users.resetAllPasswords).toBeFunction();
   });
 });
 
@@ -357,12 +346,8 @@ describe("custom mutations - fetch client", () => {
     >();
   });
 
-  test("should still have access to standard mutation methods", () => {
-    const standardInsert = fetchClient.mutate.users.insert;
-
-    expectTypeOf(standardInsert)
-      .parameter(0)
-      .toEqualTypeOf<{ id: string; name: string; email: string; age: number }>();
+  test("should expose the route's custom mutations", () => {
+    expectTypeOf(fetchClient.mutate.users.createUserWithRole).toBeFunction();
   });
 });
 
@@ -525,10 +510,6 @@ describe("procedure-only routes - websocket client mutations", () => {
     expectTypeOf(pMutate.analytics).toHaveProperty("importData");
   });
 
-  test("collection routes should still have insert/update", () => {
-    expectTypeOf(pMutate.users.insert).toBeFunction();
-    expectTypeOf(pMutate.users.update).toBeFunction();
-  });
 });
 
 /**
@@ -574,9 +555,8 @@ describe("procedure-only routes - fetch client", () => {
     expectTypeOf(fetchClientWithProcedures.mutate.analytics).toHaveProperty("importData");
   });
 
-  test("collection routes should still work normally", () => {
+  test("collection routes still expose query methods", () => {
     expectTypeOf(fetchClientWithProcedures.query.users.get).toBeFunction();
-    expectTypeOf(fetchClientWithProcedures.mutate.users.insert).toBeFunction();
   });
 });
 


### PR DESCRIPTION
Closes #163.

Removes the client→server default-mutation request path now that the server no longer handles it (#162). Completes the default-mutation removal series (#160 → #162 → #163).

## Changes

**Client (`websocket/client.ts`)**
- Delete the deprecated `mutate()` method and the `syncDeltaToMutationMessage` helper.
- Remove the `defaultMutationFallback` branch from `genericMutate()`; it now relies solely on optimistic handlers + custom mutations.
- Collapse both reconnect-replay loops to `replayCustomMutationStack()` (the old SYNC-delta→MUTATE replay only existed for default mutations).
- Collapse the `mutate` proxy dispatch to call `genericMutate()` for every method; drop `isUnknownProcedureError`.

**Fetch client (`fetch/index.ts`)** — remove the insert/update encode-shim + legacy fallback; every method goes through the single generic POST path.

**Client types (`client/types.ts`)** — `CollectionMutateType` now maps over `customMutations` only; default `insert`/`update` and the `resourceSchema extends LiveObjectAny` split are gone.

**Schemas (`core/schemas/http.ts`)** — `httpDefaultMutationSchema` removed; `httpMutationSchema` is now `httpGenericMutationSchema`.

**Transports** — HTTP and WebSocket route all client mutations through the generic mutation schema; removed the HTTP dual-parse/`UNKNOWN_PROCEDURE` block and the WebSocket insert/update shape-resolution shim.

The client store's Sync Delta application path (`addMutation`/apply) and the custom-mutation optimistic infrastructure are kept intact.

## Tests
- Converted default `mutate.X.insert()/update()` usages to custom mutations across e2e and benchmarks.
- Updated transport tests for the unified generic path (procedure stays lowercase, empty body = no-input mutation, non-object body → 400); removed the test for the deleted WS shim.
- Removed the default insert/update **type** assertions (those routes carry a `Record<string, …>` index signature, so absence can't be asserted cleanly); custom-mutation type tests still pass.

## Verification
- `pnpm typecheck --filter="./packages/*"` ✅
- `pnpm lint --filter="./packages/*" -- --diagnostic-level error` ✅
- `pnpm test --filter="./packages/*"` ✅ (863 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed default insert/update mutation handlers; all mutations now require explicit custom procedure definitions
  * Simplified HTTP and WebSocket transport layers by removing legacy error handling and fallback paths
  * Updated mutation payload format to use standardized generic mutation structure
  * Streamlined client-side mutation logic by consolidating error paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->