### PR TITLE
fix(query-engine): resolve relational sort key on own-row FK change/insert (#196)

### DIFF
--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -514,7 +514,14 @@ export class QueryEngine {
 			}),
 		);
 		const enriched = rows[0] ? inferValue(rows[0]) : undefined;
-		return enriched ?? objValue;
+		if (!enriched || typeof enriched !== 'object') return objValue;
+		// Mark each sort relation as resolved even when it's null/missing: a key
+		// present with an absent relation signals NULLS ordering to `sortKeyFor`,
+		// so an FK reassigned to `null` sorts NULLS-first rather than falling back
+		// to the previous key's stale component (#196).
+		for (const rel of Object.keys(sortInclude))
+			if (!(rel in enriched)) enriched[rel] = undefined;
+		return enriched;
 	}
 
 	/**
@@ -913,9 +920,11 @@ export class QueryEngine {
 	/**
 	 * Extract a row's sort key in `orderBy` order. Own-column keys read the row's
 	 * field; a relational key (`author.name`) reads the included related object.
-	 * When the row does not carry that relation — a bare mutation payload lacks
-	 * it — the component falls back to `previousKey`, so an own-column update
-	 * never clobbers a relational sort-key component it cannot see.
+	 * When the row does not carry that relation at all — a bare mutation payload
+	 * lacks it — the component falls back to `previousKey`, so an own-column update
+	 * never clobbers a relational sort-key component it cannot see. When the
+	 * relation key is present but its object is null/missing (a resolved read),
+	 * the component is `undefined` (NULLS ordering) rather than the stale fallback.
 	 */
 	private sortKeyFor(
 		queryNode: QueryNode,
@@ -930,6 +939,11 @@ export class QueryEngine {
 			const related = objValue?.[relationName];
 			if (related && typeof related === 'object' && field in related)
 				return related[field];
+			// The relation key is present but its object is null/missing — it was
+			// resolved (e.g. FK reassigned to `null`), so order NULLS-first instead
+			// of reusing the stale previous-key component (#196).
+			if (objValue && typeof objValue === 'object' && relationName in objValue)
+				return undefined;
 			return previousKey?.[i];
 		});
 	}
@@ -1975,37 +1989,17 @@ export class QueryEngine {
 
 			this.getMatchingQueries(mutation, objValue).then(
 				async (matchingQueries) => {
-					for (const queryHash of matchingQueries) {
-						const queryNode = this.queryNodes.get(queryHash);
+					try {
+						for (const queryHash of matchingQueries) {
+							const queryNode = this.queryNodes.get(queryHash);
 
-						if (!queryNode) continue; // TODO should we throw an error here?
+							if (!queryNode) continue; // TODO should we throw an error here?
 
-						if (queryNode.windowIndex) {
-							// A new row carries no previous key, so a relational sort key must be
-							// derived from the row's actual related object rather than an absent
-							// fallback (#196); resolve it before placing the row in the window.
-							// Non-relational windows resolve to a no-op (no read).
-							const insertValue = await this.resolveSortRelations(
-								queryNode,
-								mutation.resourceId,
-								objValue,
-							);
-							this.handleWindowedInsert(
-								queryNode,
-								queryNode.windowIndex,
-								mutation,
-								insertValue,
-							);
-							continue;
-						}
-
-						// Windowed `include`: route the child to its parent's window via the
-						// foreign key. `getMatchingQueries` already confirmed the parent is in
-						// scope, so the FK value is a tracked parent.
-						const foreignColumn = this.includeForeignColumn(queryNode);
-						if (foreignColumn) {
-							const parentId = objValue[foreignColumn];
-							if (parentId != null) {
+							if (queryNode.windowIndex) {
+								// A new row carries no previous key, so a relational sort key must be
+								// derived from the row's actual related object rather than an absent
+								// fallback (#196); resolve it before placing the row in the window.
+								// Non-relational windows resolve to a no-op (no read).
 								const insertValue = await this.resolveSortRelations(
 									queryNode,
 									mutation.resourceId,
@@ -2013,36 +2007,64 @@ export class QueryEngine {
 								);
 								this.handleWindowedInsert(
 									queryNode,
-									this.ensureParentWindow(queryNode, parentId),
+									queryNode.windowIndex,
 									mutation,
 									insertValue,
 								);
+								continue;
 							}
-							continue;
-						}
 
-						queryNode.trackedObjects.add(mutation.resourceId);
+							// Windowed `include`: route the child to its parent's window via the
+							// foreign key. `getMatchingQueries` already confirmed the parent is in
+							// scope, so the FK value is a tracked parent.
+							const foreignColumn = this.includeForeignColumn(queryNode);
+							if (foreignColumn) {
+								const parentId = objValue[foreignColumn];
+								if (parentId != null) {
+									const insertValue = await this.resolveSortRelations(
+										queryNode,
+										mutation.resourceId,
+										objValue,
+									);
+									this.handleWindowedInsert(
+										queryNode,
+										this.ensureParentWindow(queryNode, parentId),
+										mutation,
+										insertValue,
+									);
+								}
+								continue;
+							}
 
-						if (storedObjectNode) {
-							storedObjectNode.matchedQueries.add(queryHash);
-						}
+							queryNode.trackedObjects.add(mutation.resourceId);
 
-						for (const subscription of Array.from(queryNode.subscriptions)) {
-							try {
-								subscription(mutation);
-							} catch (error) {
-								this.logger.error(
-									'[QueryEngine] Error in subscription callback during INSERT mutation',
-									{
-										error,
-										queryHash: queryNode.hash,
-										resource: mutation.resource,
-										resourceId: mutation.resourceId,
-										stepPath: queryNode.queryStep.stepPath.join('.'),
-									},
-								);
+							if (storedObjectNode) {
+								storedObjectNode.matchedQueries.add(queryHash);
+							}
+
+							for (const subscription of Array.from(queryNode.subscriptions)) {
+								try {
+									subscription(mutation);
+								} catch (error) {
+									this.logger.error(
+										'[QueryEngine] Error in subscription callback during INSERT mutation',
+										{
+											error,
+											queryHash: queryNode.hash,
+											resource: mutation.resource,
+											resourceId: mutation.resourceId,
+											stepPath: queryNode.queryStep.stepPath.join('.'),
+										},
+									);
+								}
 							}
 						}
+					} catch (error) {
+						this.logger.error('[QueryEngine] Error handling INSERT mutation', {
+							error,
+							resource: mutation.resource,
+							resourceId: mutation.resourceId,
+						});
 					}
 				},
 				(error: unknown) => {

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -464,6 +464,60 @@ export class QueryEngine {
 	}
 
 	/**
+	 * The foreign-key columns backing a windowed node's relational sort deps
+	 * (e.g. `authorId` for an `author.name` sort). An own-row write to one of
+	 * these reassigns which related object supplies a sort component, so the row's
+	 * previous key is stale and its true related object must be resolved (#196).
+	 */
+	private relationalSortFkColumns(queryNode: QueryNode): Set<string> {
+		const cols = new Set<string>();
+		const deps = this.relationalSortDeps(queryNode.queryStep.query);
+		if (deps.length === 0) return cols;
+		const relationalColumns = this.getRelationalColumns(
+			queryNode.queryStep.query.resource,
+		);
+		for (const [column, { relationName }] of Array.from(relationalColumns))
+			if (deps.some((d) => d.relationName === relationName)) cols.add(column);
+		return cols;
+	}
+
+	/** Whether a mutation payload reassigns one of a node's sorted-relation FKs. */
+	private ownWriteTouchesSortRelationFk(
+		queryNode: QueryNode,
+		payload: Record<string, any> | undefined,
+	): boolean {
+		if (!payload) return false;
+		for (const column of Array.from(this.relationalSortFkColumns(queryNode)))
+			if (column in payload) return true;
+		return false;
+	}
+
+	/**
+	 * Resolve a row's related sort objects (the relations its relational sort keys
+	 * are derived from) so its sort key reflects the true related field rather than
+	 * the FK-only mutation payload or an absent previous key (#196). Reads the row
+	 * with the sort relations `include`d and returns the enriched value; a node with
+	 * no relational sort deps resolves to the input value with no read.
+	 */
+	private async resolveSortRelations(
+		queryNode: QueryNode,
+		resourceId: string,
+		objValue: any,
+	): Promise<any> {
+		const sortInclude = this.sortRelationInclude(queryNode);
+		if (!sortInclude) return objValue;
+		const rows = await toPromiseLike(
+			this.storage.get({
+				resource: queryNode.queryStep.query.resource,
+				where: { id: resourceId },
+				include: sortInclude,
+			}),
+		);
+		const enriched = rows[0] ? inferValue(rows[0]) : undefined;
+		return enriched ?? objValue;
+	}
+
+	/**
 	 * Drop the sort-relation objects a boundary read pulled in for ordering from a
 	 * delta payload, so an `INSERT` broadcast carries only the row's own columns
 	 * and not the related objects the engine included purely to derive sort keys.
@@ -1047,6 +1101,19 @@ export class QueryEngine {
 		const id = mutation.resourceId;
 		const wasInWindow = wi.has(id);
 
+		// A row scoping in has no previous key, and an own-row write that reassigned
+		// the sorted relation's FK invalidates the previous key's relational
+		// component — both need the related sort object resolved so the sort key is
+		// derived from the true related field, not an `undefined`/stale fallback
+		// (#196). An unrelated own-field update of an in-window row keeps the #187
+		// fast path (previous-key fallback, no read).
+		if (
+			predicateMatches &&
+			(!wasInWindow ||
+				this.ownWriteTouchesSortRelationFk(queryNode, mutation.payload))
+		)
+			objValue = await this.resolveSortRelations(queryNode, id, objValue);
+
 		if (predicateMatches) {
 			if (wasInWindow) {
 				await this.refreshInWindow(queryNode, wi, mutation, objValue);
@@ -1168,9 +1235,21 @@ export class QueryEngine {
 			: undefined;
 		const held = this.parentWindowHolding(queryNode, id);
 		const oldParentId = held?.parentId;
+		const sameList = oldParentId !== undefined && oldParentId === newParentId;
+
+		// Resolve the related sort object when a fresh relational sort component is
+		// needed: entering a new parent's window (no previous key there) or an
+		// own-row write that reassigned the sorted relation's FK on a same-list
+		// refresh (#196). A same-list unrelated update keeps the previous-key
+		// fast path, and non-relational windows resolve to a no-op (no read).
+		if (
+			(newParentId !== undefined && !sameList) ||
+			this.ownWriteTouchesSortRelationFk(queryNode, mutation.payload)
+		)
+			objValue = await this.resolveSortRelations(queryNode, id, objValue);
 
 		// Same list: refresh in place (field UPDATE or boundary reconcile).
-		if (oldParentId !== undefined && oldParentId === newParentId) {
+		if (sameList) {
 			await this.refreshInWindow(queryNode, held!.wi, mutation, objValue, {
 				column: foreignColumn,
 				parentId: oldParentId,
@@ -1894,63 +1973,86 @@ export class QueryEngine {
 
 			const storedObjectNode = this.objectNodes.get(mutation.resourceId);
 
-			this.getMatchingQueries(mutation, objValue).then((matchingQueries) => {
-				for (const queryHash of matchingQueries) {
-					const queryNode = this.queryNodes.get(queryHash);
+			this.getMatchingQueries(mutation, objValue).then(
+				async (matchingQueries) => {
+					for (const queryHash of matchingQueries) {
+						const queryNode = this.queryNodes.get(queryHash);
 
-					if (!queryNode) continue; // TODO should we throw an error here?
+						if (!queryNode) continue; // TODO should we throw an error here?
 
-					if (queryNode.windowIndex) {
-						this.handleWindowedInsert(
-							queryNode,
-							queryNode.windowIndex,
-							mutation,
-							objValue,
-						);
-						continue;
-					}
-
-					// Windowed `include`: route the child to its parent's window via the
-					// foreign key. `getMatchingQueries` already confirmed the parent is in
-					// scope, so the FK value is a tracked parent.
-					const foreignColumn = this.includeForeignColumn(queryNode);
-					if (foreignColumn) {
-						const parentId = objValue[foreignColumn];
-						if (parentId != null) {
-							this.handleWindowedInsert(
+						if (queryNode.windowIndex) {
+							// A new row carries no previous key, so a relational sort key must be
+							// derived from the row's actual related object rather than an absent
+							// fallback (#196); resolve it before placing the row in the window.
+							// Non-relational windows resolve to a no-op (no read).
+							const insertValue = await this.resolveSortRelations(
 								queryNode,
-								this.ensureParentWindow(queryNode, parentId),
-								mutation,
+								mutation.resourceId,
 								objValue,
 							);
-						}
-						continue;
-					}
-
-					queryNode.trackedObjects.add(mutation.resourceId);
-
-					if (storedObjectNode) {
-						storedObjectNode.matchedQueries.add(queryHash);
-					}
-
-					for (const subscription of Array.from(queryNode.subscriptions)) {
-						try {
-							subscription(mutation);
-						} catch (error) {
-							this.logger.error(
-								'[QueryEngine] Error in subscription callback during INSERT mutation',
-								{
-									error,
-									queryHash: queryNode.hash,
-									resource: mutation.resource,
-									resourceId: mutation.resourceId,
-									stepPath: queryNode.queryStep.stepPath.join('.'),
-								},
+							this.handleWindowedInsert(
+								queryNode,
+								queryNode.windowIndex,
+								mutation,
+								insertValue,
 							);
+							continue;
+						}
+
+						// Windowed `include`: route the child to its parent's window via the
+						// foreign key. `getMatchingQueries` already confirmed the parent is in
+						// scope, so the FK value is a tracked parent.
+						const foreignColumn = this.includeForeignColumn(queryNode);
+						if (foreignColumn) {
+							const parentId = objValue[foreignColumn];
+							if (parentId != null) {
+								const insertValue = await this.resolveSortRelations(
+									queryNode,
+									mutation.resourceId,
+									objValue,
+								);
+								this.handleWindowedInsert(
+									queryNode,
+									this.ensureParentWindow(queryNode, parentId),
+									mutation,
+									insertValue,
+								);
+							}
+							continue;
+						}
+
+						queryNode.trackedObjects.add(mutation.resourceId);
+
+						if (storedObjectNode) {
+							storedObjectNode.matchedQueries.add(queryHash);
+						}
+
+						for (const subscription of Array.from(queryNode.subscriptions)) {
+							try {
+								subscription(mutation);
+							} catch (error) {
+								this.logger.error(
+									'[QueryEngine] Error in subscription callback during INSERT mutation',
+									{
+										error,
+										queryHash: queryNode.hash,
+										resource: mutation.resource,
+										resourceId: mutation.resourceId,
+										stepPath: queryNode.queryStep.stepPath.join('.'),
+									},
+								);
+							}
 						}
 					}
-				}
-			});
+				},
+				(error: unknown) => {
+					this.logger.error('[QueryEngine] Error handling INSERT mutation', {
+						error,
+						resource: mutation.resource,
+						resourceId: mutation.resourceId,
+					});
+				},
+			);
 
 			return;
 		}

--- a/packages/live-state/test/e2e/query-engine.test.ts
+++ b/packages/live-state/test/e2e/query-engine.test.ts
@@ -2498,6 +2498,206 @@ describe("Query Engine Functional Requirements", () => {
 
       result.unsubscribe?.();
     });
+
+    // Own-row writes (an INSERT, or a reassignment of the sorted relation's FK)
+    // carry only the FK column, not the related object, so the sort key's
+    // relational component must be resolved from storage rather than trusted from
+    // the payload / previous key. See issue #196.
+    test("inserting a post whose author sorts outside the window is not wrongly promoted", async () => {
+      const mutations: any[] = [];
+
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "author.name", direction: "asc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId4,
+      ]);
+
+      // New author "Boris" sorts *after* Bob Williams, so the new post belongs
+      // outside the top-2. Without resolving the related object the sort key's
+      // relational component is `undefined`, which sorts first (NULLS-first) and
+      // would wrongly place the row at the top of the window.
+      const borisId = generateId();
+      const newPostId = generateId();
+      await storage.insert(deepSchema.users, {
+        id: borisId,
+        name: "Boris",
+        email: "boris@techinc.com",
+        orgId: orgId2,
+      });
+      await storage.insert(deepSchema.posts, {
+        id: newPostId,
+        title: "Boris Post",
+        content: "By Boris",
+        authorId: borisId,
+        likes: 1,
+      });
+
+      await settle();
+
+      expect(
+        mutations.some((m) => m.resourceId === newPostId && m.op === "INSERT")
+      ).toBe(false);
+      expect(mutations.some((m) => m.op === "DELETE")).toBe(false);
+
+      result.unsubscribe?.();
+    });
+
+    test("inserting a post whose author sorts into the window places it and evicts the boundary", async () => {
+      const mutations: any[] = [];
+
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "author.name", direction: "asc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId4,
+      ]);
+
+      // New author "Amy Adams" sorts between Alice Johnson and Bob Williams, so
+      // the new post enters the top-2 at the second slot and evicts Bob's post.
+      const amyId = generateId();
+      const newPostId = generateId();
+      await storage.insert(deepSchema.users, {
+        id: amyId,
+        name: "Amy Adams",
+        email: "amy@techinc.com",
+        orgId: orgId2,
+      });
+      await storage.insert(deepSchema.posts, {
+        id: newPostId,
+        title: "Amy Post",
+        content: "By Amy",
+        authorId: amyId,
+        likes: 1,
+      });
+
+      await settle();
+
+      const inserted = mutations.find(
+        (m) => m.resourceId === newPostId && m.op === "INSERT"
+      );
+      expect(inserted).toBeDefined();
+      expect(inserted.payload.title.value).toBe("Amy Post");
+      // The engine-added `author` relation is not leaked into the INSERT payload.
+      expect(inserted.payload.author).toBeUndefined();
+
+      const evicted = mutations.find(
+        (m) => m.resourceId === postId4 && m.op === "DELETE"
+      );
+      expect(evicted).toBeDefined();
+      expect(evicted.payload).toEqual({});
+
+      result.unsubscribe?.();
+    });
+
+    test("reassigning an in-window post's author FK demotes it out (DELETE) and promotes an unseen row (INSERT)", async () => {
+      const mutations: any[] = [];
+
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "author.name", direction: "asc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId4,
+      ]);
+
+      // Reassign Alice's post (postId3, in-window) to John Doe. Its sort key must
+      // follow the *new* author (John Doe sorts last), so it leaves the top-2 and
+      // Jane's post (postId2) — never loaded, invisible to the graph — is promoted
+      // via the boundary read. The FK-only payload's stale previous key ("Alice
+      // Johnson") would otherwise keep it wrongly in the window.
+      await storage.update(deepSchema.posts, postId3, { authorId: userId1 });
+
+      await settle();
+
+      const del = mutations.find(
+        (m) => m.resourceId === postId3 && m.op === "DELETE"
+      );
+      expect(del).toBeDefined();
+      expect(del.payload).toEqual({});
+
+      const promoted = mutations.find(
+        (m) => m.resourceId === postId2 && m.op === "INSERT"
+      );
+      expect(promoted).toBeDefined();
+      expect(promoted.payload.title.value).toBe("Second Post");
+      expect(promoted.payload.author).toBeUndefined();
+
+      result.unsubscribe?.();
+    });
+
+    test("reassigning an out-of-window post's author FK scopes it in (INSERT) and evicts the boundary (DELETE)", async () => {
+      const mutations: any[] = [];
+
+      const result = await handleQuery({
+        req: {
+          type: "QUERY",
+          resource: "posts",
+          sort: [{ key: "author.name", direction: "asc" }],
+          limit: 2,
+        },
+        subscription: (m) => mutations.push(m),
+      });
+
+      expect(result.data.map((p: any) => p.value.id.value)).toEqual([
+        postId3,
+        postId4,
+      ]);
+
+      // Reassign Jane's post (postId2, currently outside the window) to a new
+      // author "Aaron Aaronson" who sorts first. The row has no previous key, so
+      // its relational sort component must be resolved from the new related object
+      // rather than defaulting to `undefined`; it then enters the top-2 and evicts
+      // Bob's post.
+      const aaronId = generateId();
+      await storage.insert(deepSchema.users, {
+        id: aaronId,
+        name: "Aaron Aaronson",
+        email: "aaron@acme.com",
+        orgId: orgId1,
+      });
+      await storage.update(deepSchema.posts, postId2, { authorId: aaronId });
+
+      await settle();
+
+      const inserted = mutations.find(
+        (m) => m.resourceId === postId2 && m.op === "INSERT"
+      );
+      expect(inserted).toBeDefined();
+      expect(inserted.payload.title.value).toBe("Second Post");
+      expect(inserted.payload.author).toBeUndefined();
+
+      const evicted = mutations.find(
+        (m) => m.resourceId === postId4 && m.op === "DELETE"
+      );
+      expect(evicted).toBeDefined();
+      expect(evicted.payload).toEqual({});
+
+      result.unsubscribe?.();
+    });
   });
 
   // Relational orderBy inside a *windowed include*: each post keeps a top-N


### PR DESCRIPTION
Closes #196.

Follow-up from #187 / PR #194. A windowed query ordered by a **related** object's field (e.g. posts ordered by `author.name`) derives each row's sort key from the included related object. An **own-row** write carries only the FK column (`authorId`), not the related object, so `sortKeyFor` fell back to:

1. **`previousKey`** on an FK change — masking the reassignment, so the row keeps its *old* author's sort component and sorts by a stale key.
2. **`undefined`** on an insert / scope-in with no previous key — with NULLS-first ordering the row is placed at the top of the window regardless of its true author name.

The #187 reverse-ref fan-out only reacts to writes on the *related* resource (an author rename), not the row's own FK, so neither path was covered.

## What changed

**Engine (`query-engine/index.ts`)**
- **`resolveSortRelations`** — for the mutated row, read it once with the sort relations `include`d and feed the true related field into the existing `sortKeyFor`. Only one row moved (the mutated one), so a single-row read suffices — no top-N re-read. A node with no relational sort deps resolves to a no-op (no read).
- **`relationalSortFkColumns` / `ownWriteTouchesSortRelationFk`** — detect whether a payload reassigns a sorted-relation FK.
- Wired into the existing handlers so all membership/eviction/backfill logic is reused:
  - **INSERT** — resolve before `handleWindowedInsert` (root + windowed include).
  - **`handleWindowedUpdate`** — resolve when scoping in (no previous key) **or** the sorted-relation FK changed; an unrelated own-field update of an in-window row keeps the #187 fast path (previous-key fallback, **no read**).
  - **`handleWindowedIncludeUpdate`** — same, per-parent window.

## Acceptance criteria
- [x] Inserting a row into a relational-`orderBy` window places it at its correct position (component derived from the related object, not `undefined`)
- [x] Reassigning a row's FK for the sorted relation re-sorts it and emits the correct membership deltas
- [x] An unrelated own-field update still preserves the relational component without an extra read (no regression to the #187 fast path)
- [x] E2E tests for both the insert and FK-change cases against a `posts` window ordered by `author.name`

## Testing
Four new E2E tests in the "Relational orderBy (sort key from a related object)" suite. Two are discriminating and were verified to **fail** on the prior engine (insert-outside-window not wrongly promoted; in-window FK-change demotion); the other two cover the positive scope-in / eviction paths and INSERT payload shape.

- `pnpm typecheck --filter="./packages/*"` ✅
- `pnpm lint --filter="./packages/*" -- --diagnostic-level error` ✅
- `pnpm test --filter="./packages/*"` ✅ (850 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed windowed sorting for records ordered by related data, preventing stale or missing sort behavior during inserts and updates.
  * Improved top-N window membership so rows are added, removed, or replaced correctly when related references change.
  * Ensured inserted results no longer expose extra related-object data in returned payloads.
* **Tests**
  * Added end-to-end coverage for insert and reassign flows involving related-object sort keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->