### PR TITLE
refactor: delegate Tracked Query resolution to Storage (#182)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,8 +34,31 @@ The client-only `store.query.<resource>.where(...).get()/.subscribe()` builder t
 _Avoid_: Default Query (that is the removed server-bound path).
 
 **Tracked Query**:
-The internal query representation (historically `RawQueryRequest`) the query engine subscribes to and resolves against storage, keyed by `resource`. Minted *server-side* from a Custom Query handler's returned query builder — never sent by a client. Surviving the Default Query removal as engine/storage internals, not a wire-exposed request.
-_Avoid_: treating this as a client-facing request; after removal, clients cannot produce one directly.
+The internal query representation (historically `RawQueryRequest`) the query engine subscribes to, keyed by `resource`. Minted *server-side* from a Custom Query handler's returned query builder — never sent by a client. Surviving the Default Query removal as engine/storage internals, not a wire-exposed request.
+_Avoid_: treating this as a client-facing request; after removal, clients cannot produce one directly. _Avoid_ saying the engine "resolves" it by sub-dividing into sub-queries — resolution (including `include`) is a single Storage query (see ADR-0003).
+
+**Query Engine**:
+The server-side component that maintains realtime subscriptions to **Tracked Queries** and broadcasts **Sync Deltas** to subscribed connections as committed writes change which objects are in **scope**. After ADR-0003 it does *not* resolve queries by breaking them into sub-queries; it delegates resolution to **Storage** (one query, `include` joins and all) and owns only matching-and-broadcasting.
+_Avoid_: describing it as a query *resolver* or as the thing that runs sub-queries through routes (that path is gone).
+
+### Realtime scope
+
+**Scope**:
+The set of objects a **Tracked Query** currently matches and is therefore broadcasting changes for. For a query (or `include`) that declares a `limit`, scope is a bounded **Window**; for a windowed `include`, scope is maintained *per parent*.
+
+**Window**:
+The bounded scope of a Tracked Query (or `include`) that declares a `limit`: the top `N` objects under the query's total order. Membership is *relative* — whether an object is in the window depends on the other rows, not on the object alone.
+_Avoid_: treating window membership as a per-object predicate; that is what makes windows different from plain `where`-matching.
+
+**Scope-in / Scope-out**:
+A committed write moving an object *into* / *out of* a Tracked Query's scope, broadcast as an `INSERT` / `DELETE` **Sync Delta**. A scope-out carries only the `id`; a scope-in carries the object's payload. Membership is judged *per tracked list*: `INSERT`/`DELETE` fire only on an actual entry/exit of that list. An object that changes — *including its relations* — but stays in the same scope produces a plain field `UPDATE`, never a `DELETE`+`INSERT`. A relation change decomposes into scope-out + scope-in only when the two parents' lists genuinely differ (e.g. a task moving from project A's window to project B's).
+_Avoid_: treating "a relation changed" as the trigger; the trigger is always the membership transition.
+
+**Eviction**:
+A **Scope-out** caused not by a write to the evicted object, but by *another* object entering a full **Window** and displacing it. The displaced object is identified from in-memory window state, so eviction needs no database read.
+
+**Backfill**:
+Replacing an object that left a **Window** with the next object past the window boundary. Because the engine keeps no objects beyond the window, backfill is the one case that requires a database read on the broadcast path (see ADR-0003).
 
 ### Sync
 

--- a/docs/adr/0003-query-engine-as-realtime-broadcaster.md
+++ b/docs/adr/0003-query-engine-as-realtime-broadcaster.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+---
+
+# Query Engine becomes a realtime broadcaster; Storage owns resolution; windows are maintained in-memory
+
+## Context
+
+With the Default Query path and `collectionRoute`/`Route` removed (ADR-0002, #173/#178/#181), the query engine's original reason for existing — sub-dividing a query with `include`s into per-resource sub-queries so each could be run through its collection route — is gone. Storage (`Storage.get` → `applyInclude`) already resolves a full `include` tree (nested `where`/`orderBy`/`limit`, recursive) in a *single* query. So the engine's manual `breakdownQuery`/`resolveQuery`/`resolveStep`/`assembleResults` is redundant *for resolution*.
+
+That leaves the engine with one real job: **matching committed writes against subscribed Tracked Queries and broadcasting Sync Deltas** — keeping each subscribed connection's scope correct in realtime. The hard part of that job is **windows** (a query or `include` with a `limit`): window membership is *relative* to the other rows, and scope changes (evictions, backfills) fire for rows that were never themselves mutated — which the old per-object-boolean matcher could not express.
+
+The design goal stated for the engine: make broadcasting *fast* — neither holding every row in memory, nor hitting the database on every write.
+
+## Decision
+
+**1. Resolution moves to Storage.** Delete `breakdownQuery`/`resolveQuery`/`resolveStep`/`assembleResults`/`loadStepResults`. The engine exposes a thin `resolve(query)` that delegates to a single `storage.get(query)` (includes and all) and *ingests* the nested result into its tracking graph. `QueryStep` loses its resolution fields (`getWhere`/`referenceGetter`/`relationalWhere`/`isMany`).
+
+**2. The engine keeps a lean relationship graph** (`objectNodes` with `referencesObjects`/`referencedByObjects`) for relation-membership matching. It holds **no full rows**.
+
+Structurally, window/ordering logic is extracted into a standalone **`WindowIndex`** module (a sorted `{id, sortKey}` collection per scope, exposing insert/remove/position/boundary/needs-backfill against a clear interface) so it is unit-testable in isolation. `QueryEngine` owns subscriptions + the relationship graph and composes one `WindowIndex` per windowed scope; it stays the matcher/broadcaster.
+
+**3. Windows are maintained in-memory with a window-only ordering index — no buffer, no payloads.**
+- An ordering index exists **iff the query/include has a `limit`**. `orderBy` without `limit` needs no window (all matching rows are in scope; the client sorts locally).
+- Per windowed scope (per parent, for windowed includes), the engine keeps a **sorted list of `{id, sortKey}` for the `N` visible rows only** — no overscan buffer, no row payloads.
+- The total order is always `[...orderBy, id]` (id appended as a tiebreaker for a deterministic boundary/cursor). `limit` with no `orderBy` orders by `id`.
+- Broadcasts are **membership-only**: scope-in (`INSERT`, payload from the triggering mutation) and scope-out (`DELETE`, id only). Pure within-window reordering is *not* broadcast — the client re-sorts the `N` rows it holds. Sort keys are maintained incrementally (the new key is in the mutation payload if its field changed, else unchanged).
+- `INSERT`/`DELETE` fire only on an actual **entry/exit of a tracked list**, judged per list: was-out→now-in = `INSERT`, was-in→now-out = `DELETE`, was-in→still-in = plain field `UPDATE` (*even if relations changed*), was-out→still-out = nothing. A relation change is never itself the trigger. Re-parenting (e.g. a task moving from project A's window to B's) therefore decomposes into `DELETE` to A's subscribers + `INSERT` to B's only because the two lists differ — only A's side incurs a backfill read; B's `INSERT` payload comes from the task mutation. The same relation change against a root query that still contains the row is a single `UPDATE`.
+
+**4. The single hot-path database read is backfill.** When a window shrinks (a visible row is deleted or updated out of scope), the promoted row was deliberately not kept, so the engine issues a **boundary cursor read** — `where(<query where>) AND sortKey beyond the last remaining visible row, orderBy [...,id], limit = rows needed` — once per write-batch, synchronously, before emitting the backfill `INSERT`s. Evictions need no read (the displaced id is in the index).
+
+**5. Relational `orderBy` (sort key derived from a related object) is supported via reverse-ref fan-out *plus* a boundary cursor read.** On a related-object write that touches a relational sort key: walk `referencedByObjects` to recompute affected in-window rows' sort keys (handles demotions/boundary crossings of *known* rows), **and** issue a boundary cursor read to catch promotions of rows that were outside the window and therefore invisible to the graph.
+
+The notify path already supplies the mutated object's full own-columns (`rawUpdate` passes `rawFindById` as `entityData`), so own-column sort keys and scope-in payloads need no infra change. Relational *where*-matching keeps the existing `storage.get` fallback.
+
+## Considered options
+
+- **Re-resolve + diff** (re-run `storage.get` per affected query per write-batch, diff against last result). Uniform and simplest, handles windows for free — rejected as the default because it puts a database read on *every* write to a subscribed resource, the cost the engine exists to avoid.
+- **Overscan buffer (`N+K`) holding full rows.** Makes backfill database-free (amortized) and off the broadcast critical path. Rejected for now: chose no buffer / no payloads to minimize memory and complexity, accepting a synchronous backfill read on window shrink. (This is the natural first optimization if backfill reads become hot.)
+- **Window-only index of ids only, with no relationship graph.** Can't evaluate relational where/orderBy — rejected; the graph stays.
+- **Restrict `orderBy` to own-columns**, or **accept eventual correctness** for relational sort. Rejected in favor of full correctness via fan-out + boundary read.
+- **Keep the incremental graph and bolt ordering/eviction onto it without re-querying.** Impossible for backfill: the promoted row is by definition outside the tracked set, so *some* read is unavoidable.
+
+## Consequences
+
+- The engine no longer resolves queries; a change to `include` resolution semantics is now entirely a Storage concern.
+- Backfill is a synchronous database read on the broadcast path (one per write-batch per shrunk window). Relational-`orderBy` writes also incur a boundary cursor read. All other window events (scope-in by own mutation, eviction, within-window reorder) are pure in-memory.
+- Memory per windowed scope is bounded to `N` `{id, sortKey}` entries — no payloads, no rows beyond the window.
+- This also fixes a pre-existing gap: nested `where` on an `include` is now re-applied for realtime matching (previously child-relation matching checked only relation membership).
+- Pagination by `limit + offset` is a degenerate window whose index must span `[0, offset+N)`; deep offsets are O(offset) memory. Cursor pagination collapses back to a bounded window and should be the steered-toward API.

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -6,8 +6,6 @@ import {
 	type MaterializedLiveType,
 	type Schema,
 } from '../../schema';
-import type { Storage } from '../../server';
-import { Batcher } from '../../server/storage/batcher';
 import {
 	applyWhere,
 	extractIncludeFromWhere,
@@ -15,8 +13,8 @@ import {
 	type Logger,
 } from '../../utils';
 import type { RawQueryRequest, SyncDelta } from '../schemas/core-protocol';
-import { mergeWhereClauses, toPromiseLike } from '../utils';
-import type { DataRouter, DataSource, QueryStep } from './types';
+import { toPromiseLike } from '../utils';
+import type { DataSource, QueryStep } from './types';
 import { hashStep } from './utils';
 
 export type SyncDeltaHandler = (delta: SyncDelta) => void;
@@ -40,7 +38,6 @@ interface ObjectNode {
 }
 
 export class QueryEngine {
-	private router: DataRouter<any>;
 	private storage: DataSource;
 	private schema: Schema<any>;
 	private logger: Logger;
@@ -48,12 +45,10 @@ export class QueryEngine {
 	private objectNodes: Map<string, ObjectNode> = new Map();
 
 	constructor(opts: {
-		router: DataRouter<any>;
 		storage: DataSource;
 		schema: Schema<any>;
 		logger: Logger;
 	}) {
-		this.router = opts.router;
 		this.storage = opts.storage;
 		this.schema = opts.schema;
 		this.logger = opts.logger;
@@ -256,27 +251,78 @@ export class QueryEngine {
 		}
 	}
 
-	get(
-		query: RawQueryRequest,
-		extra?: { context?: any; batcher?: Batcher },
-	): PromiseLike<any[]> {
-		const queryPlan = this.breakdownQuery({
-			query,
-			context: extra?.context ?? {},
+	/**
+	 * Resolve a Tracked Query against storage in a single query (storage owns
+	 * `include` resolution) and ingest the nested result into the tracking graph
+	 * so realtime matching has its object/relation state populated. See ADR-0003.
+	 */
+	get(query: RawQueryRequest, _extra?: { context?: any }): PromiseLike<any[]> {
+		return toPromiseLike(this.storage.get(query)).then((results) => {
+			this.ingest(query, results);
+			return results;
 		});
+	}
 
-		return this.resolveQuery(queryPlan, {
-			context: extra?.context ?? {},
-			batcher: extra?.batcher ?? new Batcher(this.storage as Storage),
-		});
+	/**
+	 * Walk the single nested storage result alongside the query's step tree and
+	 * populate the tracking graph (object nodes, relations, per-step tracked
+	 * objects). Replaces the per-step side effects of the old resolution path.
+	 */
+	private ingest(query: RawQueryRequest, results: any[]): void {
+		for (const step of this.buildSteps({ query })) {
+			const objects =
+				step.stepPath.length === 0
+					? results
+					: this.extractByPath(results, query.resource, step.stepPath);
+			this.trackObjects(step, objects);
+		}
+	}
+
+	/**
+	 * Flatten the materialized objects nested at `stepPath` within a resolved
+	 * result tree. A `many` relation nests an array of materialized objects under
+	 * `.value[rel].value`; a `one` relation nests the materialized object itself
+	 * under `.value[rel]` (whose `.value` is the child's field map).
+	 */
+	private extractByPath(
+		results: any[],
+		rootResource: string,
+		stepPath: string[],
+	): any[] {
+		let level = results;
+		let resource = rootResource;
+
+		for (const relationName of stepPath) {
+			const relation = this.schema[resource]?.relations?.[relationName];
+			const isMany = relation?.type === 'many';
+			const next: any[] = [];
+
+			for (const item of level) {
+				const node = item?.value?.[relationName];
+				if (!node) continue;
+
+				if (isMany) {
+					if (Array.isArray(node.value)) {
+						for (const child of node.value) if (child) next.push(child);
+					}
+				} else if (node.value != null) {
+					next.push(node);
+				}
+			}
+
+			level = next;
+			if (relation) resource = relation.entity.name;
+		}
+
+		return level;
 	}
 
 	subscribe(
 		query: RawQueryRequest,
 		callback: SyncDeltaHandler,
-		context: any = {},
+		_context: any = {},
 	): () => void {
-		const queryPlan = this.breakdownQuery({ query, context });
+		const queryPlan = this.buildSteps({ query });
 
 		const stepHashes: Record<string, string> = {};
 
@@ -340,47 +386,29 @@ export class QueryEngine {
 		};
 	}
 
-	breakdownQuery(queryOrOpts: {
+	/**
+	 * Decompose a query (plus its `include` tree) into the per-relation steps
+	 * that back the subscription graph. This no longer carries any resolution
+	 * concern (resolution is a single `storage.get` — see ADR-0003); it only
+	 * shapes the query/object node tree used for realtime matching.
+	 */
+	private buildSteps(queryOrOpts: {
 		query: RawQueryRequest;
 		stepPath?: string[];
-		context?: any;
 		parentResource?: string;
 	}): QueryStep[] {
-		const { query, stepPath = [], context = {}, parentResource } = queryOrOpts;
+		const { query, stepPath = [], parentResource } = queryOrOpts;
 
 		const { include } = query;
 
 		const isRootQuery = stepPath.length === 0;
 		const relationName = stepPath.at(-1);
 
-		// For child queries, we need to set up getWhere and referenceGetter based on the relation
-		let getWhere: QueryStep['getWhere'];
-		let referenceGetter: QueryStep['referenceGetter'];
 		let isMany: boolean | undefined;
 
 		if (!isRootQuery && parentResource && relationName) {
-			const parentSchema = this.schema[parentResource];
-			const relation = parentSchema?.relations?.[relationName];
-
-			if (relation) {
-				isMany = relation.type === 'many';
-
-				if (relation.type === 'one') {
-					// For "one" relations, we query by ID (the related entity's ID)
-					getWhere = (id: string) => ({ id });
-					referenceGetter = (parentData: any[]) =>
-						parentData
-							.map((item) => item.value?.[relation.relationalColumn]?.value)
-							.filter((v): v is string => v !== undefined);
-				} else {
-					// For "many" relations, we query by foreign column
-					getWhere = (id: string) => ({ [relation.foreignColumn]: id });
-					referenceGetter = (parentData: any[]) =>
-						parentData
-							.map((item) => item.value?.id?.value as string | undefined)
-							.filter((v): v is string => v !== undefined);
-				}
-			}
+			const relation = this.schema[parentResource]?.relations?.[relationName];
+			if (relation) isMany = relation.type === 'many';
 		}
 
 		// Strip include from the query since it's been processed into child steps
@@ -391,8 +419,6 @@ export class QueryEngine {
 			stepPath: [...stepPath],
 			includedRelations:
 				include && typeof include === 'object' ? Object.keys(include) : [],
-			getWhere,
-			referenceGetter,
 			isMany,
 			relationName,
 		};
@@ -424,7 +450,7 @@ export class QueryEngine {
 						? nestedInclude
 						: null;
 
-					return this.breakdownQuery({
+					return this.buildSteps({
 						query: {
 							resource: otherResourceName,
 							include: subQuery
@@ -437,7 +463,6 @@ export class QueryEngine {
 							sort: subQuery?.orderBy,
 						},
 						stepPath: [...stepPath, relName],
-						context,
 						parentResource: query.resource,
 					});
 				}),
@@ -447,398 +472,14 @@ export class QueryEngine {
 		return queryPlan;
 	}
 
-	resolveQuery(
-		plan: QueryStep[],
-		extra?: { context?: any; batcher?: Batcher },
-	): PromiseLike<any[]> {
+	/**
+	 * Populate the tracking graph for a single step's objects: object nodes,
+	 * their relations, and the step's tracked-object set. Called per step by
+	 * `ingest` over the nested storage result.
+	 */
+	private trackObjects(step: QueryStep, results: any[]): void {
 		this.logger.debug(
-			'[QueryEngine] Resolving query',
-			plan.map((step) => step.stepPath.join('.')).join(' -> '),
-		);
-
-		// Map: stepPath -> array of { includedBy?: string, data: any[] }
-		const stepResults: Record<string, { includedBy?: string; data: any[] }[]> =
-			{};
-
-		let chain: PromiseLike<void> = this.resolveStep(plan[0], extra).then(
-			(results) => {
-				this.logger.debug(
-					'[QueryEngine] Resolved step',
-					plan[0].stepPath.join('.'),
-					'with results count:',
-					results.length,
-				);
-				stepResults[plan[0].stepPath.join('.')] = [{ data: results }];
-			},
-		);
-
-		for (let i = 1; i < plan.length; i++) {
-			const step = plan[i];
-			const parentStepPath = step.stepPath.slice(0, -1).join('.');
-
-			chain = chain.then(async () => {
-				const parentResults = stepResults[parentStepPath];
-				if (!parentResults) {
-					stepResults[step.stepPath.join('.')] = [];
-					return;
-				}
-
-				// If we have a referenceGetter, use it to get IDs and getWhere to build queries
-				if (step.referenceGetter && step.getWhere) {
-					// Build a map from reference ID (e.g., authorId) to parent IDs (e.g., post IDs)
-					// This allows us to track which parent each reference belongs to
-					const referenceToParents = new Map<string, Set<string>>();
-
-					for (const parentResultGroup of parentResults) {
-						for (const parentItem of parentResultGroup.data) {
-							const parentId = parentItem?.value?.id?.value as
-								| string
-								| undefined;
-							if (!parentId) continue;
-
-							const referenceIds = step.referenceGetter([parentItem]);
-							const referenceId = referenceIds[0];
-							if (referenceId) {
-								if (!referenceToParents.has(referenceId)) {
-									referenceToParents.set(referenceId, new Set());
-								}
-								const parentSet = referenceToParents.get(referenceId);
-								if (parentSet) {
-									parentSet.add(parentId);
-								}
-							}
-						}
-					}
-
-					const uniqueReferenceIds = Array.from(referenceToParents.keys());
-
-					if (uniqueReferenceIds.length === 0) {
-						stepResults[step.stepPath.join('.')] = [];
-						return;
-					}
-
-					// Execute a query for each unique reference ID, then distribute results to parents
-					const results: { includedBy?: string; data: any[] }[] = [];
-
-					for (const referenceId of uniqueReferenceIds) {
-						const relationalWhere = step.getWhere(referenceId);
-						const stepWithRelationalWhere: QueryStep = {
-							...step,
-							relationalWhere,
-						};
-
-						const data = await this.resolveStep(stepWithRelationalWhere, extra);
-
-						// For each parent that references this ID, create a result entry
-						const parentIds = referenceToParents.get(referenceId);
-						if (parentIds) {
-							for (const parentId of Array.from(parentIds)) {
-								results.push({ includedBy: parentId, data });
-							}
-						}
-					}
-
-					this.logger.debug(
-						'[QueryEngine] Resolved step',
-						step.stepPath.join('.'),
-						'with results count:',
-						results.reduce((acc, r) => acc + r.data.length, 0),
-					);
-					stepResults[step.stepPath.join('.')] = results;
-				} else {
-					// No relation info, just resolve normally
-					const data = await this.resolveStep(step, extra);
-					stepResults[step.stepPath.join('.')] = [{ data }];
-				}
-			});
-		}
-
-		chain = chain.then((() => {
-			this.logger.debug('[QueryEngine] Assembling results');
-			return this.assembleResults(plan, stepResults);
-		}) as () => void);
-
-		return chain as unknown as PromiseLike<any[]>;
-	}
-
-	private assembleResults(
-		plan: QueryStep[],
-		stepResults: Record<string, { includedBy?: string; data: any[] }[]>,
-	): any[] {
-		this.logger.debug('[QueryEngine] assembleResults: Starting assembly');
-		this.logger.debug(
-			'[QueryEngine] assembleResults: Plan steps:',
-			plan.length,
-		);
-		this.logger.debug(
-			'[QueryEngine] assembleResults: Step results keys:',
-			Object.keys(stepResults),
-		);
-
-		// Build a map of all entities by their full path + id
-		const entriesMap = new Map<
-			string,
-			{
-				data: any;
-				includedBy: Set<string>;
-				path: string;
-				isMany: boolean;
-				relationName?: string;
-				resourceName: string;
-				includedRelations: string[];
-			}
-		>();
-
-		// Process each step in order
-		for (const step of plan) {
-			const stepPath = step.stepPath.join('.');
-			const results = stepResults[stepPath] ?? [];
-			const includedRelations = step.includedRelations ?? [];
-
-			this.logger.debug(
-				`[QueryEngine] assembleResults: Processing step "${stepPath}"`,
-				{
-					resource: step.query.resource,
-					includedRelations,
-					resultGroups: results.length,
-					isMany: step.isMany,
-					relationName: step.relationName,
-				},
-			);
-
-			for (const resultGroup of results) {
-				this.logger.debug(
-					`[QueryEngine] assembleResults: Processing result group for "${stepPath}"`,
-					{
-						dataCount: resultGroup.data.length,
-						includedBy: resultGroup.includedBy,
-					},
-				);
-
-				for (const data of resultGroup.data) {
-					const id = data?.value?.id?.value as string | undefined;
-					if (!id) {
-						this.logger.debug(
-							`[QueryEngine] assembleResults: Skipping data without id in step "${stepPath}"`,
-						);
-						continue;
-					}
-
-					const key = stepPath ? `${stepPath}.${id}` : id;
-
-					// For child queries, find parent key
-					let parentKeys: string[] = [];
-					if (step.stepPath.length > 0 && resultGroup.includedBy) {
-						const parentStepPath = step.stepPath.slice(0, -1).join('.');
-						parentKeys = [
-							parentStepPath
-								? `${parentStepPath}.${resultGroup.includedBy}`
-								: resultGroup.includedBy,
-						];
-						this.logger.debug(
-							`[QueryEngine] assembleResults: Child entity "${key}" has parent keys:`,
-							parentKeys,
-							{
-								stepPath,
-								parentStepPath,
-								includedBy: resultGroup.includedBy,
-							},
-						);
-					} else {
-						this.logger.debug(
-							`[QueryEngine] assembleResults: Root entity "${key}" (no parent)`,
-						);
-					}
-
-					const existing = entriesMap.get(key);
-					if (existing) {
-						this.logger.debug(
-							`[QueryEngine] assembleResults: Entity "${key}" already exists, adding parent keys:`,
-							parentKeys,
-						);
-						for (const parentKey of parentKeys) {
-							existing.includedBy.add(parentKey);
-						}
-					} else {
-						this.logger.debug(
-							`[QueryEngine] assembleResults: Adding new entity "${key}"`,
-							{
-								resource: step.query.resource,
-								path: step.stepPath.at(-1) ?? '',
-								isMany: step.isMany ?? false,
-								relationName: step.relationName,
-								includedRelations,
-								parentKeys,
-							},
-						);
-						entriesMap.set(key, {
-							data,
-							includedBy: new Set(parentKeys),
-							path: step.stepPath.at(-1) ?? '',
-							isMany: step.isMany ?? false,
-							relationName: step.relationName,
-							resourceName: step.query.resource,
-							includedRelations,
-						});
-					}
-				}
-			}
-		}
-
-		this.logger.debug(
-			`[QueryEngine] assembleResults: Built entriesMap with ${entriesMap.size} entries`,
-		);
-		this.logger.debug(
-			'[QueryEngine] assembleResults: EntriesMap keys:',
-			Array.from(entriesMap.keys()),
-		);
-
-		// Assemble: iterate in reverse to attach children to parents
-		const entriesArray = Array.from(entriesMap.entries());
-		const resultData: any[] = [];
-
-		this.logger.debug(
-			`[QueryEngine] assembleResults: Starting assembly phase with ${entriesArray.length} entries`,
-		);
-
-		for (let i = entriesArray.length - 1; i >= 0; i--) {
-			const [key, entry] = entriesArray[i];
-			const resourceSchema = this.schema[entry.resourceName];
-
-			this.logger.debug(
-				`[QueryEngine] assembleResults: Processing entry "${key}"`,
-				{
-					resource: entry.resourceName,
-					path: entry.path,
-					isMany: entry.isMany,
-					relationName: entry.relationName,
-					includedRelations: entry.includedRelations,
-					parentKeys: Array.from(entry.includedBy),
-				},
-			);
-
-			// Initialize included relations if they don't exist
-			for (const includedRelation of entry.includedRelations) {
-				const relationType =
-					resourceSchema?.relations?.[includedRelation]?.type;
-				const hasRelation = !!entry.data.value[includedRelation];
-				this.logger.debug(
-					`[QueryEngine] assembleResults: Checking included relation "${includedRelation}" for "${key}"`,
-					{
-						relationType,
-						hasRelation,
-						resourceHasRelation:
-							!!resourceSchema?.relations?.[includedRelation],
-					},
-				);
-
-				if (!entry.data.value[includedRelation]) {
-					const defaultValue =
-						relationType === 'many' ? { value: [] } : { value: null };
-					entry.data.value[includedRelation] = defaultValue;
-					this.logger.debug(
-						`[QueryEngine] assembleResults: Initialized relation "${includedRelation}" for "${key}" with`,
-						defaultValue,
-					);
-				} else {
-					this.logger.debug(
-						`[QueryEngine] assembleResults: Relation "${includedRelation}" already exists for "${key}"`,
-						entry.data.value[includedRelation],
-					);
-				}
-			}
-
-			// Root level items (no path)
-			if (entry.path === '') {
-				this.logger.debug(
-					`[QueryEngine] assembleResults: Adding root entity "${key}" to resultData`,
-				);
-				resultData.unshift(entry.data);
-				continue;
-			}
-
-			// Attach to parent(s)
-			this.logger.debug(
-				`[QueryEngine] assembleResults: Attaching "${key}" to ${entry.includedBy.size} parent(s)`,
-			);
-			for (const parentKey of Array.from(entry.includedBy)) {
-				const parent = entriesMap.get(parentKey);
-				if (!parent) {
-					this.logger.warn(
-						`[QueryEngine] assembleResults: WARNING - Parent "${parentKey}" not found in entriesMap for child "${key}"`,
-					);
-					continue;
-				}
-
-				const relationName = entry.relationName ?? entry.path;
-				this.logger.debug(
-					`[QueryEngine] assembleResults: Attaching "${key}" to parent "${parentKey}" via relation "${relationName}"`,
-					{
-						isMany: entry.isMany,
-						parentHasRelation: !!parent.data.value[relationName],
-					},
-				);
-
-				if (entry.isMany) {
-					parent.data.value[relationName] ??= { value: [] };
-					parent.data.value[relationName].value.push(entry.data);
-					this.logger.debug(
-						`[QueryEngine] assembleResults: Added "${key}" to many relation "${relationName}" on parent "${parentKey}"`,
-						{
-							arrayLength: parent.data.value[relationName].value.length,
-						},
-					);
-				} else {
-					parent.data.value[relationName] = entry.data;
-					this.logger.debug(
-						`[QueryEngine] assembleResults: Set one relation "${relationName}" on parent "${parentKey}" to "${key}"`,
-					);
-				}
-			}
-		}
-
-		this.logger.debug(
-			`[QueryEngine] assembleResults: Assembly complete. Returning ${resultData.length} root items`,
-		);
-		return resultData;
-	}
-
-	resolveStep(
-		step: QueryStep,
-		extra?: { context?: any; batcher?: Batcher },
-	): PromiseLike<any[]> {
-		this.logger.debug(
-			'[QueryEngine] Resolving step',
-			step.stepPath.join('.'),
-			'with query',
-			JSON.stringify(step.query, null, 2),
-			'relationalWhere',
-			JSON.stringify(step.relationalWhere, null, 2),
-		);
-
-		const { query, relationalWhere } = step;
-
-		// Combine normal where clause with relational where clause
-		const combinedWhere =
-			query.where && relationalWhere
-				? mergeWhereClauses(query.where, relationalWhere)
-				: (relationalWhere ?? query.where);
-
-		const queryWithCombinedWhere = combinedWhere
-			? { ...query, where: combinedWhere }
-			: query;
-
-		return toPromiseLike(this.router.get(queryWithCombinedWhere, extra)).then(
-			(results) => {
-				this.loadStepResults(step, results);
-				return results;
-			},
-		);
-	}
-
-	loadStepResults(step: QueryStep, results: any[]): void {
-		this.logger.debug(
-			'[QueryEngine] Loading step results',
+			'[QueryEngine] Tracking step objects',
 			step.stepPath.join('.'),
 			'with results',
 			JSON.stringify(results, null, 2),

--- a/packages/live-state/src/core/query-engine/types.ts
+++ b/packages/live-state/src/core/query-engine/types.ts
@@ -1,35 +1,17 @@
-import type { WhereClause } from '../../schema';
-import type { Batcher } from '../../server/storage/batcher';
 import type { RawQueryRequest } from '../schemas/core-protocol';
 import type { PromiseOrSync } from '../utils';
 
 export interface DataSource {
-	get(
-		query: RawQueryRequest,
-		extra?: { context?: any; batcher?: Batcher },
-	): PromiseOrSync<any[]>;
-}
-
-export interface QueryStepResult {
-	includedBy?: string;
-	data: any[];
+	get(query: RawQueryRequest, extra?: { context?: any }): PromiseOrSync<any[]>;
 }
 
 export interface QueryStep {
 	query: RawQueryRequest;
 	stepPath: string[];
-	/** For child steps: function to create where clause from parent ID */
-	getWhere?: (id: string) => WhereClause<any>;
-	/** For child steps: function to extract IDs from parent results */
-	referenceGetter?: (parentData: any[]) => string[];
-	/** Whether this is a one-to-many relation */
+	/** Whether this is a one-to-many relation (relative to the parent step) */
 	isMany?: boolean;
 	/** The relation name in parent's schema */
 	relationName?: string;
-	/** Where clause derived from the parent step (relational filtering) */
-	relationalWhere?: WhereClause<any>;
 	/** Relation names included on this step, preserved after `include` is stripped from the query */
 	includedRelations?: string[];
 }
-
-export type DataRouter<_Context = unknown> = DataSource;

--- a/packages/live-state/src/server/index.ts
+++ b/packages/live-state/src/server/index.ts
@@ -7,7 +7,6 @@ import { createLogger, type Logger, LogLevel } from '../utils';
 import { type Hooks, type HooksRegistry, mergeEntityHooks } from './hooks';
 import type { AnyRoute, AnyRouter, QueryProcedureRequest } from './router';
 import type { Storage } from './storage';
-import type { Batcher } from './storage/batcher';
 
 export * from './adapters/express';
 export * from './hooks';
@@ -110,31 +109,10 @@ export class Server<TRouter extends AnyRouter, TContext = Record<string, any>> {
 			});
 		this.contextProvider = opts.contextProvider;
 
+		// Tracked Queries resolve in a single `storage.get` (storage owns `include`
+		// resolution); the engine only matches committed writes and broadcasts
+		// Sync Deltas to subscribers. See ADR-0003.
 		this.queryEngine = new QueryEngine({
-			router: {
-				get: async (
-					query: RawQueryRequest,
-					extra?: { context?: any; batcher?: Batcher },
-				) => {
-					if (!extra?.batcher) {
-						throw new Error('Batcher is required');
-					}
-
-					// Tracked Queries resolve directly against the batcher/storage layer
-					// keyed by the schema `resource`: any resource in the `schema` is
-					// resolvable, which lets a Custom Query handler return
-					// `db.<resource>.where(...)` for a procedure-only route. The parent
-					// step's relational filtering is already folded into `query.where` by
-					// `resolveStep`, so there is no `uniqueWhere` here.
-					return extra.batcher.rawFind({
-						resource: query.resource,
-						commonWhere: query.where,
-						include: query.include,
-						limit: query.limit,
-						sort: query.sort,
-					});
-				},
-			},
 			storage: this.storage,
 			schema: this.schema,
 			logger: this.logger,

--- a/packages/live-state/src/server/storage/sql-utils.ts
+++ b/packages/live-state/src/server/storage/sql-utils.ts
@@ -252,9 +252,16 @@ export function applyInclude<T extends LiveObjectAny>(
 
     const aggFunc = relation.type === "one" ? jsonObjectFrom : jsonArrayFrom;
 
-    // Extract sub-query options if this is a sub-query include
+    // An include value is either a sub-query (`{ where?, limit?, orderBy?,
+    // include? }`) or a plain-nested include map whose own keys are further
+    // relations (`{ posts: { comments: true } }`). For the latter the value
+    // itself is the nested include — mirror the client's interpretation.
     const subQueryOptions = isSubQueryInclude(includeValue) ? includeValue : null;
-    const nestedInclude = subQueryOptions?.include;
+    const nestedInclude = subQueryOptions
+      ? subQueryOptions.include
+      : includeValue && typeof includeValue === "object"
+        ? (includeValue as Record<string, any>)
+        : undefined;
 
     query = query.select((eb) => {
       const metaTableName = `${otherresource}_meta`;


### PR DESCRIPTION
Closes #182. First slice of the Query Engine refactor (ADR-0003).

## What

The Query Engine stops being a *resolver*. With `collectionRoute`/Default Queries removed (ADR-0002), `Storage.get` already resolves a full `include` tree (nested `where`/`orderBy`/`limit`, recursive) in a single query — so the engine's manual breakdown→resolve→assemble was redundant duplication.

- `QueryEngine.get()` now runs a single `storage.get(query)` and **ingests** the nested result into the tracking graph.
- Deleted `resolveQuery`, `resolveStep`, `assembleResults`, `loadStepResults`, `breakdownQuery`.
- Subscription-graph decomposition retained as a private `buildSteps` (no resolution-only fields); `QueryStep` slimmed (`getWhere`/`referenceGetter`/`relationalWhere` dropped).
- New `ingest`/`extractByPath`/`trackObjects` populate `objectNodes`/relations/per-step tracked sets from the one result.
- Removed the dead `router` → `batcher.rawFind` indirection from the engine and `Server`.

## Parity fix

This surfaced a real gap: storage's `applyInclude` only recursed on the **sub-query** include form (`{ include: {...} }`) and silently dropped **plain-nested** includes (`{ users: { posts: true } }`) that the old engine supported. Fixed `applyInclude` to treat a non-sub-query object value as the nested include map, mirroring the client's interpretation.

## Verification

- `query-engine.test.ts` green; full package suite **805 passed / 39 files** — identical to the pre-change baseline.
- `pnpm typecheck` clean; `biome lint src` clean.

## Notes

- Behavior-preserving: same broadcasts/matching as before. Windowing, the nested-`where` matching fix, and relational ordering land in follow-up slices (#184, #185, #186, #187).
- A cardinality subtlety future slices share: `many` relations nest an array under `.value[rel].value`, `one` relations nest the materialized child as `.value[rel]` itself — `extractByPath` is schema-aware about this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Realtime updates now track scope changes more consistently, including window membership changes and backfill behavior for moving records.
  * Deeper nested `include` structures are now supported when fetching related data.

* **Bug Fixes**
  * Improved realtime matching for complex relation filters and `include` trees.
  * Field-only changes now emit updates without unnecessary remove/add cycles.

* **Documentation**
  * Updated architecture notes and glossary to reflect the new realtime query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->