### PR TITLE
fix(query-engine): re-apply nested include where in realtime matching

### DIFF
--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -947,7 +947,6 @@ export class QueryEngine {
 					if (!relatedObj) return { hash: queryNode.hash, matches: false };
 
 					const relatedObjNode = this.objectNodes.get(relatedObj);
-					// NEXT STEP understand why this is not true (matchedQueries)
 					if (
 						!relatedObjNode ||
 						!parentQuery ||
@@ -955,7 +954,9 @@ export class QueryEngine {
 					)
 						return { hash: queryNode.hash, matches: false };
 
-					return { hash: queryNode.hash, matches: true };
+					// Relation membership holds; fall through to re-apply the
+					// include's own `where` predicate so a related-but-filtered-out
+					// object is not broadcast to this query's subscribers (ADR-0003).
 				}
 
 				if (!where) {

--- a/packages/live-state/test/core/query-engine/nested-include-where.test.ts
+++ b/packages/live-state/test/core/query-engine/nested-include-where.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test for issue #184: child-relation matching must re-apply an
+ * `include`'s own `where` predicate, so a related-but-filtered-out object is
+ * not broadcast to that query's subscribers (ADR-0003).
+ */
+
+import { beforeEach, describe, expect, test } from "vitest";
+import { QueryEngine } from "../../../src/core/query-engine";
+import type { RawQueryRequest, SyncDelta } from "../../../src/core/schemas/core-protocol";
+import {
+	createRelations,
+	createSchema,
+	id,
+	object,
+	reference,
+	string,
+} from "../../../src/schema";
+import { Logger, LogLevel } from "../../../src/utils";
+
+const user = object("users", {
+	id: id(),
+	name: string(),
+});
+
+const post = object("posts", {
+	id: id(),
+	title: string(),
+	status: string(),
+	authorId: reference("users.id"),
+});
+
+const userRelations = createRelations(user, ({ many }) => ({
+	posts: many(post, "authorId"),
+}));
+
+const postRelations = createRelations(post, ({ one }) => ({
+	author: one(user, "authorId"),
+}));
+
+const schema = createSchema({
+	users: user,
+	posts: post,
+	userRelations,
+	postRelations,
+});
+
+/** Wrap a plain field value in the `{ value, _meta }` materialized shape. */
+const field = (value: unknown) => ({
+	value,
+	_meta: { timestamp: "2026-06-30T00:00:00.000Z" },
+});
+
+/** Materialize a plain object's own columns (no relations). */
+const materialize = (obj: Record<string, unknown>) => ({
+	value: Object.fromEntries(
+		Object.entries(obj).map(([k, v]) => [k, field(v)]),
+	),
+	_meta: { timestamp: "2026-06-30T00:00:00.000Z" },
+});
+
+describe("getMatchingQueries — nested include where (issue #184)", () => {
+	const query: RawQueryRequest = {
+		resource: "users",
+		include: { posts: { where: { status: "published" } } },
+	};
+
+	const userU1 = { id: "u1", name: "Alice" };
+	const publishedPost = {
+		id: "p1",
+		title: "Hello",
+		status: "published",
+		authorId: "u1",
+	};
+
+	let engine: QueryEngine;
+
+	beforeEach(async () => {
+		// Storage resolves the whole `include` tree in one query (ADR-0003): a
+		// user with only its published posts nested under `.posts`.
+		const storage = {
+			get: async () => [
+				{
+					...materialize(userU1),
+					value: {
+						...materialize(userU1).value,
+						posts: {
+							value: [materialize(publishedPost)],
+							_meta: { timestamp: "2026-06-30T00:00:00.000Z" },
+						},
+					},
+				},
+			],
+		};
+
+		engine = new QueryEngine({
+			storage,
+			schema,
+			logger: new Logger({ level: LogLevel.CRITICAL }),
+		});
+
+		engine.subscribe(query, () => {});
+		// Ingest the resolved tree so object nodes / relations / matched-query
+		// state are populated for realtime matching.
+		await engine.get(query);
+	});
+
+	const matchPost = (status: string) =>
+		engine.getMatchingQueries(
+			{
+				op: "UPDATE",
+				resource: "posts",
+				resourceId: "p1",
+				type: "SYNC",
+				payload: { status: field(status) },
+			} as SyncDelta,
+			{ ...publishedPost, status },
+		);
+
+	test("a related row satisfying the include's where matches", async () => {
+		expect(await matchPost("published")).toHaveLength(1);
+	});
+
+	test("a related row failing the include's where does NOT match", async () => {
+		// Relation membership still holds (p1 still authored by u1), but the
+		// include's `where: { status: 'published' }` no longer holds.
+		expect(await matchPost("draft")).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
Closes #184.

## Problem

Child-relation matching in `getMatchingQueries` (`packages/live-state/src/core/query-engine/index.ts`) returned a match as soon as relation *membership* held, and never looked at the `include`'s own `where`. So a related-but-filtered-out object could still be broadcast to a query's subscribers (the nested-where matching gap called out in ADR-0003).

## Fix

On membership success, the `relationName` branch now **falls through** to the existing shared `where`-application block below it — which already handles `!where` → match, non-relational `where` via `applyWhere`, and relational `where` via a `storage.get` fallback. A child step's `query.where` already carries the include's `where` (set in `buildSteps`), so this re-applies the include's predicate per object with no new machinery.

Scope routing in `handleMutation` already keys off `getMatchingQueries`, so a row that newly satisfies the predicate scopes in (`INSERT`) and one that stops satisfying it scopes out.

Also removed a stale `// NEXT STEP understand why...` comment that the fix resolves.

## Acceptance criteria

- [x] Child-relation matching re-applies the include's `where` predicate per object
- [x] A write to a related row that fails the include's `where` is NOT broadcast to that query's subscribers
- [x] A write that newly satisfies the include's `where` scopes in; one that stops satisfying it scopes out
- [x] Regression test covering a filtered include (related row toggling in/out of the predicate)

## Test

New `test/core/query-engine/nested-include-where.test.ts` drives `QueryEngine` directly with a `users.include({ posts: { where: { status: 'published' } } })` subscription, then toggles a related post's `status`:
- `published` → 1 matching query (scopes in)
- `draft` → 0 matching queries (relation membership still holds, but the include's `where` filters it out — not broadcast)

## Verification

- `pnpm test --filter="./packages/*"` — 825 passed, 0 failed
- `pnpm typecheck --filter="./packages/*"` — clean
- `pnpm lint --filter="./packages/*" -- --diagnostic-level error` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query matching so related records are only broadcast when they also satisfy their own filter conditions.
  * Corrected nested include handling to respect deeper filtering rules, preventing non-matching related items from appearing in subscribers’ updates.

* **Tests**
  * Added a regression test covering nested include filtering behavior to protect against this issue returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->