### PR TITLE
feat(query-engine): WindowIndex for in-memory window ordering

### DIFF
--- a/packages/live-state/src/core/query-engine/window-index.ts
+++ b/packages/live-state/src/core/query-engine/window-index.ts
@@ -1,0 +1,208 @@
+/**
+ * In-memory ordering index for a single windowed scope (a Tracked Query or
+ * windowed `include` that declares a `limit`). Per ADR-0003 it holds **only**
+ * `{ id, sortKey }` for the `N` visible rows — no overscan buffer, no row
+ * payloads.
+ *
+ * The total order is always `[...orderBy, id]`: the `id` is appended as a
+ * deterministic tiebreaker so the window boundary (and any future cursor) is
+ * unambiguous. A bare `limit` with no `orderBy` therefore orders by `id` alone.
+ *
+ * This module is the matching/broadcasting half of the engine's window logic,
+ * extracted so it can be unit-tested in isolation. It exposes just enough for
+ * the engine to drive membership-only broadcasts without a database read in the
+ * common cases: insert a row, remove a row, look up a row's position, read the
+ * current boundary, and report whether a shrink left the window under-full.
+ */
+
+export type SortDirection = 'asc' | 'desc';
+
+export type OrderBy = { key: string; direction: SortDirection }[];
+
+/** A single comparable cell of a sort key. */
+export type SortValue = string | number | boolean | null | undefined;
+
+/**
+ * The ordered tuple of `orderBy` values for a row, in the same order as the
+ * index's `orderBy`. The `id` tiebreaker is appended by the index itself and
+ * must **not** be included here.
+ */
+export type SortKey = SortValue[];
+
+export interface WindowEntry {
+	id: string;
+	sortKey: SortKey;
+}
+
+export interface InsertResult {
+	/** Whether the row ended up inside the window. */
+	inserted: boolean;
+	/**
+	 * The entry displaced because the window was full and the new row sorted
+	 * ahead of the previous boundary. Present only on an eviction; the engine
+	 * broadcasts this as a scope-out (`DELETE`) without a database read.
+	 */
+	evicted?: WindowEntry;
+}
+
+/**
+ * Compare two sort cells in ascending order. `null`/`undefined` sort before any
+ * concrete value (matching SQLite's `NULLS FIRST` for ascending); booleans
+ * compare as `false < true`.
+ */
+function compareValues(a: SortValue, b: SortValue): number {
+	const aNil = a === null || a === undefined;
+	const bNil = b === null || b === undefined;
+	if (aNil && bNil) return 0;
+	if (aNil) return -1;
+	if (bNil) return 1;
+
+	if (typeof a === 'number' && typeof b === 'number') return a - b;
+	if (typeof a === 'boolean' && typeof b === 'boolean')
+		return Number(a) - Number(b);
+
+	const as = String(a);
+	const bs = String(b);
+	if (as < bs) return -1;
+	if (as > bs) return 1;
+	return 0;
+}
+
+export class WindowIndex {
+	private readonly limit: number;
+	private readonly directions: SortDirection[];
+	/** Entries sorted by the total order `[...orderBy, id]`, capped at `limit`. */
+	private entries: WindowEntry[] = [];
+	private readonly index: Map<string, WindowEntry> = new Map();
+
+	constructor(opts: { limit: number; orderBy?: OrderBy }) {
+		if (!Number.isInteger(opts.limit) || opts.limit < 0)
+			throw new Error('WindowIndex limit must be a non-negative integer');
+		this.limit = opts.limit;
+		this.directions = (opts.orderBy ?? []).map((o) => o.direction);
+	}
+
+	/** Number of rows currently held in the window. */
+	get size(): number {
+		return this.entries.length;
+	}
+
+	/** Whether the window currently holds its full `N` rows. */
+	get isFull(): boolean {
+		return this.entries.length >= this.limit;
+	}
+
+	/**
+	 * Compare two entries by the total order `[...orderBy, id]`. `id` is always
+	 * an ascending tiebreaker regardless of `orderBy` directions.
+	 */
+	private compare(a: WindowEntry, b: WindowEntry): number {
+		for (let i = 0; i < this.directions.length; i++) {
+			const cmp = compareValues(a.sortKey[i], b.sortKey[i]);
+			if (cmp !== 0) return this.directions[i] === 'desc' ? -cmp : cmp;
+		}
+		if (a.id < b.id) return -1;
+		if (a.id > b.id) return 1;
+		return 0;
+	}
+
+	/**
+	 * Binary search for the position at which `entry` sorts. Returns the index of
+	 * the first element that is **not** ordered before `entry` (lower bound).
+	 */
+	private lowerBound(entry: WindowEntry): number {
+		let lo = 0;
+		let hi = this.entries.length;
+		while (lo < hi) {
+			const mid = (lo + hi) >>> 1;
+			if (this.compare(this.entries[mid], entry) < 0) lo = mid + 1;
+			else hi = mid;
+		}
+		return lo;
+	}
+
+	/**
+	 * Insert a row into the window. If the window is full and the row sorts ahead
+	 * of the current boundary, the boundary entry is evicted and returned; if the
+	 * window is full and the row sorts at/after the boundary, it is rejected
+	 * (`inserted: false`).
+	 */
+	insert(entry: WindowEntry): InsertResult {
+		if (this.limit === 0) return { inserted: false };
+		if (this.index.has(entry.id))
+			throw new Error(`WindowIndex already contains id "${entry.id}"`);
+
+		const pos = this.lowerBound(entry);
+
+		if (this.isFull && pos >= this.limit) return { inserted: false };
+
+		this.entries.splice(pos, 0, entry);
+		this.index.set(entry.id, entry);
+
+		if (this.entries.length > this.limit) {
+			const evicted = this.entries.pop();
+			if (evicted) {
+				this.index.delete(evicted.id);
+				return { inserted: true, evicted };
+			}
+		}
+
+		return { inserted: true };
+	}
+
+	/** Remove a row from the window. Returns the removed entry, if present. */
+	remove(id: string): WindowEntry | undefined {
+		const entry = this.index.get(id);
+		if (!entry) return undefined;
+		const pos = this.lowerBound(entry);
+		// `lowerBound` lands on the first entry not ordered before `entry`; with a
+		// unique id tiebreaker that is exactly this entry.
+		this.entries.splice(pos, 1);
+		this.index.delete(id);
+		return entry;
+	}
+
+	/** Whether the given id is currently in the window. */
+	has(id: string): boolean {
+		return this.index.has(id);
+	}
+
+	/** Zero-based position of a row in the current order, or `undefined`. */
+	position(id: string): number | undefined {
+		const entry = this.index.get(id);
+		if (!entry) return undefined;
+		return this.lowerBound(entry);
+	}
+
+	/**
+	 * The current window boundary: the last (`N`th) entry in order. The engine
+	 * uses this as the cursor for a boundary read when backfilling.
+	 */
+	boundary(): WindowEntry | undefined {
+		return this.entries[this.entries.length - 1];
+	}
+
+	/**
+	 * Whether the window is under-full and therefore may need a backfill read.
+	 * True after a shrink left fewer than `N` rows; the engine decides whether
+	 * rows actually exist past the boundary.
+	 */
+	needsBackfill(): boolean {
+		return this.entries.length < this.limit;
+	}
+
+	/** How many rows would be needed to refill the window to `N`. */
+	get backfillCount(): number {
+		return Math.max(0, this.limit - this.entries.length);
+	}
+
+	/** A snapshot of the current ordering (defensive copy). */
+	snapshot(): WindowEntry[] {
+		return this.entries.map((e) => ({ id: e.id, sortKey: [...e.sortKey] }));
+	}
+
+	/** The current ordered list of ids. */
+	ids(): string[] {
+		return this.entries.map((e) => e.id);
+	}
+}

--- a/packages/live-state/test/core/query-engine/window-index.test.ts
+++ b/packages/live-state/test/core/query-engine/window-index.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "vitest";
+import {
+	type OrderBy,
+	WindowIndex,
+} from "../../../src/core/query-engine/window-index";
+
+/** Build an index and bulk-insert entries, returning the index. */
+function buildIndex(
+	opts: { limit: number; orderBy?: OrderBy },
+	entries: { id: string; sortKey: (string | number | boolean | null)[] }[] = [],
+) {
+	const index = new WindowIndex(opts);
+	for (const e of entries) index.insert(e);
+	return index;
+}
+
+describe("WindowIndex", () => {
+	describe("ordering", () => {
+		test("a bare limit with no orderBy orders by id", () => {
+			const index = buildIndex({ limit: 5 }, [
+				{ id: "c", sortKey: [] },
+				{ id: "a", sortKey: [] },
+				{ id: "b", sortKey: [] },
+			]);
+			expect(index.ids()).toEqual(["a", "b", "c"]);
+		});
+
+		test("orders by a single ascending key", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 5, orderBy }, [
+				{ id: "x", sortKey: [30] },
+				{ id: "y", sortKey: [10] },
+				{ id: "z", sortKey: [20] },
+			]);
+			expect(index.ids()).toEqual(["y", "z", "x"]);
+		});
+
+		test("orders by a single descending key", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "desc" }];
+			const index = buildIndex({ limit: 5, orderBy }, [
+				{ id: "x", sortKey: [30] },
+				{ id: "y", sortKey: [10] },
+				{ id: "z", sortKey: [20] },
+			]);
+			expect(index.ids()).toEqual(["x", "z", "y"]);
+		});
+
+		test("breaks ties on equal sort values using id (ascending)", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "desc" }];
+			const index = buildIndex({ limit: 5, orderBy }, [
+				{ id: "b", sortKey: [10] },
+				{ id: "a", sortKey: [10] },
+				{ id: "c", sortKey: [10] },
+			]);
+			// id tiebreaker stays ascending even when the key is descending
+			expect(index.ids()).toEqual(["a", "b", "c"]);
+		});
+
+		test("composite keys with mixed asc/desc compare correctly", () => {
+			const orderBy: OrderBy = [
+				{ key: "status", direction: "asc" },
+				{ key: "score", direction: "desc" },
+			];
+			const index = buildIndex({ limit: 10, orderBy }, [
+				{ id: "1", sortKey: ["open", 5] },
+				{ id: "2", sortKey: ["open", 9] },
+				{ id: "3", sortKey: ["closed", 1] },
+				{ id: "4", sortKey: ["closed", 8] },
+			]);
+			// status asc: closed before open; within each, score desc
+			expect(index.ids()).toEqual(["4", "3", "2", "1"]);
+		});
+
+		test("null/undefined sort before concrete values (ascending)", () => {
+			const orderBy: OrderBy = [{ key: "name", direction: "asc" }];
+			const index = buildIndex({ limit: 10, orderBy }, [
+				{ id: "1", sortKey: ["b"] },
+				{ id: "2", sortKey: [null] },
+				{ id: "3", sortKey: ["a"] },
+			]);
+			expect(index.ids()).toEqual(["2", "3", "1"]);
+		});
+
+		test("position reflects sorted order and is undefined for absent ids", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 5, orderBy }, [
+				{ id: "x", sortKey: [30] },
+				{ id: "y", sortKey: [10] },
+				{ id: "z", sortKey: [20] },
+			]);
+			expect(index.position("y")).toBe(0);
+			expect(index.position("z")).toBe(1);
+			expect(index.position("x")).toBe(2);
+			expect(index.position("missing")).toBeUndefined();
+			expect(index.has("missing")).toBe(false);
+		});
+	});
+
+	describe("insert and eviction", () => {
+		test("inserts without eviction while the window has room", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = new WindowIndex({ limit: 3, orderBy });
+			expect(index.insert({ id: "a", sortKey: [10] })).toEqual({
+				inserted: true,
+			});
+			expect(index.insert({ id: "b", sortKey: [20] })).toEqual({
+				inserted: true,
+			});
+			expect(index.isFull).toBe(false);
+			expect(index.size).toBe(2);
+		});
+
+		test("evicts the boundary when a new row sorts into a full window", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 3, orderBy }, [
+				{ id: "a", sortKey: [10] },
+				{ id: "b", sortKey: [20] },
+				{ id: "c", sortKey: [30] },
+			]);
+			expect(index.isFull).toBe(true);
+
+			const result = index.insert({ id: "d", sortKey: [15] });
+			expect(result.inserted).toBe(true);
+			expect(result.evicted).toEqual({ id: "c", sortKey: [30] });
+			expect(index.ids()).toEqual(["a", "d", "b"]);
+			expect(index.has("c")).toBe(false);
+		});
+
+		test("rejects a row that sorts at/after the boundary of a full window", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 3, orderBy }, [
+				{ id: "a", sortKey: [10] },
+				{ id: "b", sortKey: [20] },
+				{ id: "c", sortKey: [30] },
+			]);
+			const result = index.insert({ id: "d", sortKey: [40] });
+			expect(result).toEqual({ inserted: false });
+			expect(index.ids()).toEqual(["a", "b", "c"]);
+		});
+
+		test("a limit-0 window accepts nothing", () => {
+			const index = new WindowIndex({ limit: 0 });
+			expect(index.insert({ id: "a", sortKey: [] })).toEqual({
+				inserted: false,
+			});
+			expect(index.size).toBe(0);
+		});
+
+		test("inserting a duplicate id throws", () => {
+			const index = buildIndex({ limit: 5 }, [{ id: "a", sortKey: [] }]);
+			expect(() => index.insert({ id: "a", sortKey: [] })).toThrow();
+		});
+	});
+
+	describe("boundary and needs-backfill", () => {
+		test("boundary is the Nth (last) entry, undefined when empty", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = new WindowIndex({ limit: 3, orderBy });
+			expect(index.boundary()).toBeUndefined();
+			index.insert({ id: "a", sortKey: [10] });
+			index.insert({ id: "b", sortKey: [20] });
+			expect(index.boundary()).toEqual({ id: "b", sortKey: [20] });
+		});
+
+		test("a full window does not need backfill", () => {
+			const index = buildIndex({ limit: 2 }, [
+				{ id: "a", sortKey: [] },
+				{ id: "b", sortKey: [] },
+			]);
+			expect(index.isFull).toBe(true);
+			expect(index.needsBackfill()).toBe(false);
+			expect(index.backfillCount).toBe(0);
+		});
+
+		test("removing a visible row from a full window signals backfill", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 3, orderBy }, [
+				{ id: "a", sortKey: [10] },
+				{ id: "b", sortKey: [20] },
+				{ id: "c", sortKey: [30] },
+			]);
+			const removed = index.remove("b");
+			expect(removed).toEqual({ id: "b", sortKey: [20] });
+			expect(index.ids()).toEqual(["a", "c"]);
+			expect(index.needsBackfill()).toBe(true);
+			expect(index.backfillCount).toBe(1);
+			expect(index.boundary()).toEqual({ id: "c", sortKey: [30] });
+		});
+
+		test("eviction keeps the window full (no backfill needed)", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 3, orderBy }, [
+				{ id: "a", sortKey: [10] },
+				{ id: "b", sortKey: [20] },
+				{ id: "c", sortKey: [30] },
+			]);
+			index.insert({ id: "d", sortKey: [5] });
+			expect(index.isFull).toBe(true);
+			expect(index.needsBackfill()).toBe(false);
+		});
+
+		test("removing an absent id is a no-op", () => {
+			const index = buildIndex({ limit: 3 }, [{ id: "a", sortKey: [] }]);
+			expect(index.remove("nope")).toBeUndefined();
+			expect(index.size).toBe(1);
+		});
+	});
+
+	describe("snapshot", () => {
+		test("snapshot returns a defensive copy", () => {
+			const orderBy: OrderBy = [{ key: "age", direction: "asc" }];
+			const index = buildIndex({ limit: 3, orderBy }, [
+				{ id: "a", sortKey: [10] },
+			]);
+			const snap = index.snapshot();
+			snap[0].sortKey[0] = 999;
+			expect(index.snapshot()).toEqual([{ id: "a", sortKey: [10] }]);
+		});
+	});
+});


### PR DESCRIPTION
## What

Adds a standalone `WindowIndex` module that maintains the in-memory ordering for a single windowed scope, per ADR-0003. It holds **only** `{ id, sortKey }` for the `N` visible rows — no overscan buffer, no row payloads.

Resolution: Closes #183

## Details

- **Total order is `[...orderBy, id]`** — `id` appended as a deterministic tiebreaker so the window boundary/cursor is unambiguous. A bare `limit` with no `orderBy` orders by `id` alone.
- **Composite / mixed asc-desc keys** compare correctly via an element-wise comparator (`null`/`undefined` sort first ascending; booleans as `false < true`); per-cell direction applied by negation.
- **API for the engine's membership-only broadcasts (no DB read in common cases):**
  - `insert(entry)` — binary-search insertion; when full, evicts and returns the displaced boundary entry if the new row sorts ahead, else rejects (`inserted: false`).
  - `remove(id)`, `position(id)`, `has(id)`, `boundary()` (Nth/cursor entry).
  - `needsBackfill()` / `backfillCount` — under-full signal after a shrink (the engine decides whether to issue a backfill read).
- Eviction is read-free (the displaced id comes from the index).

Intentionally **not yet wired into `QueryEngine`** — the issue scopes it as standalone-and-unit-tested first.

## Tests

18 unit tests covering ordering (single asc/desc, id tiebreaker, composite mixed asc/desc, null ordering, position), insert/eviction, and boundary/needs-backfill behavior.

## Verification

- `vitest` — 18/18 new tests pass; full suite green (no regressions)
- `pnpm typecheck --filter="./packages/*"` — clean
- `pnpm lint --filter="./packages/*" -- --diagnostic-level error` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added windowed query indexing with sorted insertion, boundary tracking, backfill status, and snapshot/ID listing support.
  * Added deterministic ordering for mixed sort directions, including stable tie-breaking by ID.

* **Bug Fixes**
  * Enforced validation for window limits and duplicate IDs.
  * Improved handling for empty, full, and zero-capacity windows, including eviction and removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->