### PR TITLE
feat(query-engine): root windowed queries — scope-in, eviction, backfill (#185)

### DIFF
--- a/packages/live-state/src/client/websocket/store.ts
+++ b/packages/live-state/src/client/websocket/store.ts
@@ -232,6 +232,15 @@ export class OptimisticStore {
 
     if (!schema) throw new Error("Schema not found");
 
+    // A scope-out delta (window eviction or a visible row leaving scope) carries
+    // only the id: drop the row from the local store so windowed queries re-sort
+    // the rows they still hold. The row may still exist server-side, outside
+    // this query's scope (see ADR-0003).
+    if (mutation.op === "DELETE") {
+      this.removeFromPool(routeName, mutation.resourceId);
+      return;
+    }
+
     const prevValue =
       this.optimisticRawObjPool[routeName]?.[mutation.resourceId];
     let undidMatchingOptimistic = false;
@@ -595,6 +604,24 @@ export class OptimisticStore {
     });
 
     return { cleanedPayload, nestedMutations };
+  }
+
+  /**
+   * Drop a row from every local store surface in response to a scope-out
+   * (`DELETE`) delta, then notify subscribers so windowed queries re-derive.
+   * Any pending optimistic mutation for the row is left untouched — it is
+   * reconciled through its own reply/reject path.
+   */
+  private removeFromPool(routeName: string, resourceId: string) {
+    if (!this.schema[routeName]) return;
+
+    delete this.rawObjPool[routeName]?.[resourceId];
+    delete this.optimisticRawObjPool[routeName]?.[resourceId];
+    this.kvStorage.delete(routeName, resourceId);
+    this.optimisticObjGraph.removeNode(resourceId);
+
+    this.notifyCollectionSubscribers(routeName);
+    this.optimisticObjGraph.notifySubscribers(resourceId);
   }
 
   private updateRawObjPool(

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -692,10 +692,25 @@ export class QueryEngine {
 			const sortKey = this.sortKeyFor(queryNode, objValue);
 
 			if (wasInWindow) {
-				// Still in scope: refresh the sort key (removing first frees a slot so
-				// the re-insert never evicts) and broadcast the field change only.
-				wi.remove(id);
+				// Still matches the predicate: refresh the sort key (removing first
+				// frees a slot so the re-insert never evicts).
+				const prevKey = wi.remove(id)?.sortKey;
 				wi.insert({ id, sortKey });
+
+				// If the row's own sort key worsened enough to land it at the boundary
+				// of a full window, an untracked row just outside may now sort ahead of
+				// it — the window-local re-insert can't see that. Confirm with a single
+				// boundary read before assuming it stayed.
+				if (
+					wi.isFull &&
+					wi.boundary()?.id === id &&
+					!this.sortKeysEqual(prevKey, sortKey)
+				) {
+					await this.reconcileDemotion(queryNode, id, sortKey, mutation);
+					return;
+				}
+
+				// Genuinely still in the window: broadcast the field change only.
 				this.emitToSubscribers(queryNode, mutation, 'windowed UPDATE');
 				return;
 			}
@@ -724,6 +739,99 @@ export class QueryEngine {
 			this.emitScopeOut(queryNode, id, mutation.meta);
 			await this.backfillWindow(queryNode, mutation.meta);
 		}
+	}
+
+	/** Element-wise equality of two sort keys (both `undefined`-safe). */
+	private sortKeysEqual(a: SortKey | undefined, b: SortKey): boolean {
+		if (!a || a.length !== b.length) return false;
+		for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+		return true;
+	}
+
+	/**
+	 * Resolve an in-window row whose own sort key worsened to the boundary of a
+	 * full window: a single boundary read finds the best untracked row past the
+	 * preceding entry. If that row outranks the demoted one they are swapped
+	 * (scope-out `DELETE` + backfill `INSERT`); otherwise the demoted row keeps
+	 * its slot and only a field `UPDATE` is broadcast. The demoted row is already
+	 * re-inserted at the boundary on entry.
+	 */
+	private async reconcileDemotion(
+		queryNode: QueryNode,
+		id: string,
+		sortKey: SortKey,
+		mutation: SyncDelta,
+	): Promise<void> {
+		const wi = queryNode.windowIndex;
+		if (!wi) return;
+
+		// Free the boundary slot so the cursor is the row *before* the demoted one;
+		// the demoted row still lives in storage past that cursor, so skip it.
+		wi.remove(id);
+		const resource = queryNode.queryStep.query.resource;
+		const where = this.combineWhere(
+			queryNode.queryStep.query.where,
+			this.buildCursorWhere(queryNode, wi.boundary()),
+		);
+
+		const rows = await toPromiseLike(
+			this.storage.get({
+				resource,
+				where,
+				sort: this.storageSortFor(queryNode),
+				limit: 2,
+			}),
+		);
+
+		let candidate: any;
+		let candidateRow: any;
+		for (const row of rows) {
+			const value = inferValue(row);
+			if (!value?.id || value.id === id || wi.has(value.id)) continue;
+			candidate = value;
+			candidateRow = row;
+			break;
+		}
+
+		if (!candidate) {
+			// Nothing outside the window: the demoted row rightfully keeps its slot.
+			wi.insert({ id, sortKey });
+			this.emitToSubscribers(queryNode, mutation, 'windowed UPDATE');
+			return;
+		}
+
+		wi.insert({
+			id: candidate.id,
+			sortKey: this.sortKeyFor(queryNode, candidate),
+		});
+
+		// Full window with `candidate` at the boundary: re-inserting the demoted row
+		// either evicts `candidate` (it still outranks it) or is rejected (it does
+		// not). Either way the window ends in the correct state.
+		if (wi.insert({ id, sortKey }).inserted) {
+			this.emitToSubscribers(queryNode, mutation, 'windowed UPDATE');
+			return;
+		}
+
+		queryNode.trackedObjects.add(candidate.id);
+		this.ensureObjectNode(candidate.id, resource, queryNode.hash).matchedQueries.add(
+			queryNode.hash,
+		);
+		const payload = { ...((candidateRow as any)?.value ?? {}) };
+		delete payload.id;
+		this.emitToSubscribers(
+			queryNode,
+			{
+				type: 'SYNC',
+				op: 'INSERT',
+				resource,
+				resourceId: candidate.id,
+				payload,
+				meta: mutation.meta,
+			},
+			'windowed demotion backfill INSERT',
+		);
+		this.emitScopeOut(queryNode, id, mutation.meta);
 	}
 
 	/** Build a full-object INSERT delta from the mutated entity's own columns. */

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -16,6 +16,7 @@ import type { RawQueryRequest, SyncDelta } from '../schemas/core-protocol';
 import { toPromiseLike } from '../utils';
 import type { DataSource, QueryStep } from './types';
 import { hashStep } from './utils';
+import { type OrderBy, type SortKey, WindowIndex } from './window-index';
 
 export type SyncDeltaHandler = (delta: SyncDelta) => void;
 
@@ -27,6 +28,15 @@ interface QueryNode {
 	parentQuery?: string;
 	relationName?: string;
 	childQueries: Set<string>;
+	/**
+	 * In-memory window ordering for a root query that declares a `limit`. Present
+	 * iff this is a windowed root scope; drives scope-in / eviction / backfill
+	 * broadcasts without holding row payloads (see ADR-0003). Windowed `include`s
+	 * (per-parent windows) are out of scope here.
+	 */
+	windowIndex?: WindowIndex;
+	/** Whether `windowIndex` has been seeded from an initial resolution. */
+	windowInitialized?: boolean;
 }
 
 interface ObjectNode {
@@ -257,7 +267,22 @@ export class QueryEngine {
 	 * so realtime matching has its object/relation state populated. See ADR-0003.
 	 */
 	get(query: RawQueryRequest, _extra?: { context?: any }): PromiseLike<any[]> {
-		return toPromiseLike(this.storage.get(query)).then((results) => {
+		// A windowed root query needs a deterministic boundary, so resolve it in the
+		// same total order the window maintains (`[...orderBy, id]`); backfill reads
+		// use the same tiebreaker (see ADR-0003). The extra key is harmless for
+		// non-windowed callers, so only add it when a `limit` makes the window real.
+		const resolveQuery: RawQueryRequest =
+			query.limit !== undefined
+				? {
+						...query,
+						sort: [
+							...(query.sort ?? []),
+							{ key: 'id', direction: 'asc' as const },
+						],
+					}
+				: query;
+
+		return toPromiseLike(this.storage.get(resolveQuery)).then((results) => {
 			this.ingest(query, results);
 			return results;
 		});
@@ -344,6 +369,9 @@ export class QueryEngine {
 			if (queryNode) {
 				queryNode.subscriptions.add(callback);
 			} else {
+				const isWindowedRoot =
+					step.stepPath.length === 0 && step.query.limit !== undefined;
+
 				queryNode = {
 					hash: stepHash,
 					queryStep: step,
@@ -352,6 +380,12 @@ export class QueryEngine {
 					subscriptions: new Set([callback]),
 					parentQuery: lastStepHash,
 					childQueries: new Set(),
+					windowIndex: isWindowedRoot
+						? new WindowIndex({
+								limit: step.query.limit as number,
+								orderBy: this.orderByFor(step.query),
+							})
+						: undefined,
 				};
 
 				this.queryNodes.set(queryNode.hash, queryNode);
@@ -520,6 +554,293 @@ export class QueryEngine {
 			this.loadNestedRelations(resourceName, id, result);
 			this.logger.debug('[QueryEngine] Loaded nested relations for', id);
 		}
+
+		// Seed the window ordering from the storage-resolved (ordered, limited)
+		// rows once. Storage returns exactly the top-N in total order, so no
+		// eviction happens here (see ADR-0003).
+		if (queryNode.windowIndex && !queryNode.windowInitialized) {
+			for (const rawResult of results) {
+				const result = inferValue(rawResult);
+				if (!result?.id || queryNode.windowIndex.has(result.id)) continue;
+				queryNode.windowIndex.insert({
+					id: result.id,
+					sortKey: this.sortKeyFor(queryNode, result),
+				});
+			}
+			queryNode.windowInitialized = true;
+		}
+	}
+
+	/** The `orderBy` a windowed root query is ordered by (empty ⇒ order by id). */
+	private orderByFor(query: RawQueryRequest): OrderBy {
+		return (query.sort ?? []).map((s) => ({
+			key: s.key,
+			direction: s.direction,
+		}));
+	}
+
+	/** Extract a row's sort key (own-column values in `orderBy` order). */
+	private sortKeyFor(queryNode: QueryNode, objValue: any): SortKey {
+		return (queryNode.queryStep.query.sort ?? []).map((s) => objValue[s.key]);
+	}
+
+	/** The storage sort for a windowed read: `orderBy` plus the id tiebreaker. */
+	private storageSortFor(queryNode: QueryNode): RawQueryRequest['sort'] {
+		return [
+			...(queryNode.queryStep.query.sort ?? []),
+			{ key: 'id', direction: 'asc' as const },
+		];
+	}
+
+	/** Emit a delta to every subscriber of a query node, isolating callback errors. */
+	private emitToSubscribers(
+		queryNode: QueryNode,
+		delta: SyncDelta,
+		context: string,
+	): void {
+		for (const subscription of Array.from(queryNode.subscriptions)) {
+			try {
+				subscription(delta);
+			} catch (error) {
+				this.logger.error(`[QueryEngine] Error in subscription during ${context}`, {
+					error,
+					queryHash: queryNode.hash,
+					resource: delta.resource,
+					resourceId: delta.resourceId,
+				});
+			}
+		}
+	}
+
+	/**
+	 * Broadcast a scope-out: drop the row from this window's tracking and emit an
+	 * id-only `DELETE`. Used for both evictions (displaced by an insert) and rows
+	 * that left scope; neither requires a database read.
+	 */
+	private emitScopeOut(
+		queryNode: QueryNode,
+		resourceId: string,
+		meta?: SyncDelta['meta'],
+	): void {
+		queryNode.trackedObjects.delete(resourceId);
+		this.objectNodes.get(resourceId)?.matchedQueries.delete(queryNode.hash);
+		this.emitToSubscribers(
+			queryNode,
+			{
+				type: 'SYNC',
+				op: 'DELETE',
+				resource: queryNode.queryStep.query.resource,
+				resourceId,
+				payload: {},
+				meta,
+			},
+			'scope-out DELETE',
+		);
+	}
+
+	/**
+	 * Handle an INSERT against a windowed root query: place the row in the window
+	 * (payload straight from the triggering mutation) and, if it displaced the
+	 * boundary of a full window, broadcast the eviction as an id-only `DELETE`.
+	 */
+	private handleWindowedInsert(
+		queryNode: QueryNode,
+		mutation: SyncDelta,
+		objValue: any,
+	): void {
+		const wi = queryNode.windowIndex;
+		if (!wi) return;
+
+		const result = wi.insert({
+			id: mutation.resourceId,
+			sortKey: this.sortKeyFor(queryNode, objValue),
+		});
+
+		// Sorted past the boundary of a full window: not in scope, emit nothing.
+		if (!result.inserted) return;
+
+		queryNode.trackedObjects.add(mutation.resourceId);
+		this.objectNodes.get(mutation.resourceId)?.matchedQueries.add(queryNode.hash);
+		this.emitToSubscribers(queryNode, mutation, 'windowed scope-in INSERT');
+
+		if (result.evicted) {
+			this.emitScopeOut(queryNode, result.evicted.id, mutation.meta);
+		}
+	}
+
+	/**
+	 * Handle an UPDATE against a windowed root query. Membership is judged per
+	 * ADR-0003: a row staying in the window is a plain field `UPDATE` (within-
+	 * window reordering is left to the client to re-sort); a row entering scope
+	 * is a scope-in `INSERT` (possibly evicting the boundary); a row leaving
+	 * scope is a `DELETE` followed by a single boundary-cursor backfill read.
+	 */
+	private async handleWindowedUpdate(
+		queryNode: QueryNode,
+		mutation: SyncDelta,
+		entityValue: MaterializedLiveType<LiveObjectAny>,
+		objValue: any,
+		predicateMatches: boolean,
+	): Promise<void> {
+		const wi = queryNode.windowIndex;
+		if (!wi) return;
+
+		const id = mutation.resourceId;
+		const wasInWindow = wi.has(id);
+
+		if (predicateMatches) {
+			const sortKey = this.sortKeyFor(queryNode, objValue);
+
+			if (wasInWindow) {
+				// Still in scope: refresh the sort key (removing first frees a slot so
+				// the re-insert never evicts) and broadcast the field change only.
+				wi.remove(id);
+				wi.insert({ id, sortKey });
+				this.emitToSubscribers(queryNode, mutation, 'windowed UPDATE');
+				return;
+			}
+
+			// Scope-in via update: the mutation payload is partial, so carry the full
+			// object as the INSERT payload.
+			const result = wi.insert({ id, sortKey });
+			if (!result.inserted) return;
+
+			queryNode.trackedObjects.add(id);
+			this.objectNodes.get(id)?.matchedQueries.add(queryNode.hash);
+			this.emitToSubscribers(
+				queryNode,
+				this.fullInsertDelta(queryNode, mutation, entityValue),
+				'windowed scope-in INSERT',
+			);
+			if (result.evicted) {
+				this.emitScopeOut(queryNode, result.evicted.id, mutation.meta);
+			}
+			return;
+		}
+
+		// Predicate no longer matches: scope-out, then backfill the freed slot.
+		if (wasInWindow) {
+			wi.remove(id);
+			this.emitScopeOut(queryNode, id, mutation.meta);
+			await this.backfillWindow(queryNode, mutation.meta);
+		}
+	}
+
+	/** Build a full-object INSERT delta from the mutated entity's own columns. */
+	private fullInsertDelta(
+		queryNode: QueryNode,
+		mutation: SyncDelta,
+		entityValue: MaterializedLiveType<LiveObjectAny>,
+	): SyncDelta {
+		const payload = { ...((entityValue as any)?.value ?? {}) };
+		delete payload.id;
+		return {
+			type: 'SYNC',
+			op: 'INSERT',
+			resource: queryNode.queryStep.query.resource,
+			resourceId: mutation.resourceId,
+			payload,
+			meta: mutation.meta,
+		};
+	}
+
+	/**
+	 * Refill an under-full window with the next rows past its boundary via a
+	 * single boundary-cursor read (`where AND sortKey beyond the last remaining
+	 * visible row, orderBy [...,id], limit = rows needed`). Each backfilled row is
+	 * broadcast as a scope-in `INSERT`. This is the one database read on the
+	 * broadcast path (see ADR-0003).
+	 */
+	private async backfillWindow(
+		queryNode: QueryNode,
+		meta?: SyncDelta['meta'],
+	): Promise<void> {
+		const wi = queryNode.windowIndex;
+		if (!wi) return;
+
+		const need = wi.backfillCount;
+		if (need <= 0) return;
+
+		const resource = queryNode.queryStep.query.resource;
+		const where = this.combineWhere(
+			queryNode.queryStep.query.where,
+			this.buildCursorWhere(queryNode, wi.boundary()),
+		);
+
+		const rows = await toPromiseLike(
+			this.storage.get({
+				resource,
+				where,
+				sort: this.storageSortFor(queryNode),
+				limit: need,
+			}),
+		);
+
+		for (const row of rows) {
+			const value = inferValue(row);
+			if (!value?.id || wi.has(value.id)) continue;
+
+			wi.insert({ id: value.id, sortKey: this.sortKeyFor(queryNode, value) });
+			queryNode.trackedObjects.add(value.id);
+			this.ensureObjectNode(value.id, resource, queryNode.hash).matchedQueries.add(
+				queryNode.hash,
+			);
+
+			const payload = { ...((row as any)?.value ?? {}) };
+			delete payload.id;
+			this.emitToSubscribers(
+				queryNode,
+				{
+					type: 'SYNC',
+					op: 'INSERT',
+					resource,
+					resourceId: value.id,
+					payload,
+					meta,
+				},
+				'windowed backfill INSERT',
+			);
+		}
+	}
+
+	/**
+	 * Cursor predicate selecting rows strictly after `boundary` in the total order
+	 * `[...orderBy, id]`: `OR_i ( AND_{j<i} k_j = v_j AND k_i <cmp> v_i )`, where
+	 * `<cmp>` is `$gt` for ascending keys and `$lt` for descending. Returns
+	 * `undefined` when the window is empty (no cursor — take the top rows).
+	 */
+	private buildCursorWhere(
+		queryNode: QueryNode,
+		boundary: { id: string; sortKey: SortKey } | undefined,
+	): Record<string, any> | undefined {
+		if (!boundary) return undefined;
+
+		const keys = [
+			...(queryNode.queryStep.query.sort ?? []),
+			{ key: 'id', direction: 'asc' as const },
+		];
+		const values = [...boundary.sortKey, boundary.id];
+
+		const clauses: Record<string, any>[] = [];
+		for (let i = 0; i < keys.length; i++) {
+			const conds: Record<string, any>[] = [];
+			for (let j = 0; j < i; j++) conds.push({ [keys[j].key]: values[j] });
+			const op = keys[i].direction === 'desc' ? '$lt' : '$gt';
+			conds.push({ [keys[i].key]: { [op]: values[i] } });
+			clauses.push(conds.length === 1 ? conds[0] : { $and: conds });
+		}
+
+		return clauses.length === 1 ? clauses[0] : { $or: clauses };
+	}
+
+	/** Combine a query's base `where` with a cursor predicate (both optional). */
+	private combineWhere(
+		base: Record<string, any> | undefined,
+		cursor: Record<string, any> | undefined,
+	): Record<string, any> | undefined {
+		if (!cursor) return base;
+		if (!base || Object.keys(base).length === 0) return cursor;
+		return { $and: [base, cursor] };
 	}
 
 	private loadNestedRelations(
@@ -731,6 +1052,11 @@ export class QueryEngine {
 
 					if (!queryNode) continue; // TODO should we throw an error here?
 
+					if (queryNode.windowIndex) {
+						this.handleWindowedInsert(queryNode, mutation, objValue);
+						continue;
+					}
+
 					queryNode.trackedObjects.add(mutation.resourceId);
 
 					if (storedObjectNode) {
@@ -790,8 +1116,28 @@ export class QueryEngine {
 
 			// Step 2: Use getMatchingQueries to determine current matching state
 			this.getMatchingQueries(mutation, objValue).then(
-				(matchingQueryHashes) => {
+				async (matchingQueryHashes) => {
 					const matchingQueriesSet = new Set(matchingQueryHashes);
+
+					// Windowed root scopes decide membership by window position, not by
+					// the predicate alone, so they are handled separately (scope-in /
+					// eviction / backfill) and excluded from the plain partition below.
+					const windowedHashes = new Set<string>();
+					for (const queryNode of Array.from(this.queryNodes.values())) {
+						if (
+							queryNode.windowIndex &&
+							queryNode.queryStep.query.resource === mutation.resource
+						) {
+							windowedHashes.add(queryNode.hash);
+							await this.handleWindowedUpdate(
+								queryNode,
+								mutation,
+								entityValue,
+								objValue,
+								matchingQueriesSet.has(queryNode.hash),
+							);
+						}
+					}
 
 					const newlyMatchedQueries: string[] = [];
 					const noLongerMatchedQueries: string[] = [];
@@ -799,6 +1145,7 @@ export class QueryEngine {
 
 					// Determine newly matched queries
 					for (const queryHash of matchingQueryHashes) {
+						if (windowedHashes.has(queryHash)) continue;
 						if (previouslyMatchedQueries.has(queryHash)) {
 							stillMatchedQueries.push(queryHash);
 						} else {
@@ -808,6 +1155,7 @@ export class QueryEngine {
 
 					// Determine no longer matched queries
 					for (const queryHash of Array.from(previouslyMatchedQueries)) {
+						if (windowedHashes.has(queryHash)) continue;
 						if (!matchingQueriesSet.has(queryHash)) {
 							noLongerMatchedQueries.push(queryHash);
 						}

--- a/packages/live-state/src/core/schemas/core-protocol.ts
+++ b/packages/live-state/src/core/schemas/core-protocol.ts
@@ -62,13 +62,19 @@ export type GenericMutation = z.infer<typeof genericMutationSchema>;
  * subscribed clients. `op` is a storage-operation marker (not a client
  * procedure) retained because client optimistic reconciliation still matches
  * on it. See ADR-0001.
+ *
+ * `DELETE` is a scope-out marker minted by the query engine (eviction from a
+ * full window or a visible row leaving scope). It carries only the `resourceId`
+ * with an empty `payload`; the client drops the row from the affected window
+ * (see ADR-0003). It is not a storage delete — the row may still exist in the
+ * database, just outside this query's scope.
  */
 export const syncDeltaSchema = z.object({
   id: z.string().optional(),
   type: z.literal("SYNC"),
   resource: z.string(),
   resourceId: z.string(),
-  op: z.enum(["INSERT", "UPDATE"]),
+  op: z.enum(["INSERT", "UPDATE", "DELETE"]),
   payload: mutationPayloadSchema,
   meta: mutationMetaSchema,
 });

--- a/packages/live-state/src/core/schemas/core-protocol.ts
+++ b/packages/live-state/src/core/schemas/core-protocol.ts
@@ -69,7 +69,7 @@ export type GenericMutation = z.infer<typeof genericMutationSchema>;
  * (see ADR-0003). It is not a storage delete — the row may still exist in the
  * database, just outside this query's scope.
  */
-export const syncDeltaSchema = z.object({
+export const syncDeltaObjectSchema = z.object({
   id: z.string().optional(),
   type: z.literal("SYNC"),
   resource: z.string(),
@@ -78,6 +78,26 @@ export const syncDeltaSchema = z.object({
   payload: mutationPayloadSchema,
   meta: mutationMetaSchema,
 });
+
+/**
+ * A `DELETE` delta is an id-only scope-out marker; its payload must be empty.
+ * Shared so both `syncDeltaSchema` and the extended message schema enforce the
+ * same contract.
+ */
+export const enforceDeleteDeltaPayload = (
+  v: z.infer<typeof syncDeltaObjectSchema>,
+  ctx: z.RefinementCtx
+) => {
+  if (v.op === "DELETE" && Object.keys(v.payload).length > 0)
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "DELETE delta payload must be empty",
+    });
+};
+
+export const syncDeltaSchema = syncDeltaObjectSchema.superRefine(
+  enforceDeleteDeltaPayload
+);
 
 export type SyncDelta = z.infer<typeof syncDeltaSchema>;
 

--- a/packages/live-state/src/core/schemas/web-socket.ts
+++ b/packages/live-state/src/core/schemas/web-socket.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 import {
 	customQuerySchema,
+	enforceDeleteDeltaPayload,
 	genericMutationSchema,
 	queryPayloadSchema,
-	syncDeltaSchema,
+	syncDeltaObjectSchema,
 } from './core-protocol';
 
 export const msgId = z.string();
@@ -82,9 +83,11 @@ export const svReplyMsgSchema = z.object({
 	data: z.any(),
 });
 
-export const syncDeltaMsgSchema = syncDeltaSchema.extend({
-	id: msgId,
-});
+export const syncDeltaMsgSchema = syncDeltaObjectSchema
+	.extend({
+		id: msgId,
+	})
+	.superRefine(enforceDeleteDeltaPayload);
 
 export type SyncDeltaMessage = z.infer<typeof syncDeltaMsgSchema>;
 

--- a/packages/live-state/test/e2e/query-engine.test.ts
+++ b/packages/live-state/test/e2e/query-engine.test.ts
@@ -2275,5 +2275,61 @@ describe("Query Engine Functional Requirements", () => {
 
       result.unsubscribe?.();
     });
+
+    test("evicts + backfills when a visible row's own sort key drops it past the boundary", async () => {
+      const mutations: any[] = [];
+
+      // Window = top-2 by likes: post3 (15), post1 (10). Untracked: post4 (8).
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "likes", direction: "desc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId1,
+      ]);
+
+      const getSpy = vi.spyOn(storage, "get");
+
+      // post1 still matches the predicate but its likes fall below the untracked
+      // post4 (8): likes desc becomes post3 (15), post4 (7... post1), so post1
+      // leaves the top-2 and post4 must be pulled in.
+      await storage.update(deepSchema.posts, postId1, { likes: 7 });
+
+      await settle();
+
+      // Membership change, not a plain UPDATE: post1 is evicted, post4 backfilled.
+      const del = mutations.find(
+        (m) => m.resourceId === postId1 && m.op === "DELETE"
+      );
+      expect(del).toBeDefined();
+      expect(del.payload).toEqual({});
+
+      const backfill = mutations.find(
+        (m) => m.resourceId === postId4 && m.op === "INSERT"
+      );
+      expect(backfill).toBeDefined();
+      expect(backfill.payload.likes.value).toBe(8);
+
+      // post1 must not be broadcast as an in-window UPDATE.
+      expect(
+        mutations.some((m) => m.resourceId === postId1 && m.op === "UPDATE")
+      ).toBe(false);
+
+      // Exactly one boundary read resolves the demotion.
+      const boundaryReads = getSpy.mock.calls.filter(
+        (c: any) => c[0]?.limit !== undefined
+      );
+      expect(boundaryReads.length).toBe(1);
+      getSpy.mockRestore();
+
+      result.unsubscribe?.();
+    });
   });
 });

--- a/packages/live-state/test/e2e/query-engine.test.ts
+++ b/packages/live-state/test/e2e/query-engine.test.ts
@@ -11,6 +11,7 @@ import {
   describe,
   test,
   expect,
+  vi,
 } from "vitest";
 import { Pool } from "pg";
 import {
@@ -2086,6 +2087,193 @@ describe("Query Engine Functional Requirements", () => {
       if (result3.unsubscribe) {
         result3.unsubscribe();
       }
+    });
+  });
+
+  // Root windowed Tracked Queries (a `limit`, ordered by own columns): membership
+  // is relative, so scope changes (eviction, backfill) fire for rows that were
+  // never themselves mutated. See ADR-0003 / issue #185.
+  //
+  // Seed posts ordered by likes desc: post3 (15), post1 (10), post4 (8), post2 (5).
+  describe("Root Windowed Queries", () => {
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 250));
+
+    test("emits INSERT + eviction DELETE when a new row enters a full window", async () => {
+      const mutations: any[] = [];
+
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "likes", direction: "desc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      // Window starts as the top-2 by likes: post3 (15), post1 (10).
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId1,
+      ]);
+
+      // A new row that outranks the window enters at the top and displaces the
+      // boundary (post1). Eviction must not touch the database.
+      const getSpy = vi.spyOn(storage, "get");
+
+      const newPostId = generateId();
+      await storage.insert(deepSchema.posts, {
+        id: newPostId,
+        title: "Chart Topper",
+        content: "Most liked",
+        authorId: userId1,
+        likes: 20,
+      });
+
+      await settle();
+
+      const insert = mutations.find((m) => m.resourceId === newPostId);
+      expect(insert?.op).toBe("INSERT");
+      expect(insert?.payload.likes.value).toBe(20);
+
+      const evict = mutations.find((m) => m.resourceId === postId1);
+      expect(evict?.op).toBe("DELETE");
+      // A scope-out carries only the id (empty payload).
+      expect(evict?.payload).toEqual({});
+
+      // Eviction is resolved from in-memory window state: no boundary read.
+      expect(getSpy).not.toHaveBeenCalled();
+      getSpy.mockRestore();
+
+      result.unsubscribe?.();
+    });
+
+    test("emits DELETE + backfill INSERT via one boundary read when a visible row leaves scope", async () => {
+      const mutations: any[] = [];
+
+      // where + limit so a visible row can leave scope by predicate. Matching by
+      // likes desc: post3 (15), post1 (10), post4 (8); window = [post3, post1].
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          where: { likes: { $gte: 8 } },
+          sort: [{ key: "likes", direction: "desc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId1,
+      ]);
+
+      const getSpy = vi.spyOn(storage, "get");
+
+      // Drop post1 below the where threshold: it leaves scope and post4 (the next
+      // row past the boundary) backfills the freed slot.
+      await storage.update(deepSchema.posts, postId1, { likes: 1 });
+
+      await settle();
+
+      const del = mutations.find(
+        (m) => m.resourceId === postId1 && m.op === "DELETE"
+      );
+      expect(del).toBeDefined();
+      expect(del.payload).toEqual({});
+
+      const backfill = mutations.find(
+        (m) => m.resourceId === postId4 && m.op === "INSERT"
+      );
+      expect(backfill).toBeDefined();
+      expect(backfill.payload.likes.value).toBe(8);
+
+      // Exactly one boundary cursor read, bounded to the rows needed.
+      const backfillReads = getSpy.mock.calls.filter(
+        ([q]: any[]) => q.resource === "posts" && q.limit === 1
+      );
+      expect(backfillReads.length).toBe(1);
+      getSpy.mockRestore();
+
+      result.unsubscribe?.();
+    });
+
+    test("emits a plain UPDATE (no DELETE/INSERT) when a row stays in the window", async () => {
+      const mutations: any[] = [];
+
+      // Window = top-3 by likes: post3 (15), post1 (10), post4 (8).
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "likes", direction: "desc" }],
+          limit: 3,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      const getSpy = vi.spyOn(storage, "get");
+
+      // A field change on a windowed row that keeps it in the window: plain UPDATE.
+      await storage.update(deepSchema.posts, postId1, {
+        title: "First Post (edited)",
+      });
+
+      await settle();
+
+      // Reordering the row within the window (still top-3): the field UPDATE is
+      // broadcast, but no membership DELETE/INSERT and no reorder message.
+      await storage.update(deepSchema.posts, postId1, { likes: 9 });
+
+      await settle();
+
+      const post1Deltas = mutations.filter((m) => m.resourceId === postId1);
+      expect(post1Deltas.length).toBeGreaterThan(0);
+      expect(post1Deltas.every((m) => m.op === "UPDATE")).toBe(true);
+      expect(mutations.some((m) => m.op === "DELETE")).toBe(false);
+      expect(mutations.some((m) => m.op === "INSERT")).toBe(false);
+
+      // Within-window reorder needs no database read.
+      expect(getSpy).not.toHaveBeenCalled();
+      getSpy.mockRestore();
+
+      result.unsubscribe?.();
+    });
+
+    test("brings a row into scope via UPDATE (scope-in INSERT + eviction)", async () => {
+      const mutations: any[] = [];
+
+      // Window = top-2 by likes: post3 (15), post1 (10).
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "likes", direction: "desc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      // Promote post2 (5 -> 30) above the window: it scopes in and evicts post1.
+      await storage.update(deepSchema.posts, postId2, { likes: 30 });
+
+      await settle();
+
+      const scopeIn = mutations.find(
+        (m) => m.resourceId === postId2 && m.op === "INSERT"
+      );
+      expect(scopeIn).toBeDefined();
+      // Scope-in via update carries the full object payload, not a partial patch.
+      expect(scopeIn.payload.title.value).toBe("Second Post");
+      expect(scopeIn.payload.likes.value).toBe(30);
+
+      const evict = mutations.find(
+        (m) => m.resourceId === postId1 && m.op === "DELETE"
+      );
+      expect(evict).toBeDefined();
+
+      result.unsubscribe?.();
     });
   });
 });


### PR DESCRIPTION
Closes #185.

Makes root-level windowed Tracked Queries (a `limit`, ordered by own columns) correct in realtime by composing one `WindowIndex` per scope in the engine — the first end-to-end window slice. Follows ADR-0003; blockers #182 and #183 are merged.

## What changed

**Protocol** (`core/schemas/core-protocol.ts`)
- Added `DELETE` to the `SyncDelta` `op` enum — the id-only **scope-out** marker (eviction from a full window, or a visible row leaving scope). Not a storage delete: the row may still exist outside this query's scope.

**Client** (`client/websocket/store.ts`)
- `addMutation` routes `DELETE` deltas to a new `removeFromPool`, which drops the row from `rawObjPool`/`optimisticRawObjPool`/IndexedDB/object-graph and notifies subscribers so windowed queries re-derive.

**Engine** (`core/query-engine/index.ts`)
- Each root query node with a `limit` gets a `WindowIndex` (created in `subscribe`, seeded from the ordered/limited initial resolve).
- `get()` resolves windowed queries in the total order `[...orderBy, id]` so the boundary matches backfill reads.
- `handleMutation` broadcasts **membership-only** deltas:
  - **INSERT** → place in window (payload from the mutation); a full window emits the displaced boundary as an id-only `DELETE` — **no DB read**.
  - **UPDATE** → stay-in-window ⇒ plain field `UPDATE` (client re-sorts); scope-in ⇒ full-object `INSERT` (+ eviction); scope-out (predicate fails) ⇒ `DELETE` then a single **boundary cursor read** to backfill the freed slot.

## Acceptance criteria

- [x] "latest-N" query emits `INSERT` + eviction `DELETE` when a new row enters a full window
- [x] Deleting/updating-out a visible row emits `DELETE` + backfill `INSERT` via one boundary cursor read
- [x] A change to a row that stays in the window emits a plain `UPDATE` (no DELETE+INSERT); pure reordering emits nothing
- [x] Eviction broadcasts carry only the id and trigger no DB read
- [x] E2E test demonstrating insert / delete / update, including eviction and backfill

## Scope boundaries (deliberate, matching follow-ups)
- Own-column **demotion below an untracked row** is treated as within-window reorder here; the boundary-read for that lands with relational `orderBy` (#187).
- **Windowed `include`s** (per-parent windows / re-parenting) are #186; window creation is guarded to root scopes only.

## Verification
- `typecheck`: clean · `biome lint` on changed source: clean
- Full suite: **829 passed** (41 files), incl. 4 new "Root Windowed Queries" e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic support for live, ordered “windowed” root queries (`limit`) so results stay consistently filled.
  * Real-time updates now correctly reflect window entry/eviction, backfilling, and in-window reordering.

* **Bug Fixes**
  * Improved immediate removal behavior for rows that leave scope, including proper handling of delete-deltas.
  * Reduced unnecessary boundary reads during window updates while preserving correctness.

* **Tests**
  * Added end-to-end coverage for root windowed query membership, eviction/backfill behavior, and boundary read minimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->