### PR TITLE
feat(query-engine): relational orderBy for nested windowed includes (#195)

### DIFF
--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -290,9 +290,11 @@ export class QueryEngine {
 		// compute their sort keys. Include it for resolution even if the caller
 		// did not ask for it, then strip the engine-added relations from the
 		// returned rows so the caller's data shape is unchanged.
-		const addedRelations = this.relationalSortDeps(query)
-			.map((d) => d.relationName)
-			.filter((rel) => !(query.include && rel in query.include));
+		const addedRelations = this.addedSortRelations(
+			query.resource,
+			query.sort,
+			query.include,
+		);
 		const resolveInclude: Record<string, any> = { ...(query.include ?? {}) };
 		for (const rel of addedRelations) resolveInclude[rel] = true;
 
@@ -312,23 +314,99 @@ export class QueryEngine {
 					}
 				: {}),
 			...(Object.keys(resolveInclude).length > 0
-				? { include: this.withIncludeTiebreakers(resolveInclude) }
+				? {
+						include: this.prepareResolveInclude(resolveInclude, query.resource),
+					}
 				: {}),
 		};
 
 		return toPromiseLike(this.storage.get(resolveQuery)).then((results) => {
 			this.ingest(query, results);
-			if (addedRelations.length > 0)
-				this.stripRelations(results, addedRelations);
+			this.stripResolveRelations(
+				results,
+				query.resource,
+				query.include,
+				query.sort,
+			);
 			return results;
 		});
 	}
 
-	/** Remove engine-added relations from materialized rows before returning. */
-	private stripRelations(results: any[], relations: string[]): void {
-		for (const row of results) {
-			if (!row?.value) continue;
-			for (const rel of relations) delete row.value[rel];
+	/**
+	 * The relation names a level's relational sort keys (`"author.name"`) need
+	 * that the caller did not already include — the relations the engine adds to
+	 * the resolve `include` purely to derive sort keys, and strips back out before
+	 * returning. Shared by enrichment (`prepareResolveInclude`) and stripping
+	 * (`stripResolveRelations`) so the two can never disagree about what was added.
+	 */
+	private addedSortRelations(
+		resource: string,
+		sort: RawQueryRequest['sort'],
+		existingInclude: Record<string, any> | undefined,
+	): string[] {
+		const added: string[] = [];
+		for (const s of sort ?? []) {
+			const dot = s.key.indexOf('.');
+			if (dot === -1) continue;
+			const relationName = s.key.slice(0, dot);
+			if (!this.schema[resource]?.relations?.[relationName]) continue;
+			if (existingInclude && relationName in existingInclude) continue;
+			if (!added.includes(relationName)) added.push(relationName);
+		}
+		return added;
+	}
+
+	/**
+	 * Recursively strip the engine-added sort relations from a resolved result
+	 * tree so the caller's data shape is unchanged. Walks alongside the caller's
+	 * original query: at each level it deletes exactly the relations
+	 * `addedSortRelations` reports (never one the caller included), then descends
+	 * into each caller-included relation to strip its own added grandchildren.
+	 */
+	private stripResolveRelations(
+		rows: any[],
+		resource: string,
+		callerInclude: Record<string, any> | undefined,
+		sort: RawQueryRequest['sort'],
+	): void {
+		const added = this.addedSortRelations(resource, sort, callerInclude);
+		if (added.length > 0)
+			for (const row of rows) {
+				const value = row?.value;
+				if (!value) continue;
+				for (const rel of added) delete value[rel];
+			}
+
+		if (!callerInclude) return;
+		for (const [relName, sub] of Object.entries(callerInclude)) {
+			const relation = this.schema[resource]?.relations?.[relName];
+			const childResource = relation?.entity.name;
+			if (!childResource) continue;
+
+			const subQuery = isSubQueryInclude(sub) ? sub : null;
+			const childInclude = subQuery
+				? subQuery.include
+				: sub && typeof sub === 'object'
+					? (sub as Record<string, any>)
+					: undefined;
+			const childSort = subQuery?.orderBy;
+
+			for (const row of rows) {
+				const node = row?.value?.[relName];
+				if (!node) continue;
+				const childRows =
+					relation.type === 'many'
+						? Array.isArray(node.value)
+							? node.value
+							: []
+						: [node];
+				this.stripResolveRelations(
+					childRows,
+					childResource,
+					childInclude,
+					childSort,
+				);
+			}
 		}
 	}
 
@@ -400,26 +478,53 @@ export class QueryEngine {
 	}
 
 	/**
-	 * Recursively append the `id` tiebreaker to the `orderBy` of every windowed
-	 * (`limit`ed) `include`, so storage seeds each per-parent window with the same
-	 * total order (`[...orderBy, id]`) that `WindowIndex` and backfill/cursor reads
-	 * use. Returns a new include tree; the original (used by `ingest`, whose
+	 * Prepare the resolve `include` tree for a windowed read, threading each
+	 * level's resource so it can do two resource-dependent transforms:
+	 *
+	 * 1. **Sort-relation enrichment** — for a windowed (`limit`ed) sub-include
+	 *    ordered by a relational key (`assignee.name`), pull in the relation its
+	 *    `orderBy` needs so the child rows carry the objects the per-parent
+	 *    `WindowIndex` derives its sort keys from (stripped back out by
+	 *    `stripResolveRelations`). Gated on `limit`: a non-windowed include seeds
+	 *    no window, so it needs no engine-added relation.
+	 * 2. **Tiebreaker** — append `id` to every windowed `orderBy` so storage seeds
+	 *    each per-parent window in the same total order (`[...orderBy, id]`) the
+	 *    `WindowIndex` and backfill/cursor reads use.
+	 *
+	 * Returns a new include tree; the original (used by `ingest`, whose
 	 * `sortKeyFor` expects `orderBy` without the tiebreaker the window appends
 	 * itself) is left untouched.
 	 */
-	private withIncludeTiebreakers(
+	private prepareResolveInclude(
 		include: Record<string, any>,
+		resource: string,
 	): Record<string, any> {
 		const result: Record<string, any> = {};
 		for (const [relName, value] of Object.entries(include)) {
+			const childResource = this.schema[resource]?.relations?.[relName]?.entity
+				.name as string | undefined;
+
 			if (isSubQueryInclude(value)) {
-				const nested = value.include
-					? this.withIncludeTiebreakers(value.include)
-					: value.include;
+				const windowed = value.limit !== undefined;
+
+				const childInclude: Record<string, any> = { ...(value.include ?? {}) };
+				if (windowed && childResource)
+					for (const rel of this.addedSortRelations(
+						childResource,
+						value.orderBy,
+						value.include,
+					))
+						childInclude[rel] = true;
+
+				const nested =
+					childResource && Object.keys(childInclude).length > 0
+						? this.prepareResolveInclude(childInclude, childResource)
+						: value.include;
+
 				result[relName] = {
 					...value,
 					...(nested !== undefined ? { include: nested } : {}),
-					...(value.limit !== undefined
+					...(windowed
 						? {
 								orderBy: [
 									...(value.orderBy ?? []),
@@ -428,8 +533,8 @@ export class QueryEngine {
 							}
 						: {}),
 				};
-			} else if (value && typeof value === 'object') {
-				result[relName] = this.withIncludeTiebreakers(value);
+			} else if (value && typeof value === 'object' && childResource) {
+				result[relName] = this.prepareResolveInclude(value, childResource);
 			} else {
 				result[relName] = value;
 			}
@@ -1885,16 +1990,18 @@ export class QueryEngine {
 			// itself matches any query, so it runs alongside the matching pass below.
 			// It reads storage, so surface a rejection instead of leaving windows
 			// silently unreconciled with an unhandled promise.
-			void this.handleRelationalSortFanout(mutation, objValue).catch((error) => {
-				this.logger.error(
-					'[QueryEngine] Error during relational sort fan-out',
-					{
-						error,
-						resource: mutation.resource,
-						resourceId: mutation.resourceId,
-					},
-				);
-			});
+			void this.handleRelationalSortFanout(mutation, objValue).catch(
+				(error) => {
+					this.logger.error(
+						'[QueryEngine] Error during relational sort fan-out',
+						{
+							error,
+							resource: mutation.resource,
+							resourceId: mutation.resourceId,
+						},
+					);
+				},
+			);
 
 			// Step 2: Use getMatchingQueries to determine current matching state
 			this.getMatchingQueries(mutation, objValue).then(

--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -29,7 +29,7 @@ import {
 } from "./dialect-helpers";
 import { type RawMutationResult, Storage } from "./interface";
 import { initializeSchema } from "./schema-init";
-import { applyInclude, applyWhere } from "./sql-utils";
+import { applyInclude, applyRelationalOrderBy, applyWhere } from "./sql-utils";
 
 export class SQLStorage extends Storage {
   private readonly db: Kysely<{ [x: string]: Selectable<any> }>;
@@ -212,47 +212,12 @@ export class SQLStorage extends Storage {
     }
 
     if (sort !== undefined) {
-      sort.forEach((s) => {
-        // A relational sort key (`"author.name"`) orders by a related object's
-        // column. Resolve it with a correlated scalar subquery rather than a join
-        // so it never conflicts with joins the `where` clause may already add.
-        const dot = s.key.indexOf(".");
-        if (dot !== -1) {
-          const relationName = s.key.slice(0, dot);
-          const field = s.key.slice(dot + 1);
-          const relation = this.schema?.[resourceName]?.relations?.[relationName];
-
-          if (relation?.type === "one" && relation.relationalColumn) {
-            const otherResource = relation.entity.name;
-            const relationalColumn = String(relation.relationalColumn);
-            queryBuilder = queryBuilder.orderBy(
-              (eb: any) =>
-                eb
-                  .selectFrom(otherResource)
-                  .select(`${otherResource}.${field}`)
-                  .whereRef(
-                    `${otherResource}.id`,
-                    "=",
-                    `${resourceName}.${relationalColumn}`,
-                  ),
-              s.direction,
-            );
-            return;
-          }
-
-          // A dotted key that resolves to a relation we can't order by (a `many`
-          // relation, or a `one` without a `relationalColumn`) would otherwise
-          // fall through and hand the raw `"relation.field"` to `orderBy`,
-          // surfacing as an opaque missing-FROM SQL error. Fail with a clear one.
-          if (relation) {
-            throw new Error(
-              `Relational sort on "${s.key}" is only supported for "one" relations with a relationalColumn`,
-            );
-          }
-        }
-
-        queryBuilder = queryBuilder.orderBy(s.key, s.direction);
-      });
+      queryBuilder = applyRelationalOrderBy(
+        this.schema,
+        resourceName,
+        queryBuilder,
+        sort,
+      );
     }
 
     const rawResult = await queryBuilder.execute();

--- a/packages/live-state/src/server/storage/sql-utils.ts
+++ b/packages/live-state/src/server/storage/sql-utils.ts
@@ -227,6 +227,63 @@ function selectMainColumns(
   return eb.selectFrom(tableName).selectAll(tableName);
 }
 
+/**
+ * Apply a `sort` spec to a query, resolving relational sort keys. An own-column
+ * key (`"name"`) becomes a plain `orderBy`; a relational key (`"author.name"`)
+ * orders by a *related* object's column, resolved with a correlated scalar
+ * subquery rather than a join so it never conflicts with joins the `where`
+ * clause may already add. Shared by the root query (`sql-storage.get`) and every
+ * windowed `include` (`applyInclude`), so relational ordering resolves the same
+ * way at any nesting depth.
+ */
+export function applyRelationalOrderBy(
+  schema: Schema<any>,
+  resource: string,
+  query: SelectQueryBuilder<any, any, any>,
+  sort: { key: string; direction: "asc" | "desc" }[]
+): SelectQueryBuilder<any, any, any> {
+  for (const s of sort) {
+    const dot = s.key.indexOf(".");
+    if (dot !== -1) {
+      const relationName = s.key.slice(0, dot);
+      const field = s.key.slice(dot + 1);
+      const relation = schema?.[resource]?.relations?.[relationName];
+
+      if (relation?.type === "one" && relation.relationalColumn) {
+        const otherResource = relation.entity.name;
+        const relationalColumn = String(relation.relationalColumn);
+        query = query.orderBy(
+          (eb: any) =>
+            eb
+              .selectFrom(otherResource)
+              .select(`${otherResource}.${field}`)
+              .whereRef(
+                `${otherResource}.id`,
+                "=",
+                `${resource}.${relationalColumn}`
+              ),
+          s.direction
+        );
+        continue;
+      }
+
+      // A dotted key that resolves to a relation we can't order by (a `many`
+      // relation, or a `one` without a `relationalColumn`) would otherwise fall
+      // through and hand the raw `"relation.field"` to `orderBy`, surfacing as an
+      // opaque missing-FROM SQL error. Fail with a clear one.
+      if (relation) {
+        throw new Error(
+          `Relational sort on "${s.key}" is only supported for "one" relations with a relationalColumn`
+        );
+      }
+    }
+
+    query = query.orderBy(s.key, s.direction);
+  }
+
+  return query;
+}
+
 export function applyInclude<T extends LiveObjectAny>(
   schema: Schema<any>,
   resource: string,
@@ -308,14 +365,16 @@ export function applyInclude<T extends LiveObjectAny>(
         );
       }
 
-      // Apply sub-query orderBy
+      // Apply sub-query orderBy, resolving relational sort keys (`assignee.name`)
+      // relative to the included resource so a windowed include's `LIMIT` selects
+      // the correct per-parent top-N.
       if (subQueryOptions?.orderBy) {
-        for (const order of subQueryOptions.orderBy) {
-          subQuery = subQuery.orderBy(
-            `${otherresource}.${order.key}`,
-            order.direction
-          );
-        }
+        subQuery = applyRelationalOrderBy(
+          schema,
+          otherresource,
+          subQuery,
+          subQueryOptions.orderBy
+        );
       }
 
       // Apply sub-query limit

--- a/packages/live-state/test/e2e/query-engine.test.ts
+++ b/packages/live-state/test/e2e/query-engine.test.ts
@@ -2499,4 +2499,194 @@ describe("Query Engine Functional Requirements", () => {
       result.unsubscribe?.();
     });
   });
+
+  // Relational orderBy inside a *windowed include*: each post keeps a top-N
+  // window of its comments ordered by a grandchild relation (the comment's
+  // author name). A rename of a comment author must reorder that post's comment
+  // window via the same reverse-ref fan-out + boundary read as the root case,
+  // and the initial seed must select the correct per-parent top-N (which needs
+  // storage to resolve the relational include orderBy). See #195 / ADR-0003.
+  describe("Relational orderBy in a windowed include (grandchild sort key)", () => {
+    const settle = () => new Promise((resolve) => setTimeout(resolve, 250));
+
+    // A dedicated post whose comments are authored by three fresh users, so the
+    // window is independent of the base-seed data.
+    let post: string;
+    let authorA: string; // "Alice" -> commentA
+    let authorB: string; // "Bob"   -> commentB
+    let authorC: string; // "Carol" -> commentC (outside a top-2 window)
+    let commentA: string;
+    let commentB: string;
+    let commentC: string;
+
+    const setup = async () => {
+      post = generateId();
+      authorA = generateId();
+      authorB = generateId();
+      authorC = generateId();
+      commentA = generateId();
+      commentB = generateId();
+      commentC = generateId();
+
+      await storage.insert(deepSchema.users, {
+        id: authorA,
+        name: "Alice",
+        email: "alice@x.com",
+        orgId: orgId1,
+      });
+      await storage.insert(deepSchema.users, {
+        id: authorB,
+        name: "Bob",
+        email: "bob@x.com",
+        orgId: orgId1,
+      });
+      await storage.insert(deepSchema.users, {
+        id: authorC,
+        name: "Carol",
+        email: "carol@x.com",
+        orgId: orgId1,
+      });
+      await storage.insert(deepSchema.posts, {
+        id: post,
+        title: "Windowed comments",
+        content: "…",
+        authorId: authorA,
+        likes: 0,
+      });
+      await storage.insert(deepSchema.comments, {
+        id: commentA,
+        content: "a",
+        postId: post,
+        authorId: authorA,
+      });
+      await storage.insert(deepSchema.comments, {
+        id: commentB,
+        content: "b",
+        postId: post,
+        authorId: authorB,
+      });
+      await storage.insert(deepSchema.comments, {
+        id: commentC,
+        content: "c",
+        postId: post,
+        authorId: authorC,
+      });
+    };
+
+    // posts -> each post's top-2 comments ordered by the comment author's name.
+    const subscribeWindowedComments = (mutations: any[]) =>
+      handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          include: {
+            comments: {
+              limit: 2,
+              orderBy: [{ key: "author.name", direction: "asc" }],
+            },
+          },
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+    const commentIds = (data: any[]): string[] => {
+      const p = data.find((row: any) => row.value.id.value === post);
+      const comments = p?.value?.comments?.value ?? [];
+      return comments.map((c: any) => c.value.id.value);
+    };
+
+    test("seeds each post's comment window in author-name order", async () => {
+      await setup();
+      const result = await subscribeWindowedComments([]);
+
+      // Top-2 by author name asc: Alice's comment, then Bob's. Carol is outside.
+      expect(commentIds(result.data)).toEqual([commentA, commentB]);
+
+      // The engine-added `author` relation (pulled in only to derive sort keys)
+      // is stripped from the nested comment rows.
+      const p = result.data.find((row: any) => row.value.id.value === post);
+      expect(p.value.comments.value[0].value.author).toBeUndefined();
+
+      result.unsubscribe?.();
+    });
+
+    test("author rename demotes an in-window comment (DELETE) and backfills the unseen one (INSERT)", async () => {
+      await setup();
+      const mutations: any[] = [];
+      const result = await subscribeWindowedComments(mutations);
+      expect(commentIds(result.data)).toEqual([commentA, commentB]);
+
+      // Alice -> "Zed": order becomes Bob, Carol, Zed, so commentA leaves the
+      // top-2 and commentC (never loaded) must be promoted via a boundary read.
+      await storage.update(deepSchema.users, authorA, { name: "Zed" });
+      await settle();
+
+      const del = mutations.find(
+        (m) => m.resourceId === commentA && m.op === "DELETE"
+      );
+      expect(del).toBeDefined();
+      expect(del.payload).toEqual({});
+
+      const backfill = mutations.find(
+        (m) => m.resourceId === commentC && m.op === "INSERT"
+      );
+      expect(backfill).toBeDefined();
+      expect(backfill.payload.content.value).toBe("c");
+      // The INSERT carries the comment's own columns, not the author the engine
+      // included to order the boundary read.
+      expect(backfill.payload.author).toBeUndefined();
+
+      result.unsubscribe?.();
+    });
+
+    test("renaming an out-of-window author promotes its unseen comment (INSERT) and evicts the boundary (DELETE)", async () => {
+      await setup();
+      const mutations: any[] = [];
+      const result = await subscribeWindowedComments(mutations);
+      expect(commentIds(result.data)).toEqual([commentA, commentB]);
+
+      // Carol -> "Aaa" (out-of-window commentC): order becomes Aaa, Alice, Bob,
+      // so commentC enters the top-2 and Bob's commentB is evicted. No in-window
+      // comment changed, so only the boundary read can catch this promotion.
+      await storage.update(deepSchema.users, authorC, { name: "Aaa" });
+      await settle();
+
+      const promoted = mutations.find(
+        (m) => m.resourceId === commentC && m.op === "INSERT"
+      );
+      expect(promoted).toBeDefined();
+      expect(promoted.payload.content.value).toBe("c");
+
+      const evicted = mutations.find(
+        (m) => m.resourceId === commentB && m.op === "DELETE"
+      );
+      expect(evicted).toBeDefined();
+      expect(evicted.payload).toEqual({});
+
+      result.unsubscribe?.();
+    });
+
+    test("author rename that only reorders within the comment window emits no delta", async () => {
+      await setup();
+      const mutations: any[] = [];
+      const result = await subscribeWindowedComments(mutations);
+      expect(commentIds(result.data)).toEqual([commentA, commentB]);
+
+      // Alice -> "Boris": the window is still {commentA, commentB} but their
+      // order flips (Bob before Boris). Membership is unchanged, so nothing is
+      // broadcast — the client re-sorts the rows it holds.
+      await storage.update(deepSchema.users, authorA, { name: "Boris" });
+      await settle();
+
+      expect(
+        mutations.some(
+          (m) =>
+            (m.op === "INSERT" || m.op === "DELETE") &&
+            [commentA, commentB, commentC].includes(m.resourceId)
+        )
+      ).toBe(false);
+
+      result.unsubscribe?.();
+    });
+  });
 });

--- a/packages/live-state/test/e2e/windowed-includes.test.ts
+++ b/packages/live-state/test/e2e/windowed-includes.test.ts
@@ -36,11 +36,19 @@ const project = object('projects', {
 	status: string(),
 });
 
+// `assigneeId` is nullable so the priority-ordered tests can keep inserting
+// tasks without an assignee; the relational-orderBy test below sets it.
+const user = object('users', {
+	id: id(),
+	name: string(),
+});
+
 const task = object('tasks', {
 	id: id(),
 	title: string(),
 	priority: number(),
 	projectId: reference('projects.id'),
+	assigneeId: reference('users.id').nullable(),
 });
 
 const projectRelations = createRelations(project, ({ many }) => ({
@@ -49,13 +57,20 @@ const projectRelations = createRelations(project, ({ many }) => ({
 
 const taskRelations = createRelations(task, ({ one }) => ({
 	project: one(project, 'projectId'),
+	assignee: one(user, 'assigneeId'),
+}));
+
+const userRelations = createRelations(user, ({ many }) => ({
+	assignedTasks: many(task, 'assigneeId'),
 }));
 
 const testSchema = createSchema({
 	projects: project,
 	tasks: task,
+	users: user,
 	projectRelations,
 	taskRelations,
+	userRelations,
 });
 
 const publicRoute = routeFactory();
@@ -65,6 +80,7 @@ const testRouter = router({
 	routes: {
 		projects: publicRoute.withProcedures(() => ({})),
 		tasks: publicRoute.withProcedures(() => ({})),
+		users: publicRoute.withProcedures(() => ({})),
 	},
 });
 
@@ -385,6 +401,79 @@ describe('Windowed includes (per-parent windows)', () => {
 		expect(mutations.some((m) => m.resourceId === c1 && m.op === 'INSERT')).toBe(
 			false,
 		);
+
+		result.unsubscribe?.();
+	});
+
+	// Dialect parity for #195: seeding a windowed include ordered by a *relational*
+	// key (`assignee.name`) requires storage to resolve that key with a correlated
+	// subquery inside the include's `LIMIT`. The primary relational-include suite
+	// runs on Postgres (query-engine.test.ts); this pins the same behavior on the
+	// SQLite dialect.
+	test('seeds a windowed include ordered by a relational key (assignee.name) on SQLite', async () => {
+		const proj = generateId();
+		await storage.insert(testSchema.projects, {
+			id: proj,
+			name: 'Sort',
+			status: 'active',
+		});
+
+		// Three assignees; the top-2 by name are Ann and Bea, Cid is outside.
+		const users: { id: string; name: string }[] = [];
+		for (const name of ['Ann', 'Bea', 'Cid']) {
+			const uid = generateId();
+			await storage.insert(testSchema.users, { id: uid, name });
+			users.push({ id: uid, name });
+		}
+		const userByName = (name: string) => users.find((u) => u.name === name)!.id;
+
+		// Insert in a deliberately shuffled order so a correct seed can only come
+		// from ordering by the assignee's name, not insertion/id order.
+		const tCid = generateId();
+		const tAnn = generateId();
+		const tBea = generateId();
+		await storage.insert(testSchema.tasks, {
+			id: tCid,
+			title: 't-cid',
+			priority: 0,
+			projectId: proj,
+			assigneeId: userByName('Cid'),
+		});
+		await storage.insert(testSchema.tasks, {
+			id: tAnn,
+			title: 't-ann',
+			priority: 0,
+			projectId: proj,
+			assigneeId: userByName('Ann'),
+		});
+		await storage.insert(testSchema.tasks, {
+			id: tBea,
+			title: 't-bea',
+			priority: 0,
+			projectId: proj,
+			assigneeId: userByName('Bea'),
+		});
+
+		const result = await handleQuery({
+			req: {
+				type: 'QUERY',
+				resource: 'projects',
+				where: { id: proj },
+				include: {
+					tasks: {
+						limit: 2,
+						orderBy: [{ key: 'assignee.name', direction: 'asc' }],
+					},
+				},
+			},
+		});
+
+		// Top-2 tasks by assignee name asc: Ann's task, then Bea's.
+		expect(windowIds(result.data, proj)).toEqual([tAnn, tBea]);
+
+		// The engine-added `assignee` relation is stripped from the nested rows.
+		const parent = result.data.find((p: any) => p.value.id.value === proj);
+		expect(parent.value.tasks.value[0].value.assignee).toBeUndefined();
 
 		result.unsubscribe?.();
 	});


### PR DESCRIPTION
Closes #195.

Extends #187's relational `orderBy` from **root** windowed queries to **nested windowed `include`s** — e.g. each post keeping a top-N window of its comments ordered by `author.name` (a grandchild relation).

## Two gaps closed

**Storage — the load-bearing half.** `sql-utils.applyInclude` ordered a windowed sub-include with a raw dotted key: `orderBy(\`${resource}.${key}\`)` → `ORDER BY tasks."assignee.name"` (a nonexistent column) *before* `LIMIT N`, so the wrong per-parent top-N was selected (or it errored). #187 taught only the **root** path (`sql-storage.get`) to resolve a dotted key via a correlated scalar subquery.
- Extracted a shared `applyRelationalOrderBy(schema, resource, qb, sort)` in `sql-utils.ts` (correlated subquery + the clear-error for `many`/no-`relationalColumn` from PR #194) and call it from **both** `sql-storage.get` and `applyInclude`. `applyInclude` recurses, so each level resolves relative to its own resource → arbitrary depth.

**Engine — seeding.** `get()` only enriched the *root* include with its sort relations; nested windowed sub-includes resolved without `assignee`, so `sortKeyFor()` seeded `undefined`.
- Generalized `withIncludeTiebreakers` into a resource-threaded `prepareResolveInclude(include, resource)` that, per **windowed** (`limit`ed) sub-include, pulls in the relations its `orderBy` needs (that the caller didn't already include) and appends the `id` tiebreaker.
- A shared `addedSortRelations` rule drives both enrichment and a recursive `stripResolveRelations`, so engine-added relations are stripped at every nesting level and enrichment/strip can't disagree (no leaked engine relations, no deleted caller data). Root behavior is unchanged.

**Realtime — no new code.** Once seeding wires `comment → author` into the graph (via `loadNestedRelations`), the existing reverse-ref fan-out finds in-window rows and the per-parent `reconcilePromotions` (whose boundary reads go through the flat root `get` path) reconciles nested include windows on a related write.

## Acceptance criteria
- [x] `applyInclude` resolves a relational `orderBy` on a windowed include via a correlated subquery so `LIMIT` selects the correct per-parent top-N
- [x] A windowed `include` ordered by a relational key seeds its per-parent `WindowIndex` with correct sort keys
- [x] Engine-added sort relations are stripped from returned rows (recursively, every level)
- [x] Fan-out + boundary read reconciles nested windowed includes on a related-object write
- [x] E2E: a windowed include ordered by a grandchild relation reacts correctly to a rename (Postgres) + seeding on SQLite

## Testing
- `query-engine.test.ts` (Postgres, existing deep schema): `posts.include({ comments: { limit: 2, orderBy: [author.name] } })` — seed order, in-window demotion + backfill, unseen-row promotion + eviction, no-op reorder.
- `windowed-includes.test.ts` (SQLite): one seeding-order case ordered by `assignee.name` for dialect parity.
- All five new tests were verified to **fail on the prior code**. Full suite green (846 passed), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sorting for included records using related fields, including nested/windowed includes.
  * Added support for relational sorting in SQL-backed reads without changing the visible result shape.

* **Bug Fixes**
  * Fixed windowed include results so engine-added related data is removed from returned records.
  * Improved update behavior when relational sorting affects which records enter or leave a window.
  * Added coverage for relational ordering cases to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->