### PR TITLE
refactor: decouple Tracked Query resolution from Route (#173)

### DIFF
--- a/packages/live-state/src/server/index.ts
+++ b/packages/live-state/src/server/index.ts
@@ -115,36 +115,24 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
           query: RawQueryRequest,
           extra?: { context?: any; batcher?: Batcher }
         ) => {
-          const {
-            headers,
-            cookies,
-            queryParams,
-            context: ctx,
-          } = extra?.context ?? {};
-
           if (!extra?.batcher) {
             throw new Error("Batcher is required");
           }
 
-          const req: QueryRequest = {
-            ...query,
-            type: "QUERY",
-            headers,
-            cookies,
-            queryParams,
-            context: ctx,
-          };
-
-          const result = await (
-            this.router.routes[query.resource] as
-              | Route<any, any, any, any, any, any>
-              | undefined
-          )?.handleQuery({
-            req,
-            batcher: extra.batcher,
+          // Tracked Queries resolve directly against the batcher/storage layer
+          // keyed by the schema `resource`. This is intentionally independent of
+          // whether a `collectionRoute` is declared for the resource: any
+          // resource in the `schema` is resolvable, which lets a Custom Query
+          // handler return `db.<resource>.where(...)` for a procedure-only route.
+          // The parent step's relational filtering is already folded into
+          // `query.where` by `resolveStep`, so there is no `uniqueWhere` here.
+          return extra.batcher.rawFind({
+            resource: query.resource,
+            commonWhere: query.where,
+            include: query.include,
+            limit: query.limit,
+            sort: query.sort,
           });
-
-          return result?.data ?? [];
         },
         incrementQueryStep: (step: CoreQueryStep, context: any = {}) => {
           const authorizationClause = (

--- a/packages/live-state/test/e2e/procedure-only-routes.test.ts
+++ b/packages/live-state/test/e2e/procedure-only-routes.test.ts
@@ -19,6 +19,7 @@ import {
 	createSchema,
 	createRelations,
 	id,
+	inferValue,
 	number,
 	object,
 	reference,
@@ -46,6 +47,14 @@ const post = object("posts", {
 	likes: number(),
 });
 
+// A resource that is in the schema but has NO collectionRoute declared.
+// It is only ever read via a procedure-only route returning a tracked query.
+const comment = object("comments", {
+	id: id(),
+	text: string(),
+	topic: string(),
+});
+
 const userRelations = createRelations(user, ({ many }) => ({
 	posts: many(post, "authorId"),
 }));
@@ -57,6 +66,7 @@ const postRelations = createRelations(post, ({ one }) => ({
 const testSchema = createSchema({
 	users: user,
 	posts: post,
+	comments: comment,
 	userRelations,
 	postRelations,
 });
@@ -95,6 +105,13 @@ const testRouter = router({
 					const userId = users[0].id;
 					return db.posts.where({ authorId: userId }).get();
 				}
+			),
+
+			// Returns an *unresolved* query builder for `comments`, a resource
+			// with no collectionRoute. The query engine must resolve and subscribe
+			// it directly against the batcher/storage keyed by `resource`.
+			watchComments: query(z.object({ topic: z.string() })).handler(
+				({ req, db }) => db.comments.where({ topic: req.input.topic })
 			),
 
 			seedData: mutation(
@@ -366,6 +383,68 @@ describe("Procedure-Only Routes E2E", () => {
 			const result = await fetchClient.mutate.analytics.resetLikes();
 
 			expect(result).toEqual({ resetCount: 0 });
+		});
+	});
+
+	describe("Tracked query returned from a procedure-only route", () => {
+		test("resolves and subscribes a resource with no collectionRoute", async () => {
+			const matchingId = generateId();
+			await storage.insert(testSchema.comments, {
+				id: matchingId,
+				text: "initial",
+				topic: "sync",
+			});
+			await storage.insert(testSchema.comments, {
+				id: generateId(),
+				text: "other topic",
+				topic: "unrelated",
+			});
+
+			const deltas: any[] = [];
+
+			const result = await testServer.handleCustomQuery({
+				req: {
+					headers: {},
+					cookies: {},
+					queryParams: {},
+					type: "CUSTOM_QUERY",
+					resource: "analytics",
+					procedure: "watchComments",
+					input: { topic: "sync" },
+					context: {},
+				},
+				subscription: (m) => deltas.push(m),
+			});
+
+			// Initial resolution against storage, filtered by the handler's where.
+			expect(result.data).toHaveLength(1);
+			expect(inferValue(result.data[0]).text).toBe("initial");
+
+			// Realtime: a new matching comment produces a Sync Delta to the subscriber.
+			const newId = generateId();
+			await storage.insert(testSchema.comments, {
+				id: newId,
+				text: "live",
+				topic: "sync",
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(deltas.some((d) => d.resourceId === newId)).toBe(true);
+
+			// A non-matching comment must NOT notify the subscriber.
+			const nonMatchingId = generateId();
+			await storage.insert(testSchema.comments, {
+				id: nonMatchingId,
+				text: "nope",
+				topic: "unrelated",
+			});
+
+			await new Promise((resolve) => setTimeout(resolve, 200));
+
+			expect(deltas.some((d) => d.resourceId === nonMatchingId)).toBe(false);
+
+			result.unsubscribe?.();
 		});
 	});
 


### PR DESCRIPTION
## What

Closes #173.

The query engine resolved every Tracked Query by routing back through `routes[resource].handleQuery`, which only exists on `collectionRoute` (the `Route` class). For a procedure-only route (`ProcedureRoute`) that lookup returned `undefined` and the engine silently resolved to `[]`.

This decouples Tracked Query resolution from `Route`: the engine's `DataRouter.get` callback now resolves directly against the batcher/storage layer keyed by the schema `resource`. As a result, a Custom Query handler can return `db.<resource>.where(...)` for a resource that has **no** `collectionRoute` declared and it still resolves and subscribes for realtime Sync Delta updates.

This is the enabling refactor described in ADR-0002 that lets later slices delete `collectionRoute`.

## Changes

- **`server/index.ts`** — replace the `routes[resource].handleQuery` indirection in the query engine's `get` callback with a direct `batcher.rawFind` keyed by `resource`. The parent-step relational filter is already folded into `query.where` by `resolveStep`, so there is no `uniqueWhere` to forward and existing behavior is preserved. The per-resource `read` auth merge in `incrementQueryStep` is untouched.
- **`test/e2e/procedure-only-routes.test.ts`** — add a `comments` resource with no `collectionRoute` and a procedure-only `watchComments` query that returns an unresolved builder. New test asserts initial resolution, realtime Sync Delta on a matching insert, and no notification on a non-matching insert.

## Acceptance criteria

- [x] Query engine resolves Tracked Queries via the batcher/storage layer keyed by `resource`, not `routes[resource].handleQuery`
- [x] A Custom Query handler returning a builder for a procedure-only route resolves and subscribes correctly, including realtime Sync Deltas
- [x] Existing Default and Custom Query behavior unchanged (all existing query e2e tests pass)
- [x] New test covers a procedure-only route whose handler returns a tracked query builder

## Verification

- `pnpm test --filter="./packages/*"`: 864 passed (+1), 0 failures
- `pnpm lint --filter="./packages/*" -- --diagnostic-level error`: clean
- `pnpm typecheck --filter="./packages/*"`: no errors

## Note

`Route.handleQuery` is now unused but left in place — deleting `collectionRoute`/`Route` is a later slice per ADR-0002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized query resolution for tracked queries, improving response times and efficiency

* **Bug Fixes**
  * Fixed query resolution and subscription behavior for queries in procedure-only routes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->