### PR TITLE
feat(query-engine): windowed includes — per-parent windows and re-parenting (#186)

### DIFF
--- a/.agents/skills/grilling/SKILL.md
+++ b/.agents/skills/grilling/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grilling
+description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/.claude/skills/grilling
+++ b/.claude/skills/grilling
@@ -1,0 +1,1 @@
+../../.agents/skills/grilling

--- a/API_DESIGN_V3.md
+++ b/API_DESIGN_V3.md
@@ -1,0 +1,532 @@
+To Do:
+
+- [x] Lifecycle functions
+- [ ] Client-side optimistic mutations for custom mutations
+- [x] Typed Context
+
+
+# Routers:
+
+A `Router` is the collection of `Routes`.
+
+`Routes` are the collection of `Mutations` and `Queries`.
+
+## Differences from V2
+
+- Routes are no longer tied to an `Entity`.
+- Routes are seeing a major simplification in the syntax.
+- We no longer have authorization handlers, authorization is now handled inside the procedures handlers.
+- We no longer have "default" procedures, we now have procedures that are explicitly defined. (Except for the legacy routes that are tied to an `Entity`. But are now deprecated.)
+
+
+## Similarities to V2
+
+- Routes still have access to the `Context`. Provided by the `ContextProvider` (Server).
+- Routes still have `Middleware`s. Created on the route itself or on a router factory.
+
+**Examples**
+
+This is an example of a `Router` declaration:
+
+```typescript
+const router = router({
+  routes: {
+    // This is a legacy route that is tied to an `Entity`.
+    users: routeFactory().collectionRoute(schema.users),
+    // This is a new route that is not tied to an `Entity`.
+    // Note that it's called withProcedures instead of withMutations
+    posts: routeFactory().withProcedures(({ query, mutation }) => ({
+      find: query(z.object({
+        limit: z.number().optional(),
+        offset: z.number().optional(),
+      })).handler(async ({ req, db, ctx }) => {
+        // Use the database to get the user
+        // This is NOT the query that will be tracked by the query engine and sent to the client.
+        // Major difference from V2: uses a syntax identical to client-side queries.
+        const user = await db.users.first({id: ctx.user.id}).get();
+
+        // Returns a unresolved query (no .get() called)
+        // This is the query that will be tracked by the query engine and sent to the client.
+        return db.posts.where({ authorId: user.id }).limit(req.input.limit).offset(req.input.offset);
+      }),
+      insert: mutation(z.object({
+        title: z.string(),
+        content: z.string(),
+      })).handler(async ({ req, db }) => {
+        // Difference from V2: uses the same syntax as client-side mutations.
+        // It will internally handle the conflict resolution and propagation of the new record via the query engine.
+        return db.posts.insert(req.input);
+      }),
+    })),
+  },
+});
+```
+
+# Query Builder API:
+
+The Query Builder provides a fluent, chainable API for constructing queries on both the client and server side. It supports filtering, sorting, limiting, and including related entities.
+
+## Basic Methods
+
+- `.where(conditions)` - Filter records by conditions
+- `.limit(n)` - Limit the number of results
+- `.orderBy(key, direction)` - Sort results by a field
+- `.first(where?)` - Get the first matching record
+- `.one(id)` - Get a record by ID (shorthand for `.first({ id })`)
+- `.get()` - Execute the query and return results
+- `.subscribe(callback)` - Subscribe to real-time updates
+
+## Including Relations
+
+### Deprecated: Simple Object-based `.include()`
+
+The simple object-based `.include()` syntax with boolean values is **deprecated** and will be removed in a future version:
+
+```typescript
+// ❌ DEPRECATED - Simple object-based include
+const users = await db.users
+  .include({ 
+    posts: true,
+    profile: {
+      avatar: true 
+    }
+  })
+  .get();
+```
+
+### New: Sub-query `.include()`
+
+Use sub-queries in `.include()` for more flexibility. Instead of just passing `true`, pass a query object that supports all query methods:
+
+```typescript
+// ✅ NEW - Sub-query include
+const users = await db.users
+  .include({ 
+    posts: {
+      where: { published: true },
+      limit: 10,
+      orderBy: [{ key: 'createdAt', direction: 'desc' }],
+      include: {
+        author: true, // Simple include (no specific conditions)
+      },
+    },
+    profile: {
+      where: { avatar: true },
+    },
+    comments: {
+      where: { approved: true },
+    },
+  })
+  .get();
+```
+
+
+### Migration Example
+
+```typescript
+// Old (deprecated)
+const oldQuery = db.users
+  .include({ 
+    posts: true,
+    comments: {
+      author: true
+    }
+  })
+  .get();
+
+// New (recommended)
+const newQuery = db.users
+  .include({ 
+    posts: {
+      include: {
+        comments: {
+          include: {
+            author: true,
+          },
+        },
+      },
+    }
+  })
+  .get();
+```
+
+# Client-Side Optimistic Mutations for Custom Mutations
+
+Currently, built-in mutations (`insert` and `update`) automatically provide optimistic updates when using the WebSocket client. Custom mutations do not have this capability. This section documents the API design for adding optimistic mutation support for custom mutations.
+
+## Requirements
+
+1. **Declaration-Based**: Optimistic mutations must be declared once, upfront, similar to how server mutations are declared on the router
+2. **Client-Side Only**: Declarations must be client-side only - clients can only import server types, not server code
+3. **Automatic Reversibility**: Optimistic mutations must be automatically undo-able without requiring extra code from developers
+4. **API Consistency**: The API should follow similar patterns to existing live-state APIs
+
+## Current Behavior
+
+- Built-in mutations (`insert`/`update`) automatically apply optimistic updates
+- Custom mutations (`store.mutate.routeName.customMethod()`) do not apply optimistic updates
+- When a mutation is rejected, the system automatically reverts optimistic updates by restoring previous state
+- Server mutations are declared on the router using `routeFactory().withProcedures()`
+- Clients receive router types (not code) and use them for type inference
+
+---
+
+## Optimistic Mutations API
+
+This API design uses a builder pattern that provides storage operations scoped under a handler function. Operations are registered in a registry rather than being returned.
+
+### API Design
+
+```typescript
+// client.ts - Client-side only
+import type { Router } from "./server/router"; // Only importing types
+import { createClient } from "@live-state/sync/client";
+import { defineOptimisticMutations } from "@live-state/sync/client/optimistic";
+import { schema } from "./schema";
+
+// Declare optimistic mutations using builder
+const optimisticMutations = defineOptimisticMutations<Router>({
+  routes: {
+    posts: {
+      incrementLikes: ({ input, storage }) => {
+        // Query current state using storage API
+        const currentPost = storage.posts.one(input.postId).get();
+        
+        // Register update operation (no return - operations are registered in handler's registry)
+        storage.posts.update(input.postId, {
+          likes: currentPost.likes + 1,
+        });
+      },
+      createPost: ({ input, storage }) => {
+        const tempId = generateId();
+        
+        // Register insert operation
+        storage.posts.insert({
+          id: tempId,
+          title: input.title,
+          content: input.content,
+          likes: 0,
+        });
+      },
+      transferOwnership: ({ input, storage }) => {
+        const currentPost = storage.posts.one(input.postId).get();
+        const currentOwner = storage.users.one(currentPost.ownerId).get();
+        const newOwner = storage.users.one(input.newOwnerId).get();
+        
+        // Register multiple update operations
+        storage.posts.update(input.postId, {
+          ownerId: input.newOwnerId,
+        });
+        storage.users.update(input.newOwnerId, {
+          postCount: newOwner.postCount + 1,
+        });
+        storage.users.update(currentPost.ownerId, {
+          postCount: currentOwner.postCount - 1,
+        });
+      },
+      deletePost: ({ input, storage }) => {
+        // Register delete operation
+        storage.posts.delete(input.postId);
+      },
+      findPosts: ({ input, storage }) => {
+        // Query operations use the same storage API
+        const posts = storage.posts
+          .where({ authorId: input.authorId })
+          .limit(input.limit)
+          .get();
+        
+        // Register updates based on query results
+        posts.forEach((post) => {
+          storage.posts.update(post.id, {
+            views: post.views + 1,
+          });
+        });
+      },
+    },
+  },
+});
+
+// Create client with optimistic mutations
+const { store } = createClient<Router>({
+  url: "ws://localhost:5001/ws",
+  schema,
+  optimisticMutations,
+});
+
+// Usage - mutations automatically apply optimistic updates
+await store.mutate.posts.incrementLikes({ postId: "post-123" });
+```
+
+### Implementation Notes
+
+- `defineOptimisticMutations<TRouter>()` creates a registry of operations that are executed when the mutation is applied.
+- `storage` provides typed access to collections (e.g., `storage.posts`, `storage.users`)
+- Query operations use the same API: `storage.posts.where({...}).get()`
+- Mutation operations register themselves in the handler's internal stack of operations that are executed when the mutation is applied. No return needed.
+- Operations are automatically reversible based on type
+- All operations are type-safe and inferred from router types
+- Query operations resolve state at mutation execution time
+
+### Pros
+
+- Clean builder API with storage operations scoped under handler
+- Type-safe operations with full inference from router types
+- No circular dependencies (handler resolves at execution time)
+- Consistent API: queries and mutations use the same `storage.[collection]` pattern
+- Clear, readable syntax that mirrors server-side storage API
+- Operations registered in registry rather than returned, making the intent clear
+
+### Cons
+
+- Requires new builder API
+- The registry needs to track operations for reversibility
+
+# Lifecycle Hooks (Server)
+
+Collection routes are deprecated; lifecycle hooks are **no longer declared on routes**. They are registered in a **central hook registry** keyed by **schema entity names** (the same keys used for `db.posts`, optimistic mutations, and router route names where applicable). This keeps one mental model: “hooks for `posts`,” not “hooks on the `posts` route object.”
+
+## Requirements
+
+1. **Optional**: If `hooks` is omitted from `server()`, no lifecycle behavior runs beyond what procedures implement themselves.
+2. **Schema-keyed**: Hooks are grouped by entity (`posts`, `users`, …) and typed from `typeof schema`, not from `Route` instances.
+3. **Composable across files**: Small `defineHooks` slices can live in separate modules and be merged at server startup.
+4. **Type-safe**: `TSchema` and `TContext` flow through `defineHooks` so `value` / `record` / `patch` match the entity and `ctx` matches the app context.
+5. **DX**: Single object-literal style per slice; mirrors `defineOptimisticMutations` and `db.[entity]` naming.
+
+## Current Behavior (V2) vs V3
+
+- **V2**: Hooks lived on collection routes: `routeFactory().collectionRoute(schema.posts).withHooks({ beforeInsert: ... })`.
+- **V3**: Hooks are declared with `defineHooks` and passed to `server({ hooks })`. Routes only define procedures; lifecycle is orthogonal.
+
+---
+
+## Lifecycle Hooks API
+
+Hooks are declared with `defineHooks` and passed to `server({ hooks })`. When you have **multiple** hook slices (e.g. split across files), combine them with `mergeHooks` — that helper is **completely optional**; if everything lives in one `defineHooks` object, pass it straight to `hooks` with no merge. Multiple slices for the same entity merge at the **hook name** level when you do use `mergeHooks` (see Implementation Notes).
+
+### API Design
+
+```typescript
+// hooks/posts.insert.ts — one concern per file
+import { defineHooks } from '@live-state/sync/server';
+import type { AppContext } from '../context';
+import { schema } from '../schema';
+
+export const postsInsertHooks = defineHooks<typeof schema, AppContext>({
+	posts: {
+		beforeInsert: async ({ ctx, value, db }) => {
+			// `value` is typed from schema.posts insert shape
+			if (ctx?.role !== 'admin') throw new Error('Unauthorized');
+		},
+		afterInsert: async ({ ctx, record, db }) => {
+			// `record` is typed as the inserted row
+		},
+	},
+});
+```
+
+```typescript
+// hooks/users.ts
+import { defineHooks } from '@live-state/sync/server';
+import type { AppContext } from '../context';
+import { schema } from '../schema';
+
+export const usersHooks = defineHooks<typeof schema, AppContext>({
+	users: {
+		beforeUpdate: async ({ ctx, id, patch, db }) => {
+			// ...
+		},
+	},
+});
+```
+
+```typescript
+// server.ts — single hooks definition (no merge needed)
+import { defineHooks } from '@live-state/sync/server';
+import type { AppContext } from './context';
+import { schema } from './schema';
+
+const hooks = defineHooks<typeof schema, AppContext>({
+	posts: {
+		beforeInsert: async ({ ctx, value, db }) => {
+			/* ... */
+		},
+	},
+	users: {
+		beforeUpdate: async ({ ctx, id, patch, db }) => {
+			/* ... */
+		},
+	},
+});
+
+const app = server({
+	router,
+	storage,
+	schema,
+	contextProvider,
+	hooks, // omit entirely if you do not need lifecycle hooks
+});
+```
+
+```typescript
+// server.ts — multiple slices from separate modules: use mergeHooks
+import { mergeHooks } from '@live-state/sync/server';
+import { postsInsertHooks } from './hooks/posts.insert';
+import { usersHooks } from './hooks/users';
+
+const hooks = mergeHooks(postsInsertHooks, usersHooks);
+
+const app = server({
+	router,
+	storage,
+	schema,
+	contextProvider,
+	hooks,
+});
+```
+
+### Implementation Notes
+
+- `defineHooks<TSchema, TContext>(definition)` validates that top-level keys are entities on `TSchema` and narrows handler payloads per entity.
+- **`mergeHooks` is optional.** Use it only when combining two or more hook objects (e.g. from different files). A single `defineHooks(...)` result can be assigned directly to `server({ hooks })` without calling `mergeHooks`.
+- `mergeHooks(a, b, ...)` combines multiple definitions. **Merge semantics** for the same entity and same hook name (e.g. two `beforeInsert` for `posts`) must be documented and implemented consistently — e.g. **order preserved by argument order** (first wins, last wins, or **sequential chain**); the recommended default is **sequential execution in merge order** so multiple files can each append behavior safely.
+- Hook names align with storage lifecycle events (exact set TBD by implementation): e.g. `beforeInsert`, `afterInsert`, `beforeUpdate`, `afterUpdate`, `beforeDelete`, `afterDelete`. Handlers receive `{ ctx, db, ... }` consistent with V2 collection hooks where applicable.
+- Lifecycle runs when the sync engine / storage performs the corresponding mutation (including paths invoked from procedure handlers such as `db.posts.insert(...)`), unless explicitly scoped otherwise in implementation.
+- `ctx` follows the same `TContext` as `contextProvider` / procedures; optional context remains optional in handlers if the server allows missing context.
+
+### Pros
+
+- Clear separation from routes: procedures stay thin; cross-cutting rules live in one registry.
+- Easy to split large codebases: one file per entity or per concern, merged at the server.
+- Same entity naming as schema and client-side patterns — easy for humans and agents to discover and extend.
+- Optional: no hooks object means zero lifecycle overhead at the API level.
+
+### Cons
+
+- When using `mergeHooks`, teams need clear rules and ordering documentation when multiple slices target the same hook.
+- Duplicated entity keys across `defineHooks` slices are merged — teams should agree on file boundaries (by entity vs by concern) to avoid surprises.
+
+# Typed Context
+
+Context is now fully typed throughout the system. Instead of `Record<string, any>`, you can define an application-specific context type that flows from the `RouteFactory` through to authorization handlers, lifecycle hooks (`defineHooks`), and procedure handlers.
+
+## Defining Typed Context
+
+Pass a `TContext` type parameter to `routeFactory` to type context across all routes created by that factory:
+
+```typescript
+type AppContext = { user: string; role: "admin" | "user" };
+
+// Context type flows to all routes created by this factory
+const protectedRoute = routeFactory<typeof schema, AppContext>();
+
+// ctx is now typed as AppContext
+posts: protectedRoute.collectionRoute(schema.posts, {
+  read: ({ ctx }) => ({ authorId: ctx.user }),  // ✅ ctx.user is string
+  insert: ({ ctx }) => ctx.role === "admin",     // ✅ ctx.role is "admin" | "user"
+});
+```
+
+## Context in Procedures
+
+Procedure handlers receive the typed context through `req.context`:
+
+```typescript
+protectedRoute.withProcedures(({ query, mutation }) => ({
+  find: query(z.object({ limit: z.number() })).handler(({ req, db }) => {
+    const userId = req.context.user;  // ✅ typed as string
+    return db.posts.where({ authorId: userId }).limit(req.input.limit);
+  }),
+}));
+```
+
+## Context in Lifecycle Hooks
+
+Lifecycle hook handlers receive the typed context through `ctx` (see **Lifecycle Hooks (Server)**). They are declared with `defineHooks<typeof schema, AppContext>`, not on routes:
+
+```typescript
+defineHooks<typeof schema, AppContext>({
+  posts: {
+    beforeInsert: ({ ctx, value, db }) => {
+      // ctx is typed as AppContext | undefined (or narrowed if server guarantees context)
+      if (ctx?.role !== "admin") throw new Error("Unauthorized");
+    },
+  },
+});
+```
+
+Legacy `collectionRoute(...).withHooks(...)` remains for deprecated collection routes only; new code should use the central registry and `server({ hooks })`.
+
+## Context Provider
+
+The `Server` infers `TContext` from the `contextProvider` return type:
+
+```typescript
+const app = server({
+  router: appRouter,
+  storage,
+  schema,
+  // TContext is inferred as { user: string; role: "admin" | "user" }
+  contextProvider: (req) => ({
+    user: req.headers["x-user-id"],
+    role: req.headers["x-role"] as "admin" | "user",
+  }),
+});
+```
+
+## Typed Middleware with `createMiddleware`
+
+Raw middleware (`({ req, next }) => ...`) preserves the existing context type. To **transform** the context type (e.g., narrowing optional fields after authentication), use `createMiddleware`:
+
+```typescript
+import { createMiddleware, routeFactory } from "@live-state/sync/server";
+
+// Narrows { user?: string } to { user: string }
+const authMiddleware = createMiddleware<{ user?: string }, { user: string }>(
+  ({ ctx, next }) => {
+    if (!ctx.user) throw new Error("Unauthorized");
+    return next({ user: ctx.user });  // passes narrowed context to next
+  },
+);
+
+// Factory starts with optional user
+const publicRoute = routeFactory<typeof schema, { user?: string }>();
+
+// After .use(authMiddleware), context is narrowed to { user: string }
+const protectedRoute = publicRoute.use(authMiddleware);
+
+// ctx.user is guaranteed to be string — no optional chaining needed
+protectedRoute.collectionRoute(schema.posts, {
+  read: ({ ctx }) => ({ authorId: ctx.user }),  // ✅ string, not string | undefined
+});
+```
+
+### Chaining Typed Middleware
+
+Multiple typed middlewares can be chained to accumulate context transformations:
+
+```typescript
+const withAuth = createMiddleware<Record<string, any>, { user: string }>(
+  ({ next }) => next({ user: "resolved-user" }),
+);
+
+const withOrg = createMiddleware<{ user: string }, { user: string; org: string }>(
+  ({ ctx, next }) => next({ ...ctx, org: "resolved-org" }),
+);
+
+// Context type is { user: string; org: string }
+const orgRoute = routeFactory<typeof schema>()
+  .use(withAuth)
+  .use(withOrg);
+```
+
+## Backward Compatibility
+
+All `TContext` parameters default to `Record<string, any>`, so existing code continues to work unchanged:
+
+```typescript
+// These are equivalent — both use Record<string, any> for context
+const route = routeFactory<typeof schema>();
+const route = routeFactory<typeof schema, Record<string, any>>();
+```
+

--- a/API_DESIGN_V3.md
+++ b/API_DESIGN_V3.md
@@ -408,7 +408,7 @@ const app = server({
 
 # Typed Context
 
-Context is now fully typed throughout the system. Instead of `Record<string, any>`, you can define an application-specific context type that flows from the `RouteFactory` through to authorization handlers, lifecycle hooks (`defineHooks`), and procedure handlers.
+Context is now fully typed throughout the system. Instead of `Record<string, any>`, you can define an application-specific context type that flows from the `RouteFactory` through to procedure handlers (where authorization now lives) and lifecycle hooks (`defineHooks`). Deprecated collection routes also receive it in their `read`/`insert` access rules.
 
 ## Defining Typed Context
 
@@ -461,16 +461,24 @@ Legacy `collectionRoute(...).withHooks(...)` remains for deprecated collection r
 
 The `Server` infers `TContext` from the `contextProvider` return type:
 
+Headers are client-controlled and, under strict Node typings, may be `string | string[] | undefined`. Normalize and validate them before trusting them as auth context (in practice you'd verify a signed token rather than a raw id):
+
 ```typescript
+const first = (h: string | string[] | undefined) =>
+  Array.isArray(h) ? h[0] : h;
+
 const app = server({
   router: appRouter,
   storage,
   schema,
-  // TContext is inferred as { user: string; role: "admin" | "user" }
-  contextProvider: (req) => ({
-    user: req.headers["x-user-id"],
-    role: req.headers["x-role"] as "admin" | "user",
-  }),
+  // TContext is inferred from the validated result: { user: string; role: "admin" | "user" }
+  contextProvider: (req) => {
+    const user = first(req.headers["x-user-id"]);
+    const role = first(req.headers["x-role"]);
+    if (!user) throw new Error("Unauthorized");
+    if (role !== "admin" && role !== "user") throw new Error("Invalid role");
+    return { user, role };
+  },
 });
 ```
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,72 @@
+# Backlog
+
+Engineering backlog for simplifying `@live-state/sync`: fewer implicit behaviors, thinner query processing, and explicit server-side patterns.
+
+---
+
+## 1. Remove default mutations
+
+**Goal:** Drop built-in `insert` / `update` handling on `Route` so **custom mutations only** (`withProcedures` / procedures) are the supported path.
+
+**Why:** Default mutations duplicate what explicit procedures can express; they pull in deprecated surface area (automatic optimistic updates, `handleSet`, default mutation protocol, etc.). Custom mutations already offer typed input/output, `ServerDB` access, and optimistic flows via `defineOptimisticMutations`.
+
+**Related work / notes:**
+
+- Audit parity: inserts/updates via `db.<resource>` are already covered; lifecycle hooks today are tied to default mutations via storage (`rawInsert` / `rawUpdate` + `hooks`) — decide whether hooks move into handlers only (recommended in `REMOVE_DEFAULT_MUTATIONS.md`) or get a new home.
+- Migration: document or codemod from declarative `insert` / `update` auth + `withHooks` to inline checks and side effects inside procedure handlers.
+- See `REMOVE_DEFAULT_MUTATIONS.md` for the full phased plan.
+
+---
+
+## 2. Remove authorization checks
+
+**Goal:** Remove **framework-level** authorization from routes (e.g. declarative `insert` / `update` auth, route-level auth plumbing tied to default mutations).
+
+**Why:** Authorization should live in explicit procedure handlers, middleware, or storage policies — not in a parallel declarative API that only default mutations used. Aligns with “explicit > implicit” and reduces surface area once default mutations are gone.
+
+**Scope clarification:** This is about deleting the **built-in** auth integration on `Route` / protocol paths that exist for legacy flows. Application code must still enforce auth inside custom mutations or adapters; the backlog item is **removal of the library’s default auth hooks**, not “stop securing APIs.”
+
+---
+
+## 3. Remove custom query-engine handling of `include` — use storage include handlers
+
+**Goal:** Strip the **query engine** logic that resolves `include` (nested relation loading / graph expansion) in favor of **storage-layer include handlers**. Keep **realtime updates** as they are today.
+
+**Why:** Centralizing `include` in storage avoids duplicating relation semantics between the query engine and persistence; storage already knows how to join or batch-load related rows.
+
+**Explicitly in scope:**
+
+- Remove or bypass the query-engine code path that interprets `include` on queries.
+
+**Explicitly out of scope / unchanged:**
+
+- Realtime subscription and invalidation behavior — **maintained**.
+- Client query builders may still express `.include(...)` for API ergonomics; execution should delegate to storage (see also `MIGRATE_INCLUDE_SYNTAX.md` for client-side include shape migration).
+
+**Follow-up:** Ensure one clear contract for “include” resolution (storage-only), update tests, and document how relation loads map to storage APIs.
+
+---
+
+## 4. Update documentation
+
+**Goal:** Bring **public docs** (`docs/`), **package READMEs**, **examples/**, and **migration notes** in line with the backlog above so users are not guided toward removed APIs.
+
+**Why:** Removing default mutations, framework auth hooks, and query-engine `include` changes how integrations are built. Stale docs cause churn and support load; shipping behavior changes without doc updates breaks trust.
+
+**What to cover (non-exhaustive):**
+
+- **Default mutations:** Replace tutorials and snippets that use `Route` insert/update, `withHooks` for insert/update lifecycle, or default optimistic flows; point to `withProcedures`, `defineOptimisticMutations`, and `REMOVE_DEFAULT_MUTATIONS.md` (or fold key bits into official docs once stable).
+- **Authorization:** Document that auth belongs in procedure handlers, middleware, or your storage/adapter layer — not removed “security,” but removed **library** auth APIs.
+- `**include`:** Explain that relation expansion is **storage-driven**; keep `MIGRATE_INCLUDE_SYNTAX.md` aligned with the final client query shape; add or update a short “how includes execute” page if needed.
+- **Changelog / release notes:** Call out breaking changes and migration steps for each release that lands items 1–3.
+
+**Cadence:** Prefer **small doc PRs alongside** each code change; use a final **docs sweep** before a major version if multiple items ship together.
+
+---
+
+## Ordering suggestion
+
+1. **Default mutations** — largest API and protocol impact; unlocks cleaning auth tied to them.
+2. **Authorization checks** — natural cleanup after default mutations are removed (or in parallel where decoupled).
+3. **Include in query engine → storage** — orthogonal to mutations; can be scheduled once storage include handlers are ready and tests cover parity.
+4. **Update documentation** — run in parallel with each item above; finish with a release-notes and examples pass before tagging a breaking release.

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -31,12 +31,30 @@ interface QueryNode {
 	/**
 	 * In-memory window ordering for a root query that declares a `limit`. Present
 	 * iff this is a windowed root scope; drives scope-in / eviction / backfill
-	 * broadcasts without holding row payloads (see ADR-0003). Windowed `include`s
-	 * (per-parent windows) are out of scope here.
+	 * broadcasts without holding row payloads (see ADR-0003).
 	 */
 	windowIndex?: WindowIndex;
 	/** Whether `windowIndex` has been seeded from an initial resolution. */
 	windowInitialized?: boolean;
+	/**
+	 * Per-parent window ordering for a windowed `include` (a `limit` on an
+	 * `include` step), keyed by parent id. Each parent keeps its own bounded
+	 * window (e.g. every project showing its latest 5 tasks); a child write is
+	 * routed to the affected parent's window via its foreign key (see ADR-0003 /
+	 * issue #186).
+	 */
+	windowIndexes?: Map<string, WindowIndex>;
+	/** Parent ids whose window has been seeded from an initial resolution. */
+	seededParents?: Set<string>;
+}
+
+/**
+ * Scopes a windowed read to a single parent of a windowed `include`: the child's
+ * foreign-key column and the parent id. `undefined` for a root window.
+ */
+interface ParentScope {
+	column: string;
+	parentId: string;
 }
 
 interface ObjectNode {
@@ -569,6 +587,29 @@ export class QueryEngine {
 			}
 			queryNode.windowInitialized = true;
 		}
+
+		// Seed the per-parent windows of a windowed `include`. Storage already
+		// limited children to the top-N per parent, so grouping the flattened rows
+		// by their foreign key and inserting each into its parent's window never
+		// evicts. A parent is seeded only once; realtime handlers keep it current.
+		const foreignColumn = this.includeForeignColumn(queryNode);
+		if (foreignColumn) {
+			queryNode.seededParents ??= new Set();
+			for (const rawResult of results) {
+				const result = inferValue(rawResult);
+				const childId = result?.id;
+				const parentId = result?.[foreignColumn];
+				if (!childId || parentId == null) continue;
+				if (queryNode.seededParents.has(parentId)) continue;
+				const wi = this.ensureParentWindow(queryNode, parentId);
+				if (wi.has(childId)) continue;
+				wi.insert({ id: childId, sortKey: this.sortKeyFor(queryNode, result) });
+			}
+			for (const rawResult of results) {
+				const parentId = inferValue(rawResult)?.[foreignColumn];
+				if (parentId != null) queryNode.seededParents.add(parentId);
+			}
+		}
 	}
 
 	/** The `orderBy` a windowed root query is ordered by (empty ⇒ order by id). */
@@ -592,6 +633,66 @@ export class QueryEngine {
 		];
 	}
 
+	/**
+	 * The foreign-key column on a windowed `include`'s child that points back at
+	 * its parent (the `foreignColumn` of the parent's `many` relation). Returns
+	 * `undefined` for a node that is not a windowed `many` include, which is the
+	 * signal used to recognize per-parent windows.
+	 */
+	private includeForeignColumn(queryNode: QueryNode): string | undefined {
+		if (
+			queryNode.queryStep.stepPath.length === 0 ||
+			queryNode.queryStep.query.limit === undefined ||
+			!queryNode.relationName ||
+			!queryNode.parentQuery
+		)
+			return undefined;
+
+		const parentNode = this.queryNodes.get(queryNode.parentQuery);
+		const parentResource = parentNode?.queryStep.query.resource;
+		if (!parentResource) return undefined;
+
+		const relation =
+			this.schema[parentResource]?.relations?.[queryNode.relationName];
+		if (relation?.type !== 'many' || !relation.foreignColumn) return undefined;
+
+		return String(relation.foreignColumn);
+	}
+
+	/** Whether a query node maintains per-parent windows (a windowed `include`). */
+	private isWindowedIncludeNode(queryNode: QueryNode): boolean {
+		return this.includeForeignColumn(queryNode) !== undefined;
+	}
+
+	/** Get (or lazily create) the window for one parent of a windowed `include`. */
+	private ensureParentWindow(
+		queryNode: QueryNode,
+		parentId: string,
+	): WindowIndex {
+		if (!queryNode.windowIndexes) queryNode.windowIndexes = new Map();
+		let wi = queryNode.windowIndexes.get(parentId);
+		if (!wi) {
+			wi = new WindowIndex({
+				limit: queryNode.queryStep.query.limit as number,
+				orderBy: this.orderByFor(queryNode.queryStep.query),
+			});
+			queryNode.windowIndexes.set(parentId, wi);
+		}
+		return wi;
+	}
+
+	/** Find the parent window currently holding a child, if any. */
+	private parentWindowHolding(
+		queryNode: QueryNode,
+		id: string,
+	): { parentId: string; wi: WindowIndex } | undefined {
+		if (!queryNode.windowIndexes) return undefined;
+		for (const [parentId, wi] of Array.from(queryNode.windowIndexes)) {
+			if (wi.has(id)) return { parentId, wi };
+		}
+		return undefined;
+	}
+
 	/** Emit a delta to every subscriber of a query node, isolating callback errors. */
 	private emitToSubscribers(
 		queryNode: QueryNode,
@@ -602,12 +703,15 @@ export class QueryEngine {
 			try {
 				subscription(delta);
 			} catch (error) {
-				this.logger.error(`[QueryEngine] Error in subscription during ${context}`, {
-					error,
-					queryHash: queryNode.hash,
-					resource: delta.resource,
-					resourceId: delta.resourceId,
-				});
+				this.logger.error(
+					`[QueryEngine] Error in subscription during ${context}`,
+					{
+						error,
+						queryHash: queryNode.hash,
+						resource: delta.resource,
+						resourceId: delta.resourceId,
+					},
+				);
 			}
 		}
 	}
@@ -645,12 +749,10 @@ export class QueryEngine {
 	 */
 	private handleWindowedInsert(
 		queryNode: QueryNode,
+		wi: WindowIndex,
 		mutation: SyncDelta,
 		objValue: any,
 	): void {
-		const wi = queryNode.windowIndex;
-		if (!wi) return;
-
 		const result = wi.insert({
 			id: mutation.resourceId,
 			sortKey: this.sortKeyFor(queryNode, objValue),
@@ -660,7 +762,9 @@ export class QueryEngine {
 		if (!result.inserted) return;
 
 		queryNode.trackedObjects.add(mutation.resourceId);
-		this.objectNodes.get(mutation.resourceId)?.matchedQueries.add(queryNode.hash);
+		this.objectNodes
+			.get(mutation.resourceId)
+			?.matchedQueries.add(queryNode.hash);
 		this.emitToSubscribers(queryNode, mutation, 'windowed scope-in INSERT');
 
 		if (result.evicted) {
@@ -689,47 +793,12 @@ export class QueryEngine {
 		const wasInWindow = wi.has(id);
 
 		if (predicateMatches) {
-			const sortKey = this.sortKeyFor(queryNode, objValue);
-
 			if (wasInWindow) {
-				// Still matches the predicate: refresh the sort key (removing first
-				// frees a slot so the re-insert never evicts).
-				const prevKey = wi.remove(id)?.sortKey;
-				wi.insert({ id, sortKey });
-
-				// If the row's own sort key worsened enough to land it at the boundary
-				// of a full window, an untracked row just outside may now sort ahead of
-				// it — the window-local re-insert can't see that. Confirm with a single
-				// boundary read before assuming it stayed.
-				if (
-					wi.isFull &&
-					wi.boundary()?.id === id &&
-					!this.sortKeysEqual(prevKey, sortKey)
-				) {
-					await this.reconcileDemotion(queryNode, id, sortKey, mutation);
-					return;
-				}
-
-				// Genuinely still in the window: broadcast the field change only.
-				this.emitToSubscribers(queryNode, mutation, 'windowed UPDATE');
+				await this.refreshInWindow(queryNode, wi, mutation, objValue);
 				return;
 			}
 
-			// Scope-in via update: the mutation payload is partial, so carry the full
-			// object as the INSERT payload.
-			const result = wi.insert({ id, sortKey });
-			if (!result.inserted) return;
-
-			queryNode.trackedObjects.add(id);
-			this.objectNodes.get(id)?.matchedQueries.add(queryNode.hash);
-			this.emitToSubscribers(
-				queryNode,
-				this.fullInsertDelta(queryNode, mutation, entityValue),
-				'windowed scope-in INSERT',
-			);
-			if (result.evicted) {
-				this.emitScopeOut(queryNode, result.evicted.id, mutation.meta);
-			}
+			this.scopeInViaUpdate(queryNode, wi, mutation, entityValue, objValue);
 			return;
 		}
 
@@ -737,7 +806,137 @@ export class QueryEngine {
 		if (wasInWindow) {
 			wi.remove(id);
 			this.emitScopeOut(queryNode, id, mutation.meta);
-			await this.backfillWindow(queryNode, mutation.meta);
+			await this.backfillWindow(queryNode, wi, mutation.meta);
+		}
+	}
+
+	/**
+	 * Refresh the sort key of a row that stays in a window after an update. If the
+	 * row's own sort key worsened enough to land it at the boundary of a full
+	 * window, an untracked row just outside may now sort ahead of it — the
+	 * window-local re-insert can't see that, so a single boundary read confirms
+	 * (see `reconcileDemotion`). Otherwise the field change is broadcast as a
+	 * plain `UPDATE` (within-window reordering is left to the client).
+	 */
+	private async refreshInWindow(
+		queryNode: QueryNode,
+		wi: WindowIndex,
+		mutation: SyncDelta,
+		objValue: any,
+		parentScope?: ParentScope,
+	): Promise<void> {
+		const id = mutation.resourceId;
+		const sortKey = this.sortKeyFor(queryNode, objValue);
+
+		// Removing first frees a slot so the re-insert never evicts.
+		const prevKey = wi.remove(id)?.sortKey;
+		wi.insert({ id, sortKey });
+
+		if (
+			wi.isFull &&
+			wi.boundary()?.id === id &&
+			!this.sortKeysEqual(prevKey, sortKey)
+		) {
+			await this.reconcileDemotion(
+				queryNode,
+				wi,
+				id,
+				sortKey,
+				mutation,
+				parentScope,
+			);
+			return;
+		}
+
+		this.emitToSubscribers(queryNode, mutation, 'windowed UPDATE');
+	}
+
+	/**
+	 * Bring a row into a window via an update. The mutation payload is partial, so
+	 * carry the full object as the INSERT payload; a displaced boundary is emitted
+	 * as an id-only eviction `DELETE`.
+	 */
+	private scopeInViaUpdate(
+		queryNode: QueryNode,
+		wi: WindowIndex,
+		mutation: SyncDelta,
+		entityValue: MaterializedLiveType<LiveObjectAny>,
+		objValue: any,
+	): void {
+		const id = mutation.resourceId;
+		const result = wi.insert({
+			id,
+			sortKey: this.sortKeyFor(queryNode, objValue),
+		});
+		if (!result.inserted) return;
+
+		queryNode.trackedObjects.add(id);
+		this.objectNodes.get(id)?.matchedQueries.add(queryNode.hash);
+		this.emitToSubscribers(
+			queryNode,
+			this.fullInsertDelta(queryNode, mutation, entityValue),
+			'windowed scope-in INSERT',
+		);
+		if (result.evicted) {
+			this.emitScopeOut(queryNode, result.evicted.id, mutation.meta);
+		}
+	}
+
+	/**
+	 * Membership update for a windowed `include`, judged per parent list
+	 * (ADR-0003). Finds the parent window that currently holds the child and the
+	 * parent the child now belongs to, then:
+	 * - same list → a plain field `UPDATE` (or a boundary reconcile);
+	 * - left the old list (removed / re-parented / predicate-out) → `DELETE` to
+	 *   that parent's subscribers plus a backfill of its freed slot;
+	 * - entered a new list → scope-in `INSERT` (payload from the mutation) plus
+	 *   any eviction on that parent's boundary.
+	 *
+	 * Re-parenting A→B therefore decomposes into a `DELETE`+backfill on A and an
+	 * `INSERT` on B; unrelated parents are untouched.
+	 */
+	private async handleWindowedIncludeUpdate(
+		queryNode: QueryNode,
+		mutation: SyncDelta,
+		entityValue: MaterializedLiveType<LiveObjectAny>,
+		objValue: any,
+		belongsToNewParent: boolean,
+	): Promise<void> {
+		const foreignColumn = this.includeForeignColumn(queryNode);
+		if (!foreignColumn) return;
+
+		const id = mutation.resourceId;
+		const newParentId = belongsToNewParent
+			? (objValue[foreignColumn] as string | undefined)
+			: undefined;
+		const held = this.parentWindowHolding(queryNode, id);
+		const oldParentId = held?.parentId;
+
+		// Same list: refresh in place (field UPDATE or boundary reconcile).
+		if (oldParentId !== undefined && oldParentId === newParentId) {
+			await this.refreshInWindow(queryNode, held!.wi, mutation, objValue, {
+				column: foreignColumn,
+				parentId: oldParentId,
+			});
+			return;
+		}
+
+		// Left the old list: DELETE to A's subscribers, then backfill A.
+		if (held) {
+			held.wi.remove(id);
+			this.emitScopeOut(queryNode, id, mutation.meta);
+			await this.backfillWindow(queryNode, held.wi, mutation.meta, {
+				column: foreignColumn,
+				parentId: held.parentId,
+			});
+		}
+
+		// Entered a new list: scope-in INSERT (+ eviction) on B.
+		if (newParentId !== undefined) {
+			const wi = this.ensureParentWindow(queryNode, newParentId);
+			if (!wi.has(id)) {
+				this.scopeInViaUpdate(queryNode, wi, mutation, entityValue, objValue);
+			}
 		}
 	}
 
@@ -758,21 +957,17 @@ export class QueryEngine {
 	 */
 	private async reconcileDemotion(
 		queryNode: QueryNode,
+		wi: WindowIndex,
 		id: string,
 		sortKey: SortKey,
 		mutation: SyncDelta,
+		parentScope?: ParentScope,
 	): Promise<void> {
-		const wi = queryNode.windowIndex;
-		if (!wi) return;
-
 		// Free the boundary slot so the cursor is the row *before* the demoted one;
 		// the demoted row still lives in storage past that cursor, so skip it.
 		wi.remove(id);
 		const resource = queryNode.queryStep.query.resource;
-		const where = this.combineWhere(
-			queryNode.queryStep.query.where,
-			this.buildCursorWhere(queryNode, wi.boundary()),
-		);
+		const where = this.windowReadWhere(queryNode, wi, parentScope);
 
 		const rows = await toPromiseLike(
 			this.storage.get({
@@ -814,9 +1009,11 @@ export class QueryEngine {
 		}
 
 		queryNode.trackedObjects.add(candidate.id);
-		this.ensureObjectNode(candidate.id, resource, queryNode.hash).matchedQueries.add(
+		this.ensureObjectNode(
+			candidate.id,
+			resource,
 			queryNode.hash,
-		);
+		).matchedQueries.add(queryNode.hash);
 		const payload = { ...((candidateRow as any)?.value ?? {}) };
 		delete payload.id;
 		this.emitToSubscribers(
@@ -861,19 +1058,15 @@ export class QueryEngine {
 	 */
 	private async backfillWindow(
 		queryNode: QueryNode,
+		wi: WindowIndex,
 		meta?: SyncDelta['meta'],
+		parentScope?: ParentScope,
 	): Promise<void> {
-		const wi = queryNode.windowIndex;
-		if (!wi) return;
-
 		const need = wi.backfillCount;
 		if (need <= 0) return;
 
 		const resource = queryNode.queryStep.query.resource;
-		const where = this.combineWhere(
-			queryNode.queryStep.query.where,
-			this.buildCursorWhere(queryNode, wi.boundary()),
-		);
+		const where = this.windowReadWhere(queryNode, wi, parentScope);
 
 		const rows = await toPromiseLike(
 			this.storage.get({
@@ -890,9 +1083,11 @@ export class QueryEngine {
 
 			wi.insert({ id: value.id, sortKey: this.sortKeyFor(queryNode, value) });
 			queryNode.trackedObjects.add(value.id);
-			this.ensureObjectNode(value.id, resource, queryNode.hash).matchedQueries.add(
+			this.ensureObjectNode(
+				value.id,
+				resource,
 				queryNode.hash,
-			);
+			).matchedQueries.add(queryNode.hash);
 
 			const payload = { ...((row as any)?.value ?? {}) };
 			delete payload.id;
@@ -939,6 +1134,28 @@ export class QueryEngine {
 		}
 
 		return clauses.length === 1 ? clauses[0] : { $or: clauses };
+	}
+
+	/**
+	 * The `where` for a windowed boundary read: the query's base `where`, scoped to
+	 * a single parent (`foreignColumn = parentId`) for a windowed `include`, plus
+	 * the boundary cursor predicate.
+	 */
+	private windowReadWhere(
+		queryNode: QueryNode,
+		wi: WindowIndex,
+		parentScope?: ParentScope,
+	): Record<string, any> | undefined {
+		let where = queryNode.queryStep.query.where;
+		if (parentScope) {
+			where = this.combineWhere(where, {
+				[parentScope.column]: parentScope.parentId,
+			});
+		}
+		return this.combineWhere(
+			where,
+			this.buildCursorWhere(queryNode, wi.boundary()),
+		);
 	}
 
 	/** Combine a query's base `where` with a cursor predicate (both optional). */
@@ -1161,7 +1378,29 @@ export class QueryEngine {
 					if (!queryNode) continue; // TODO should we throw an error here?
 
 					if (queryNode.windowIndex) {
-						this.handleWindowedInsert(queryNode, mutation, objValue);
+						this.handleWindowedInsert(
+							queryNode,
+							queryNode.windowIndex,
+							mutation,
+							objValue,
+						);
+						continue;
+					}
+
+					// Windowed `include`: route the child to its parent's window via the
+					// foreign key. `getMatchingQueries` already confirmed the parent is in
+					// scope, so the FK value is a tracked parent.
+					const foreignColumn = this.includeForeignColumn(queryNode);
+					if (foreignColumn) {
+						const parentId = objValue[foreignColumn];
+						if (parentId != null) {
+							this.handleWindowedInsert(
+								queryNode,
+								this.ensureParentWindow(queryNode, parentId),
+								mutation,
+								objValue,
+							);
+						}
 						continue;
 					}
 
@@ -1232,12 +1471,21 @@ export class QueryEngine {
 					// eviction / backfill) and excluded from the plain partition below.
 					const windowedHashes = new Set<string>();
 					for (const queryNode of Array.from(this.queryNodes.values())) {
-						if (
-							queryNode.windowIndex &&
-							queryNode.queryStep.query.resource === mutation.resource
-						) {
+						if (queryNode.queryStep.query.resource !== mutation.resource)
+							continue;
+
+						if (queryNode.windowIndex) {
 							windowedHashes.add(queryNode.hash);
 							await this.handleWindowedUpdate(
+								queryNode,
+								mutation,
+								entityValue,
+								objValue,
+								matchingQueriesSet.has(queryNode.hash),
+							);
+						} else if (this.isWindowedIncludeNode(queryNode)) {
+							windowedHashes.add(queryNode.hash);
+							await this.handleWindowedIncludeUpdate(
 								queryNode,
 								mutation,
 								entityValue,

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -285,25 +285,68 @@ export class QueryEngine {
 	 * so realtime matching has its object/relation state populated. See ADR-0003.
 	 */
 	get(query: RawQueryRequest, _extra?: { context?: any }): PromiseLike<any[]> {
-		// A windowed root query needs a deterministic boundary, so resolve it in the
-		// same total order the window maintains (`[...orderBy, id]`); backfill reads
-		// use the same tiebreaker (see ADR-0003). The extra key is harmless for
-		// non-windowed callers, so only add it when a `limit` makes the window real.
-		const resolveQuery: RawQueryRequest =
-			query.limit !== undefined
+		// A windowed read needs a deterministic boundary, so resolve it in the same
+		// total order the window maintains (`[...orderBy, id]`); backfill reads use
+		// the same tiebreaker (see ADR-0003). This holds for the root `limit` and,
+		// recursively, for every windowed `include`. The extra key is harmless for
+		// non-windowed callers, so only add it where a `limit` makes the window real.
+		const resolveQuery: RawQueryRequest = {
+			...query,
+			...(query.limit !== undefined
 				? {
-						...query,
 						sort: [
 							...(query.sort ?? []),
 							{ key: 'id', direction: 'asc' as const },
 						],
 					}
-				: query;
+				: {}),
+			...(query.include
+				? { include: this.withIncludeTiebreakers(query.include) }
+				: {}),
+		};
 
 		return toPromiseLike(this.storage.get(resolveQuery)).then((results) => {
 			this.ingest(query, results);
 			return results;
 		});
+	}
+
+	/**
+	 * Recursively append the `id` tiebreaker to the `orderBy` of every windowed
+	 * (`limit`ed) `include`, so storage seeds each per-parent window with the same
+	 * total order (`[...orderBy, id]`) that `WindowIndex` and backfill/cursor reads
+	 * use. Returns a new include tree; the original (used by `ingest`, whose
+	 * `sortKeyFor` expects `orderBy` without the tiebreaker the window appends
+	 * itself) is left untouched.
+	 */
+	private withIncludeTiebreakers(
+		include: Record<string, any>,
+	): Record<string, any> {
+		const result: Record<string, any> = {};
+		for (const [relName, value] of Object.entries(include)) {
+			if (isSubQueryInclude(value)) {
+				const nested = value.include
+					? this.withIncludeTiebreakers(value.include)
+					: value.include;
+				result[relName] = {
+					...value,
+					...(nested !== undefined ? { include: nested } : {}),
+					...(value.limit !== undefined
+						? {
+								orderBy: [
+									...(value.orderBy ?? []),
+									{ key: 'id', direction: 'asc' as const },
+								],
+							}
+						: {}),
+				};
+			} else if (value && typeof value === 'object') {
+				result[relName] = this.withIncludeTiebreakers(value);
+			} else {
+				result[relName] = value;
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/packages/live-state/test/e2e/e2e.test.ts
+++ b/packages/live-state/test/e2e/e2e.test.ts
@@ -11,6 +11,7 @@ import {
   describe,
   expect,
   test,
+  vi,
 } from "vitest";
 import { Pool } from "pg";
 import express from "express";
@@ -1286,9 +1287,11 @@ describe("End-to-End Query Tests", () => {
           customerName: "Sync Test",
         });
 
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await vi.waitFor(() => {
+          const latest = receivedUpdates[receivedUpdates.length - 1];
+          expect(latest?.find((o: any) => o.id === orderId)).toBeDefined();
+        });
 
-        expect(receivedUpdates.length).toBeGreaterThan(0);
         const latest = receivedUpdates[receivedUpdates.length - 1];
         const syncedOrder = latest.find((o: any) => o.id === orderId);
 
@@ -1721,9 +1724,11 @@ describe("End-to-End Query Tests", () => {
           price: 199,
         });
 
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await vi.waitFor(() => {
+          const latest = receivedUpdates[receivedUpdates.length - 1];
+          expect(latest?.find((p: any) => p.id === productId)).toBeDefined();
+        });
 
-        expect(receivedUpdates.length).toBeGreaterThan(0);
         const latest = receivedUpdates[receivedUpdates.length - 1];
         const syncedProduct = latest.find((p: any) => p.id === productId);
 

--- a/packages/live-state/test/e2e/windowed-includes.test.ts
+++ b/packages/live-state/test/e2e/windowed-includes.test.ts
@@ -1,0 +1,391 @@
+/**
+ * End-to-end tests for windowed `include`s: each parent keeps its own bounded
+ * window (e.g. every project showing its latest N tasks). A child write is
+ * routed to the affected parent's window via its foreign key, and re-parenting
+ * decomposes into a scope-out on the old parent (with backfill) plus a scope-in
+ * on the new one. See ADR-0003 / issue #186.
+ */
+
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from 'vitest';
+import Database from 'better-sqlite3';
+import { Kysely, SqliteDialect, type Selectable } from 'kysely';
+import {
+	createRelations,
+	createSchema,
+	id,
+	number,
+	object,
+	reference,
+	string,
+} from '../../src/schema';
+import { routeFactory, router, server } from '../../src/server';
+import { SQLStorage } from '../../src/server/storage';
+import { generateId } from '../../src/core/utils';
+import { LogLevel } from '../../src/utils';
+
+const project = object('projects', {
+	id: id(),
+	name: string(),
+	status: string(),
+});
+
+const task = object('tasks', {
+	id: id(),
+	title: string(),
+	priority: number(),
+	projectId: reference('projects.id'),
+});
+
+const projectRelations = createRelations(project, ({ many }) => ({
+	tasks: many(task, 'projectId'),
+}));
+
+const taskRelations = createRelations(task, ({ one }) => ({
+	project: one(project, 'projectId'),
+}));
+
+const testSchema = createSchema({
+	projects: project,
+	tasks: task,
+	projectRelations,
+	taskRelations,
+});
+
+const publicRoute = routeFactory();
+
+const testRouter = router({
+	schema: testSchema,
+	routes: {
+		projects: publicRoute.withProcedures(() => ({})),
+		tasks: publicRoute.withProcedures(() => ({})),
+	},
+});
+
+describe('Windowed includes (per-parent windows)', () => {
+	let storage: SQLStorage;
+	let testServer: ReturnType<typeof server>;
+	let db: Database.Database;
+	let kyselyDb: Kysely<{ [x: string]: Selectable<any> }>;
+
+	// Tracked (active) parents plus one archived parent that the root query
+	// filters out, so a re-parent *to* it is a plain removal from a tracked list.
+	let projectA: string;
+	let projectB: string;
+	let projectC: string;
+	let projectArchived: string;
+
+	// projectA tasks by priority: a5(50) a4(40) a3(30) a2(20) a1(10).
+	const aTasks: { id: string; priority: number }[] = [];
+	// projectB tasks by priority: b2(15) b1(5).
+	const bTasks: { id: string; priority: number }[] = [];
+
+	const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+	// Drive the query engine directly (the inbound Default Query path was removed
+	// with ADR-0002); this mirrors the shim used by query-engine.test.ts.
+	const handleQuery = async (opts: {
+		// biome-ignore lint/suspicious/noExplicitAny: test shim mirrors the old request shape
+		req: any;
+		// biome-ignore lint/suspicious/noExplicitAny: test shim mirrors the SyncDelta callback
+		subscription?: (mutation: any) => void;
+	}) => {
+		const { type: _type, ...query } = opts.req;
+		const ctx = { headers: {}, cookies: {}, queryParams: {}, context: {} };
+		const unsubscribe = opts.subscription
+			? testServer.queryEngine.subscribe(query, opts.subscription, ctx)
+			: undefined;
+		const data = await testServer.queryEngine.get(query, { context: ctx });
+		return { data, unsubscribe };
+	};
+
+	const insertTask = (
+		id: string,
+		projectId: string,
+		priority: number,
+		title = `task-${priority}`,
+	) => storage.insert(testSchema.tasks, { id, title, priority, projectId });
+
+	beforeEach(async () => {
+		db = new Database(':memory:');
+		db.pragma('foreign_keys = ON');
+		kyselyDb = new Kysely({ dialect: new SqliteDialect({ database: db }) });
+
+		storage = new SQLStorage(kyselyDb, testSchema);
+		await storage.init(testSchema);
+
+		testServer = server({
+			router: testRouter,
+			storage,
+			schema: testSchema,
+			logLevel: LogLevel.ERROR,
+		});
+
+		projectA = generateId();
+		projectB = generateId();
+		projectC = generateId();
+		projectArchived = generateId();
+
+		await storage.insert(testSchema.projects, {
+			id: projectA,
+			name: 'A',
+			status: 'active',
+		});
+		await storage.insert(testSchema.projects, {
+			id: projectB,
+			name: 'B',
+			status: 'active',
+		});
+		await storage.insert(testSchema.projects, {
+			id: projectC,
+			name: 'C',
+			status: 'active',
+		});
+		await storage.insert(testSchema.projects, {
+			id: projectArchived,
+			name: 'Archived',
+			status: 'archived',
+		});
+
+		aTasks.length = 0;
+		for (const priority of [10, 20, 30, 40, 50]) {
+			const tid = generateId();
+			await insertTask(tid, projectA, priority);
+			aTasks.push({ id: tid, priority });
+		}
+
+		bTasks.length = 0;
+		for (const priority of [5, 15]) {
+			const tid = generateId();
+			await insertTask(tid, projectB, priority);
+			bTasks.push({ id: tid, priority });
+		}
+	});
+
+	afterEach(async () => {
+		await kyselyDb.destroy();
+	});
+
+	const taskById = (list: typeof aTasks, priority: number) =>
+		list.find((t) => t.priority === priority)!.id;
+
+	// project → latest-3-tasks (by priority desc), across active projects only.
+	const subscribeLatest3 = (mutations: any[]) =>
+		handleQuery({
+			req: {
+				type: 'QUERY',
+				resource: 'projects',
+				where: { status: 'active' },
+				include: {
+					tasks: { limit: 3, orderBy: [{ key: 'priority', direction: 'desc' }] },
+				},
+			},
+			subscription: (m) => mutations.push(m),
+		});
+
+	const windowIds = (data: any[], projectId: string): string[] => {
+		const parent = data.find((p: any) => p.value.id.value === projectId);
+		const tasks = parent?.value?.tasks?.value ?? [];
+		return tasks.map((t: any) => t.value.id.value);
+	};
+
+	test('seeds each parent window independently to its own top-N', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		// projectA is full at its top-3; projectB keeps both of its tasks.
+		expect(windowIds(result.data, projectA)).toEqual([
+			taskById(aTasks, 50),
+			taskById(aTasks, 40),
+			taskById(aTasks, 30),
+		]);
+		expect(windowIds(result.data, projectB)).toEqual([
+			taskById(bTasks, 15),
+			taskById(bTasks, 5),
+		]);
+		expect(windowIds(result.data, projectC)).toEqual([]);
+
+		result.unsubscribe?.();
+	});
+
+	test('adding a child to a full per-parent window emits INSERT + eviction DELETE scoped to that parent', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		const getSpy = vi.spyOn(storage, 'get');
+
+		// New top task for A: enters A's window, evicts A's boundary (a3, priority 30).
+		const newTask = generateId();
+		await insertTask(newTask, projectA, 60);
+		await settle();
+
+		const insert = mutations.find((m) => m.resourceId === newTask);
+		expect(insert?.op).toBe('INSERT');
+		expect(insert?.payload.priority.value).toBe(60);
+
+		const evict = mutations.find(
+			(m) => m.resourceId === taskById(aTasks, 30) && m.op === 'DELETE',
+		);
+		expect(evict).toBeDefined();
+		expect(evict.payload).toEqual({});
+
+		// Eviction is resolved from the in-memory window: no boundary read.
+		expect(getSpy).not.toHaveBeenCalled();
+
+		// projectB is untouched by a write to projectA's window.
+		expect(
+			mutations.some((m) => bTasks.some((t) => t.id === m.resourceId)),
+		).toBe(false);
+
+		getSpy.mockRestore();
+		result.unsubscribe?.();
+	});
+
+	test('adding a child to a non-full per-parent window emits INSERT with no eviction', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		const newTask = generateId();
+		await insertTask(newTask, projectB, 25);
+		await settle();
+
+		const insert = mutations.find((m) => m.resourceId === newTask);
+		expect(insert?.op).toBe('INSERT');
+		expect(mutations.some((m) => m.op === 'DELETE')).toBe(false);
+
+		result.unsubscribe?.();
+	});
+
+	test('a field change that leaves the row in the same tracked list emits a plain UPDATE', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		const getSpy = vi.spyOn(storage, 'get');
+
+		// A visible task's title changes; it stays in A's window.
+		await storage.update(testSchema.tasks, taskById(aTasks, 50), {
+			title: 'renamed',
+		});
+		await settle();
+
+		const deltas = mutations.filter(
+			(m) => m.resourceId === taskById(aTasks, 50),
+		);
+		expect(deltas.length).toBeGreaterThan(0);
+		expect(deltas.every((m) => m.op === 'UPDATE')).toBe(true);
+		expect(mutations.some((m) => m.op === 'INSERT' || m.op === 'DELETE')).toBe(
+			false,
+		);
+		expect(getSpy).not.toHaveBeenCalled();
+
+		getSpy.mockRestore();
+		result.unsubscribe?.();
+	});
+
+	test('re-parenting A→B emits DELETE + backfill on A and INSERT on B; unrelated parents untouched', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		const a5 = taskById(aTasks, 50);
+		// Move the top task of A into B.
+		await storage.update(testSchema.tasks, a5, { projectId: projectB });
+		await settle();
+
+		// Scope-out from A.
+		const del = mutations.find((m) => m.resourceId === a5 && m.op === 'DELETE');
+		expect(del).toBeDefined();
+		expect(del.payload).toEqual({});
+
+		// A backfills its freed slot from the next row past its boundary: a2 (20).
+		const backfill = mutations.find(
+			(m) => m.resourceId === taskById(aTasks, 20) && m.op === 'INSERT',
+		);
+		expect(backfill).toBeDefined();
+		expect(backfill.payload.priority.value).toBe(20);
+
+		// Scope-in to B (payload from the row's own mutation).
+		const scopeIn = mutations.filter(
+			(m) => m.resourceId === a5 && m.op === 'INSERT',
+		);
+		expect(scopeIn.length).toBe(1);
+
+		// projectC never held this row and is untouched.
+		expect(mutations.some((m) => m.resourceId === projectC)).toBe(false);
+
+		result.unsubscribe?.();
+	});
+
+	test('removing a child (re-parenting to an untracked parent) emits DELETE + backfill, no INSERT', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		const a4 = taskById(aTasks, 40);
+		// Move a visible task out to the archived (untracked) project.
+		await storage.update(testSchema.tasks, a4, { projectId: projectArchived });
+		await settle();
+
+		const del = mutations.find((m) => m.resourceId === a4 && m.op === 'DELETE');
+		expect(del).toBeDefined();
+
+		// A backfills from the next row past its boundary: a2 (20).
+		const backfill = mutations.find(
+			(m) => m.resourceId === taskById(aTasks, 20) && m.op === 'INSERT',
+		);
+		expect(backfill).toBeDefined();
+
+		// The row scoped into no tracked window, so it is never re-inserted.
+		expect(mutations.some((m) => m.resourceId === a4 && m.op === 'INSERT')).toBe(
+			false,
+		);
+
+		result.unsubscribe?.();
+	});
+
+	test('covers add, remove, and re-parent against project → latest-3-tasks', async () => {
+		const mutations: any[] = [];
+		const result = await subscribeLatest3(mutations);
+
+		// Add: new top task for C (empty window) — INSERT, no eviction.
+		const c1 = generateId();
+		await insertTask(c1, projectC, 100);
+		await settle();
+		expect(mutations.find((m) => m.resourceId === c1)?.op).toBe('INSERT');
+
+		// Re-parent: A's top task moves to C.
+		const a5 = taskById(aTasks, 50);
+		mutations.length = 0;
+		await storage.update(testSchema.tasks, a5, { projectId: projectC });
+		await settle();
+		expect(
+			mutations.find((m) => m.resourceId === a5 && m.op === 'DELETE'),
+		).toBeDefined();
+		expect(
+			mutations.find((m) => m.resourceId === a5 && m.op === 'INSERT'),
+		).toBeDefined();
+		// A backfills from a2 (20); a4/a3 were already visible.
+		expect(
+			mutations.find(
+				(m) => m.resourceId === taskById(aTasks, 20) && m.op === 'INSERT',
+			),
+		).toBeDefined();
+
+		// Remove: send a visible C task to the archived project.
+		mutations.length = 0;
+		await storage.update(testSchema.tasks, c1, { projectId: projectArchived });
+		await settle();
+		expect(
+			mutations.find((m) => m.resourceId === c1 && m.op === 'DELETE'),
+		).toBeDefined();
+		expect(mutations.some((m) => m.resourceId === c1 && m.op === 'INSERT')).toBe(
+			false,
+		);
+
+		result.unsubscribe?.();
+	});
+});

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -19,6 +19,12 @@
       "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
       "computedHash": "e7ef25bbee50cda2eb7b3a8ef541db0a0396dad7d369f7d14fb610671dd1864b"
     },
+    "grilling": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/grilling/SKILL.md",
+      "computedHash": "ef685a6fa0bbe73b05bbd8dc1ec97258191587f07c6aa7dbc9006675ceb8f90f"
+    },
     "improve-codebase-architecture": {
       "source": "mattpocock/skills",
       "sourceType": "github",


### PR DESCRIPTION
Closes #186. Builds on #185 (root windowed queries).

## What

Extends windowing to windowed `include`s, where **each parent keeps its own bounded window** (e.g. every project showing its latest N tasks). `WindowIndex` instances are keyed per `(query node, parentId)`, and an incoming child write is routed to the correct parent's window via its foreign key.

Re-parenting is handled per the ADR-0003 membership invariant: `INSERT`/`DELETE` fire only on an actual entry/exit of a tracked list. A child moving from parent A's window to B's decomposes into `DELETE` to A's subscribers (A backfills via a boundary cursor read) + `INSERT` to B's (payload from the row's own mutation). A relation/field change that leaves the row in the same tracked list is a plain `UPDATE`.

## How

- `QueryNode` gains `windowIndexes: Map<parentId, WindowIndex>` (per-parent) alongside the existing single `windowIndex` (root scopes).
- `includeForeignColumn()` recognizes a windowed `include` and yields the FK column used to route writes; `ensureParentWindow()` lazily creates a parent's window.
- Seeding groups the storage-limited children by FK and seeds each parent once.
- INSERT routes to the parent's window (INSERT + scoped eviction DELETE).
- `handleWindowedIncludeUpdate()` finds the old holding window and the new parent, then emits same-list `UPDATE` / old-list `DELETE`+backfill / new-list scope-in `INSERT`.
- `backfillWindow`/`reconcileDemotion` take an explicit `WindowIndex` + `ParentScope`; a new `windowReadWhere()` ANDs `foreignColumn = parentId` into the boundary read so a parent only backfills from its own children. Root-window behavior is unchanged.

## Acceptance criteria

- [x] `WindowIndex` keyed per `(node, parentId)`; a write updates only the affected parent's window
- [x] Adding a child to a full per-parent window emits `INSERT` + eviction `DELETE` scoped to that parent
- [x] Re-parenting (A→B) emits `DELETE`+backfill on A and `INSERT` on B; unrelated parents untouched
- [x] A relation/field change that leaves the row in the same tracked list emits a plain `UPDATE`
- [x] E2E test for a project→latest-N-tasks include covering add, remove, and re-parent

## Testing

- New `test/e2e/windowed-includes.test.ts` (7 tests) — all pass
- `pnpm typecheck` clean; full `pnpm test` suite green (837 passed); #185 root-window tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windowed `include` results are now isolated per parent record, each maintaining its own bounded list.
  * Re-parenting related items updates the correct parent’s visible window.

* **Bug Fixes**
  * Improved reconciliation for windowed related records, including correct boundary eviction/backfill behavior.
  * More reliable ordering for windowed `include` via deterministic tie-breaking.

* **Tests**
  * Added E2E coverage for per-parent windowing and re-parent scenarios.
  * Improved WebSocket sync assertions to wait for the expected latest payload.

* **Documentation**
  * Added API V3 design notes and an `@live-state/sync` simplification roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->