### PR TITLE
refactor(query-engine): extract RelationGraph deep module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,10 @@ _Avoid_: treating this as a client-facing request; after removal, clients cannot
 The server-side component that maintains realtime subscriptions to **Tracked Queries** and broadcasts **Sync Deltas** to subscribed connections as committed writes change which objects are in **scope**. After ADR-0003 it does *not* resolve queries by breaking them into sub-queries; it delegates resolution to **Storage** (one query, `include` joins and all) and owns only matching-and-broadcasting.
 _Avoid_: describing it as a query *resolver* or as the thing that runs sub-queries through routes (that path is gone).
 
+**Relation Graph**:
+The **Query Engine**'s in-memory graph of the objects it currently tracks and the relations between them, used for relation-membership matching and the reverse-ref fan-out (see ADR-0003). Each **Object Node** is keyed by id and holds only its outgoing relations (`references`), its inbound relations (`referencedBy`), and the set of query hashes it currently matches — no row payloads. The graph owns the paired `references`/`referencedBy` invariant and all inverse-relation-name resolution *internally*: callers traverse edges in query-relation terms (`reference(child, parentResource, parentRelation)`, `referencedBy(related, fromResource, relation)`) and never compute an inverse name. Writes enter through two methods — `ingest` (a resolved, possibly nested storage tree; additive) and `applyWrite` (a mutation; diff-aware, FK→null unlinks, re-parent = unlink+link).
+_Avoid_: treating the graph as a store of rows (it holds no payloads); conflating **Object Node** membership (`matchedQueries`) with the **Window** ordering index (that is `WindowIndex`).
+
 ### Realtime scope
 
 **Scope**:

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -14,6 +14,8 @@ import {
 } from '../../utils';
 import type { RawQueryRequest, SyncDelta } from '../schemas/core-protocol';
 import { toPromiseLike } from '../utils';
+import { RelationGraph } from './relation-graph';
+import { relationalColumns } from './schema-relations';
 import type { DataSource, QueryStep } from './types';
 import { hashStep } from './utils';
 import { type OrderBy, type SortKey, WindowIndex } from './window-index';
@@ -23,7 +25,6 @@ export type SyncDeltaHandler = (delta: SyncDelta) => void;
 interface QueryNode {
 	hash: string;
 	queryStep: QueryStep;
-	trackedObjects: Set<string>;
 	subscriptions: Set<SyncDeltaHandler>;
 	parentQuery?: string;
 	relationName?: string;
@@ -57,20 +58,12 @@ interface ParentScope {
 	parentId: string;
 }
 
-interface ObjectNode {
-	id: string;
-	type: string;
-	matchedQueries: Set<string>;
-	referencesObjects: Map<string, string>;
-	referencedByObjects: Map<string, Set<string>>;
-}
-
 export class QueryEngine {
 	private storage: DataSource;
 	private schema: Schema<any>;
 	private logger: Logger;
 	private queryNodes: Map<string, QueryNode> = new Map();
-	private objectNodes: Map<string, ObjectNode> = new Map();
+	private graph: RelationGraph;
 
 	constructor(opts: {
 		storage: DataSource;
@@ -80,203 +73,7 @@ export class QueryEngine {
 		this.storage = opts.storage;
 		this.schema = opts.schema;
 		this.logger = opts.logger;
-	}
-
-	private getRelationalColumns(
-		resourceName: string,
-	): Map<string, { relationName: string; targetResource: string }> {
-		const result = new Map<
-			string,
-			{ relationName: string; targetResource: string }
-		>();
-		const resourceSchema = this.schema[resourceName];
-
-		if (!resourceSchema?.relations) return result;
-
-		for (const [relationName, relation] of Object.entries(
-			resourceSchema.relations,
-		)) {
-			// "one" relations have relationalColumn on the source entity
-			if (relation.type === 'one' && relation.relationalColumn) {
-				result.set(String(relation.relationalColumn), {
-					relationName,
-					targetResource: relation.entity.name,
-				});
-			}
-		}
-
-		return result;
-	}
-
-	private ensureObjectNode(
-		id: string,
-		type: string,
-		matchedQuery?: string,
-	): ObjectNode {
-		let objectNode = this.objectNodes.get(id);
-
-		if (!objectNode) {
-			objectNode = {
-				id,
-				type,
-				matchedQueries: new Set(matchedQuery ? [matchedQuery] : []),
-				referencesObjects: new Map(),
-				referencedByObjects: new Map(),
-			};
-			this.objectNodes.set(id, objectNode);
-		} else if (matchedQuery) {
-			objectNode.matchedQueries.add(matchedQuery);
-		}
-
-		return objectNode;
-	}
-
-	private storeRelation(
-		sourceId: string,
-		targetId: string,
-		relationName: string,
-		inverseRelationName?: string,
-	): void {
-		const sourceNode = this.objectNodes.get(sourceId);
-		const targetNode = this.objectNodes.get(targetId);
-
-		if (sourceNode) {
-			sourceNode.referencesObjects.set(relationName, targetId);
-		}
-
-		if (targetNode && inverseRelationName) {
-			let referencedBy =
-				targetNode.referencedByObjects.get(inverseRelationName);
-			if (!referencedBy) {
-				referencedBy = new Set();
-				targetNode.referencedByObjects.set(inverseRelationName, referencedBy);
-			}
-			referencedBy.add(sourceId);
-		}
-	}
-
-	private removeRelation(
-		sourceId: string,
-		targetId: string,
-		relationName: string,
-		inverseRelationName?: string,
-	): void {
-		const sourceNode = this.objectNodes.get(sourceId);
-		const targetNode = this.objectNodes.get(targetId);
-
-		if (sourceNode) {
-			sourceNode.referencesObjects.delete(relationName);
-		}
-
-		if (targetNode && inverseRelationName) {
-			const referencedBy =
-				targetNode.referencedByObjects.get(inverseRelationName);
-			if (referencedBy) {
-				referencedBy.delete(sourceId);
-				if (referencedBy.size === 0) {
-					targetNode.referencedByObjects.delete(inverseRelationName);
-				}
-			}
-		}
-	}
-
-	private getInverseRelationName(
-		sourceResource: string,
-		targetResource: string,
-		relationName: string,
-	): string | undefined {
-		const sourceSchema = this.schema[sourceResource];
-		if (!sourceSchema?.relations) return undefined;
-
-		const sourceRelation = sourceSchema.relations[relationName];
-		if (!sourceRelation) return undefined;
-
-		const targetSchema = this.schema[targetResource];
-		if (!targetSchema?.relations) return undefined;
-
-		// For a "many" relation, find the "one" relation on target with matching relationalColumn
-		if (sourceRelation.type === 'many' && sourceRelation.foreignColumn) {
-			for (const [inverseName, relation] of Object.entries(
-				targetSchema.relations,
-			)) {
-				if (
-					relation.entity.name === sourceResource &&
-					relation.type === 'one' &&
-					relation.relationalColumn === sourceRelation.foreignColumn
-				) {
-					return inverseName;
-				}
-			}
-		}
-
-		// For a "one" relation, find the "many" relation on target with matching foreignColumn
-		if (sourceRelation.type === 'one' && sourceRelation.relationalColumn) {
-			for (const [inverseName, relation] of Object.entries(
-				targetSchema.relations,
-			)) {
-				if (
-					relation.entity.name === sourceResource &&
-					relation.type === 'many' &&
-					relation.foreignColumn === sourceRelation.relationalColumn
-				) {
-					return inverseName;
-				}
-			}
-		}
-
-		return undefined;
-	}
-
-	private updateRelationsFromMutation(
-		resourceName: string,
-		resourceId: string,
-		objValue: any,
-		payload?: Record<string, any>,
-	): void {
-		const relationalColumns = this.getRelationalColumns(resourceName);
-		const objectNode = this.objectNodes.get(resourceId);
-
-		if (!objectNode) return;
-
-		for (const [columnName, { relationName, targetResource }] of Array.from(
-			relationalColumns,
-		)) {
-			const wasUpdated = payload && columnName in payload;
-
-			if (!wasUpdated) continue;
-
-			const inverseRelationName = this.getInverseRelationName(
-				resourceName,
-				targetResource,
-				relationName,
-			);
-
-			const previousTargetId = objectNode.referencesObjects.get(relationName);
-
-			const newTargetId = objValue[columnName];
-
-			if (previousTargetId === newTargetId) continue;
-
-			if (previousTargetId) {
-				this.removeRelation(
-					resourceId,
-					previousTargetId,
-					relationName,
-					inverseRelationName,
-				);
-			}
-
-			if (newTargetId) {
-				this.ensureObjectNode(newTargetId, targetResource);
-
-				this.storeRelation(
-					resourceId,
-					newTargetId,
-					relationName,
-					inverseRelationName,
-				);
-			}
-		}
+		this.graph = new RelationGraph(opts.schema);
 	}
 
 	/**
@@ -473,10 +270,11 @@ export class QueryEngine {
 		const cols = new Set<string>();
 		const deps = this.relationalSortDeps(queryNode.queryStep.query);
 		if (deps.length === 0) return cols;
-		const relationalColumns = this.getRelationalColumns(
+		const cols2 = relationalColumns(
+			this.schema,
 			queryNode.queryStep.query.resource,
 		);
-		for (const [column, { relationName }] of Array.from(relationalColumns))
+		for (const [column, { relationName }] of Array.from(cols2))
 			if (deps.some((d) => d.relationName === relationName)) cols.add(column);
 		return cols;
 	}
@@ -691,7 +489,6 @@ export class QueryEngine {
 					hash: stepHash,
 					queryStep: step,
 					relationName: currentRelationName,
-					trackedObjects: new Set(),
 					subscriptions: new Set([callback]),
 					parentQuery: lastStepHash,
 					childQueries: new Set(),
@@ -840,34 +637,11 @@ export class QueryEngine {
 
 		if (!queryNode) return;
 
-		const relationalColumns = this.getRelationalColumns(resourceName);
-
 		for (const rawResult of results) {
 			const result = inferValue(rawResult);
-			const id = result.id;
-
-			this.ensureObjectNode(id, resourceName, stepHash);
-			queryNode.trackedObjects.add(id);
-
-			for (const [columnName, { relationName, targetResource }] of Array.from(
-				relationalColumns,
-			)) {
-				const targetId = result[columnName];
-				if (targetId) {
-					this.ensureObjectNode(targetId, targetResource);
-
-					const inverseRelationName = this.getInverseRelationName(
-						resourceName,
-						targetResource,
-						relationName,
-					);
-
-					this.storeRelation(id, targetId, relationName, inverseRelationName);
-				}
-			}
-
-			this.loadNestedRelations(resourceName, id, result);
-			this.logger.debug('[QueryEngine] Loaded nested relations for', id);
+			this.graph.ingest(resourceName, result);
+			this.graph.setMatched(result.id, stepHash);
+			this.logger.debug('[QueryEngine] Loaded nested relations for', result.id);
 		}
 
 		// Seed the window ordering from the storage-resolved (ordered, limited)
@@ -1049,8 +823,7 @@ export class QueryEngine {
 		resourceId: string,
 		meta?: SyncDelta['meta'],
 	): void {
-		queryNode.trackedObjects.delete(resourceId);
-		this.objectNodes.get(resourceId)?.matchedQueries.delete(queryNode.hash);
+		this.graph.clearMatched(resourceId, queryNode.hash);
 		this.emitToSubscribers(
 			queryNode,
 			{
@@ -1084,10 +857,7 @@ export class QueryEngine {
 		// Sorted past the boundary of a full window: not in scope, emit nothing.
 		if (!result.inserted) return;
 
-		queryNode.trackedObjects.add(mutation.resourceId);
-		this.objectNodes
-			.get(mutation.resourceId)
-			?.matchedQueries.add(queryNode.hash);
+		this.graph.setMatched(mutation.resourceId, queryNode.hash);
 		this.emitToSubscribers(queryNode, mutation, 'windowed scope-in INSERT');
 
 		if (result.evicted) {
@@ -1208,8 +978,7 @@ export class QueryEngine {
 		});
 		if (!result.inserted) return;
 
-		queryNode.trackedObjects.add(id);
-		this.objectNodes.get(id)?.matchedQueries.add(queryNode.hash);
+		this.graph.setMatched(id, queryNode.hash);
 		this.emitToSubscribers(
 			queryNode,
 			this.fullInsertDelta(queryNode, mutation, entityValue),
@@ -1296,7 +1065,7 @@ export class QueryEngine {
 	 * every windowed row ordered by that object's field. Per affected windowed
 	 * scope, in two steps:
 	 *
-	 * 1. **Fan-out** — walk `referencedByObjects` to the *known* in-window rows and
+	 * 1. **Fan-out** — walk the graph's reverse refs to the *known* in-window rows and
 	 *    recompute, component-wise, the touched sort-key component so the in-memory
 	 *    order stays accurate. This is pure in-memory: it neither reads nor emits.
 	 * 2. **Boundary read** — the fan-out sees only tracked rows, so a row that was
@@ -1311,10 +1080,8 @@ export class QueryEngine {
 	): Promise<void> {
 		if (!mutation.payload) return;
 		// The mutated related object may not be tracked at all (no in-window row
-		// references it) yet still promote an unseen row, so absence of an object
-		// node does not skip the boundary read below.
-		const objectNode = this.objectNodes.get(mutation.resourceId);
-
+		// references it) yet still promote an unseen row, so an empty reverse-ref
+		// set does not skip the boundary read below.
 		for (const queryNode of Array.from(this.queryNodes.values())) {
 			const deps = this.relationalSortDeps(queryNode.queryStep.query);
 			if (deps.length === 0) continue;
@@ -1334,16 +1101,12 @@ export class QueryEngine {
 				const newValue = objValue?.[dep.field];
 
 				// Rows referencing the mutated related object via this relation.
-				const inverseRel = this.getInverseRelationName(
+				const referencing = this.graph.referencedBy(
+					mutation.resourceId,
 					queryNode.queryStep.query.resource,
-					mutation.resource,
 					dep.relationName,
 				);
-				const referencing =
-					objectNode && inverseRel
-						? objectNode.referencedByObjects.get(inverseRel)
-						: undefined;
-				if (!referencing || referencing.size === 0) continue;
+				if (referencing.size === 0) continue;
 
 				for (const rowId of Array.from(referencing)) {
 					if (isRootWindow) {
@@ -1475,15 +1238,10 @@ export class QueryEngine {
 			const result = wi.insert({ id: value.id, sortKey });
 			if (!result.inserted) continue;
 
-			queryNode.trackedObjects.add(value.id);
-			this.ensureObjectNode(
-				value.id,
-				resource,
-				queryNode.hash,
-			).matchedQueries.add(queryNode.hash);
+			this.graph.setMatched(value.id, queryNode.hash);
 			// Register the promoted row's relations so a later write to its related
 			// sort object reaches it through the fan-out.
-			this.registerObjectRelations(resource, value.id, value);
+			this.graph.ingest(resource, value);
 
 			const payload = this.stripPayloadRelations(
 				{ ...((row as any)?.value ?? {}) },
@@ -1504,32 +1262,6 @@ export class QueryEngine {
 			);
 			if (result.evicted)
 				this.emitScopeOut(queryNode, result.evicted.id, mutation.meta);
-		}
-	}
-
-	/**
-	 * Wire a row's relational-column references into the tracking graph (mirrors
-	 * the per-row relation loading in `trackObjects`). Used when a row enters a
-	 * window outside the normal ingest path so future reverse-ref fan-outs find it.
-	 */
-	private registerObjectRelations(
-		resource: string,
-		id: string,
-		value: any,
-	): void {
-		const relationalColumns = this.getRelationalColumns(resource);
-		for (const [columnName, { relationName, targetResource }] of Array.from(
-			relationalColumns,
-		)) {
-			const targetId = value?.[columnName];
-			if (!targetId) continue;
-			this.ensureObjectNode(targetId, targetResource);
-			const inverse = this.getInverseRelationName(
-				resource,
-				targetResource,
-				relationName,
-			);
-			this.storeRelation(id, targetId, relationName, inverse);
 		}
 	}
 
@@ -1603,12 +1335,7 @@ export class QueryEngine {
 			return;
 		}
 
-		queryNode.trackedObjects.add(candidate.id);
-		this.ensureObjectNode(
-			candidate.id,
-			resource,
-			queryNode.hash,
-		).matchedQueries.add(queryNode.hash);
+		this.graph.setMatched(candidate.id, queryNode.hash);
 		const payload = this.stripPayloadRelations(
 			{ ...((candidateRow as any)?.value ?? {}) },
 			sortInclude,
@@ -1682,12 +1409,7 @@ export class QueryEngine {
 			if (!value?.id || wi.has(value.id)) continue;
 
 			wi.insert({ id: value.id, sortKey: this.sortKeyFor(queryNode, value) });
-			queryNode.trackedObjects.add(value.id);
-			this.ensureObjectNode(
-				value.id,
-				resource,
-				queryNode.hash,
-			).matchedQueries.add(queryNode.hash);
+			this.graph.setMatched(value.id, queryNode.hash);
 
 			const payload = this.stripPayloadRelations(
 				{ ...((row as any)?.value ?? {}) },
@@ -1784,66 +1506,6 @@ export class QueryEngine {
 		return { $and: [base, cursor] };
 	}
 
-	private loadNestedRelations(
-		resourceName: string,
-		objectId: string,
-		data: any,
-	): void {
-		const resourceSchema = this.schema[resourceName];
-		if (!resourceSchema?.relations) return;
-
-		for (const [relationName, relation] of Object.entries(
-			resourceSchema.relations,
-		)) {
-			const nestedData = data[relationName];
-			if (!nestedData) continue;
-
-			const targetResource = relation.entity.name;
-			const inverseRelationName = this.getInverseRelationName(
-				resourceName,
-				targetResource,
-				relationName,
-			);
-
-			if (relation.type === 'one') {
-				if (nestedData && typeof nestedData === 'object' && nestedData.id) {
-					this.ensureObjectNode(nestedData.id, targetResource);
-					this.storeRelation(
-						objectId,
-						nestedData.id,
-						relationName,
-						inverseRelationName,
-					);
-					this.loadNestedRelations(targetResource, nestedData.id, nestedData);
-				}
-			} else if (relation.type === 'many') {
-				if (Array.isArray(nestedData)) {
-					for (const item of nestedData) {
-						if (item && typeof item === 'object' && item.id) {
-							this.ensureObjectNode(item.id, targetResource);
-							// For "many" relations, the relation is stored on the child pointing to parent
-							// But we also track the reverse reference
-							const reverseInverse = this.getInverseRelationName(
-								targetResource,
-								resourceName,
-								relationName,
-							);
-							if (reverseInverse) {
-								this.storeRelation(
-									item.id,
-									objectId,
-									reverseInverse,
-									relationName,
-								);
-							}
-							this.loadNestedRelations(targetResource, item.id, item);
-						}
-					}
-				}
-			}
-		}
-	}
-
 	/**
 	 * Builds an include object from a query node's child queries recursively.
 	 * This allows fetching related data when an object moves into scope.
@@ -1909,9 +1571,7 @@ export class QueryEngine {
 		}
 
 		// Track this object in the query
-		queryNode.trackedObjects.add(id);
-		const objectNode = this.ensureObjectNode(id, resourceName, queryNode.hash);
-		objectNode.matchedQueries.add(queryNode.hash);
+		this.graph.setMatched(id, queryNode.hash);
 
 		// Process child queries and send INSERTs for related objects
 		for (const childHash of Array.from(queryNode.childQueries)) {
@@ -1946,46 +1606,13 @@ export class QueryEngine {
 		entityValue: MaterializedLiveType<LiveObjectAny>,
 	) {
 		if (mutation.op === 'INSERT') {
-			if (this.objectNodes.has(mutation.resourceId)) return;
+			if (this.graph.has(mutation.resourceId)) return;
 
 			const objValue = inferValue(entityValue);
 
 			if (!objValue) return;
 
-			const newObjectNode: ObjectNode = {
-				id: mutation.resourceId,
-				type: mutation.resource,
-				matchedQueries: new Set(),
-				referencesObjects: new Map(),
-				referencedByObjects: new Map(),
-			};
-
-			this.objectNodes.set(mutation.resourceId, newObjectNode);
-
-			const relationalColumns = this.getRelationalColumns(mutation.resource);
-			for (const [columnName, { relationName, targetResource }] of Array.from(
-				relationalColumns,
-			)) {
-				const targetId = objValue[columnName];
-				if (targetId) {
-					this.ensureObjectNode(targetId, targetResource);
-
-					const inverseRelationName = this.getInverseRelationName(
-						mutation.resource,
-						targetResource,
-						relationName,
-					);
-
-					this.storeRelation(
-						mutation.resourceId,
-						targetId,
-						relationName,
-						inverseRelationName,
-					);
-				}
-			}
-
-			const storedObjectNode = this.objectNodes.get(mutation.resourceId);
+			this.graph.applyWrite(mutation.resource, mutation.resourceId, objValue);
 
 			this.getMatchingQueries(mutation, objValue).then(
 				async (matchingQueries) => {
@@ -2036,11 +1663,7 @@ export class QueryEngine {
 								continue;
 							}
 
-							queryNode.trackedObjects.add(mutation.resourceId);
-
-							if (storedObjectNode) {
-								storedObjectNode.matchedQueries.add(queryHash);
-							}
+							this.graph.setMatched(mutation.resourceId, queryHash);
 
 							for (const subscription of Array.from(queryNode.subscriptions)) {
 								try {
@@ -2083,25 +1706,13 @@ export class QueryEngine {
 
 			if (!objValue) return;
 
-			// Step 1: Ensure object node exists and update object relations first
-			let objectNode = this.objectNodes.get(mutation.resourceId);
+			// Step 1: Snapshot prior membership, then update object relations (which
+			// ensures the node exists) before checking query matching.
 			const previouslyMatchedQueries = new Set(
-				objectNode?.matchedQueries ?? [],
+				this.graph.matchedQueriesOf(mutation.resourceId),
 			);
 
-			if (!objectNode) {
-				objectNode = {
-					id: mutation.resourceId,
-					type: mutation.resource,
-					matchedQueries: new Set(),
-					referencesObjects: new Map(),
-					referencedByObjects: new Map(),
-				};
-				this.objectNodes.set(mutation.resourceId, objectNode);
-			}
-
-			// Update object relations before checking query matching
-			this.updateRelationsFromMutation(
+			this.graph.applyWrite(
 				mutation.resource,
 				mutation.resourceId,
 				objValue,
@@ -2183,30 +1794,12 @@ export class QueryEngine {
 						}
 					}
 
-					// Update query node tracking
+					// Update object → query membership
 					for (const queryHash of newlyMatchedQueries) {
-						const queryNode = this.queryNodes.get(queryHash);
-						if (queryNode) {
-							queryNode.trackedObjects.add(mutation.resourceId);
-						}
+						this.graph.setMatched(mutation.resourceId, queryHash);
 					}
-
 					for (const queryHash of noLongerMatchedQueries) {
-						const queryNode = this.queryNodes.get(queryHash);
-						if (queryNode) {
-							queryNode.trackedObjects.delete(mutation.resourceId);
-						}
-					}
-
-					// Update object node matched queries
-					const currentObjectNode = this.objectNodes.get(mutation.resourceId);
-					if (currentObjectNode) {
-						for (const queryHash of newlyMatchedQueries) {
-							currentObjectNode.matchedQueries.add(queryHash);
-						}
-						for (const queryHash of noLongerMatchedQueries) {
-							currentObjectNode.matchedQueries.delete(queryHash);
-						}
+						this.graph.clearMatched(mutation.resourceId, queryHash);
 					}
 
 					// Notify subscriptions for still matched and no longer matched queries
@@ -2290,38 +1883,29 @@ export class QueryEngine {
 				const where = queryNode.queryStep.query.where;
 				const resource = queryNode.queryStep.query.resource;
 				const resourceId = mutation.resourceId;
-				const objectNode = this.objectNodes.get(resourceId);
 
-				if (!objectNode) return { hash: queryNode.hash, matches: false };
+				if (!this.graph.has(resourceId))
+					return { hash: queryNode.hash, matches: false };
 
 				if (queryNode.relationName) {
-					// queryNode.relationName is the relation from the parent's perspective (e.g., "posts" on User)
-					// but referencesObjects uses the relation from this object's perspective (e.g., "author" on Post)
-					// So we need to find the inverse relation name
+					// queryNode.relationName is the parent-side relation (e.g. "posts"
+					// on User); the graph resolves the inverse ("author" on Post) and
+					// follows this object's FK up to its parent internally.
 					const parentQuery = queryNode.parentQuery
 						? this.queryNodes.get(queryNode.parentQuery)
 						: undefined;
 					const parentResource = parentQuery?.queryStep.query.resource;
 
-					const inverseRelationName = parentResource
-						? this.getInverseRelationName(
+					const relatedObj = parentResource
+						? this.graph.reference(
+								resourceId,
 								parentResource,
-								resource,
 								queryNode.relationName,
 							)
 						: undefined;
-
-					const relatedObj = inverseRelationName
-						? objectNode.referencesObjects.get(inverseRelationName)
-						: undefined;
 					if (!relatedObj) return { hash: queryNode.hash, matches: false };
 
-					const relatedObjNode = this.objectNodes.get(relatedObj);
-					if (
-						!relatedObjNode ||
-						!parentQuery ||
-						!relatedObjNode.matchedQueries.has(parentQuery.hash)
-					)
+					if (!parentQuery || !this.graph.matches(relatedObj, parentQuery.hash))
 						return { hash: queryNode.hash, matches: false };
 
 					// Relation membership holds; fall through to re-apply the

--- a/packages/live-state/src/core/query-engine/relation-graph.ts
+++ b/packages/live-state/src/core/query-engine/relation-graph.ts
@@ -1,0 +1,264 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: tracked rows are dynamically shaped */
+
+import type { Schema } from '../../schema';
+import { inverseRelationName, relationalColumns } from './schema-relations';
+
+/**
+ * One tracked object. Holds only its edges and query membership — never a row
+ * payload. `references` maps a relation name to the id it points at (its
+ * outgoing FK edges); `referencedBy` maps an inverse relation name to the ids
+ * pointing back (its inbound edges); `matchedQueries` is the set of query hashes
+ * this object currently matches.
+ */
+interface ObjectNode {
+	matchedQueries: Set<string>;
+	references: Map<string, string>;
+	referencedBy: Map<string, Set<string>>;
+}
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+/**
+ * The query engine's in-memory graph of tracked objects and the relations
+ * between them (see `CONTEXT.md` → Relation Graph, ADR-0003). It owns the paired
+ * `references`/`referencedBy` invariant and all inverse-relation-name resolution
+ * internally: callers traverse edges in query-relation terms and never compute an
+ * inverse name.
+ *
+ * Writes enter through two methods: `ingest` (a resolved, possibly nested storage
+ * tree; purely additive) and `applyWrite` (a mutation; diff-aware). Reads answer
+ * relation-membership matching (`reference`, `matches`) and the reverse-ref
+ * fan-out (`referencedBy`). Holds no row payloads and never removes a node.
+ */
+export class RelationGraph {
+	private readonly schema: Schema<any>;
+	private readonly nodes: Map<string, ObjectNode> = new Map();
+
+	constructor(schema: Schema<any>) {
+		this.schema = schema;
+	}
+
+	private ensureNode(id: string): ObjectNode {
+		let node = this.nodes.get(id);
+		if (!node) {
+			node = {
+				matchedQueries: new Set(),
+				references: new Map(),
+				referencedBy: new Map(),
+			};
+			this.nodes.set(id, node);
+		}
+		return node;
+	}
+
+	/** Wire an edge in both directions (source → target, and the inverse back). */
+	private link(
+		sourceId: string,
+		targetId: string,
+		relationName: string,
+		inverseName: string | undefined,
+	): void {
+		this.ensureNode(sourceId).references.set(relationName, targetId);
+		if (!inverseName) return;
+		const target = this.ensureNode(targetId);
+		let refs = target.referencedBy.get(inverseName);
+		if (!refs) {
+			refs = new Set();
+			target.referencedBy.set(inverseName, refs);
+		}
+		refs.add(sourceId);
+	}
+
+	/** Remove an edge in both directions. */
+	private unlink(
+		sourceId: string,
+		targetId: string,
+		relationName: string,
+		inverseName: string | undefined,
+	): void {
+		this.nodes.get(sourceId)?.references.delete(relationName);
+		if (!inverseName) return;
+		const refs = this.nodes.get(targetId)?.referencedBy.get(inverseName);
+		if (!refs) return;
+		refs.delete(sourceId);
+		if (refs.size === 0)
+			this.nodes.get(targetId)?.referencedBy.delete(inverseName);
+	}
+
+	/**
+	 * Ingest a resolved storage row (its inferred value, relations nested inline)
+	 * into the graph: create its node, wire its outgoing FK edges, and recurse
+	 * through any nested `one`/`many` relations. Purely additive and idempotent —
+	 * used for resolution, backfill, and promotion reads.
+	 */
+	ingest(resource: string, row: any): void {
+		const id = row?.id;
+		if (!id) return;
+		this.ensureNode(id);
+
+		for (const [column, { relationName, targetResource }] of Array.from(
+			relationalColumns(this.schema, resource),
+		)) {
+			const targetId = row[column];
+			if (!targetId) continue;
+			this.link(
+				id,
+				targetId,
+				relationName,
+				inverseRelationName(this.schema, resource, targetResource, relationName),
+			);
+		}
+
+		this.ingestNested(resource, id, row);
+	}
+
+	/** Recurse through a row's nested relations, wiring edges for the subtree. */
+	private ingestNested(resource: string, id: string, data: any): void {
+		const relations = this.schema[resource]?.relations;
+		if (!relations) return;
+
+		for (const [relationName, relation] of Object.entries(relations)) {
+			const nested = data[relationName];
+			if (!nested) continue;
+
+			const targetResource = relation.entity.name;
+
+			if (relation.type === 'one') {
+				if (typeof nested === 'object' && nested.id) {
+					this.link(
+						id,
+						nested.id,
+						relationName,
+						inverseRelationName(
+							this.schema,
+							resource,
+							targetResource,
+							relationName,
+						),
+					);
+					this.ingestNested(targetResource, nested.id, nested);
+				}
+			} else if (relation.type === 'many' && Array.isArray(nested)) {
+				// The edge is stored on the child pointing back at the parent, so wire
+				// the reverse (child → parent) using the child-side inverse relation.
+				const reverseInverse = inverseRelationName(
+					this.schema,
+					targetResource,
+					resource,
+					relationName,
+				);
+				for (const item of nested) {
+					if (item && typeof item === 'object' && item.id) {
+						this.ensureNode(item.id);
+						if (reverseInverse)
+							this.link(item.id, id, reverseInverse, relationName);
+						this.ingestNested(targetResource, item.id, item);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Apply a committed write's effect on `id`'s outgoing FK edges. With no
+	 * `payload` (an INSERT) every present FK column is wired; with a `payload` (an
+	 * UPDATE) only the columns it touches are diffed — a reassigned FK unlinks the
+	 * old target and links the new one, an FK set to `null`/absent just unlinks.
+	 */
+	applyWrite(
+		resource: string,
+		id: string,
+		value: any,
+		payload?: Record<string, any>,
+	): void {
+		this.ensureNode(id);
+
+		for (const [column, { relationName, targetResource }] of Array.from(
+			relationalColumns(this.schema, resource),
+		)) {
+			if (payload && !(column in payload)) continue;
+
+			const inverse = inverseRelationName(
+				this.schema,
+				resource,
+				targetResource,
+				relationName,
+			);
+			const previous = this.nodes.get(id)?.references.get(relationName);
+			const next = value?.[column];
+			if (previous === next) continue;
+
+			if (previous) this.unlink(id, previous, relationName, inverse);
+			if (next) this.link(id, next, relationName, inverse);
+		}
+	}
+
+	/** Mark `id` as matching a query (creating the node if needed). */
+	setMatched(id: string, queryHash: string): void {
+		this.ensureNode(id).matchedQueries.add(queryHash);
+	}
+
+	/** Clear a query match from `id`. */
+	clearMatched(id: string, queryHash: string): void {
+		this.nodes.get(id)?.matchedQueries.delete(queryHash);
+	}
+
+	/** Whether `id` currently matches the given query. */
+	matches(id: string, queryHash: string): boolean {
+		return this.nodes.get(id)?.matchedQueries.has(queryHash) ?? false;
+	}
+
+	/** The set of query hashes `id` currently matches (live view; copy to retain). */
+	matchedQueriesOf(id: string): ReadonlySet<string> {
+		return this.nodes.get(id)?.matchedQueries ?? EMPTY;
+	}
+
+	/**
+	 * The id `childId` points at via the parent-side relation `parentRelation`
+	 * (declared on `parentResource`) — i.e. follow the child's FK up to its parent.
+	 * The inverse relation is resolved internally.
+	 */
+	reference(
+		childId: string,
+		parentResource: string,
+		parentRelation: string,
+	): string | undefined {
+		const relation = this.schema[parentResource]?.relations?.[parentRelation];
+		if (!relation) return undefined;
+		const inverse = inverseRelationName(
+			this.schema,
+			parentResource,
+			relation.entity.name,
+			parentRelation,
+		);
+		if (!inverse) return undefined;
+		return this.nodes.get(childId)?.references.get(inverse);
+	}
+
+	/**
+	 * The ids that reference `relatedId` through `relation` (declared on
+	 * `fromResource`) — i.e. the rows whose `relation` FK points at `relatedId`.
+	 * Drives the reverse-ref fan-out; the inverse relation is resolved internally.
+	 */
+	referencedBy(
+		relatedId: string,
+		fromResource: string,
+		relation: string,
+	): ReadonlySet<string> {
+		const rel = this.schema[fromResource]?.relations?.[relation];
+		if (!rel) return EMPTY;
+		const inverse = inverseRelationName(
+			this.schema,
+			fromResource,
+			rel.entity.name,
+			relation,
+		);
+		if (!inverse) return EMPTY;
+		return this.nodes.get(relatedId)?.referencedBy.get(inverse) ?? EMPTY;
+	}
+
+	/** Whether the graph is tracking `id` at all. */
+	has(id: string): boolean {
+		return this.nodes.has(id);
+	}
+}

--- a/packages/live-state/src/core/query-engine/schema-relations.ts
+++ b/packages/live-state/src/core/query-engine/schema-relations.ts
@@ -1,0 +1,89 @@
+/** biome-ignore-all lint/suspicious/noExplicitAny: schema relations are dynamically shaped */
+
+import type { Schema } from '../../schema';
+
+/**
+ * The relational (foreign-key) columns declared on a resource: each maps a local
+ * column (e.g. `authorId`) to the relation it backs and the resource it targets.
+ * Only `one` relations carry a `relationalColumn` on the source entity, so only
+ * those appear here. Pure schema query — shared by the {@link RelationGraph}
+ * (edge wiring) and the query engine's relational-sort logic.
+ */
+export function relationalColumns(
+	schema: Schema<any>,
+	resourceName: string,
+): Map<string, { relationName: string; targetResource: string }> {
+	const result = new Map<
+		string,
+		{ relationName: string; targetResource: string }
+	>();
+	const resourceSchema = schema[resourceName];
+
+	if (!resourceSchema?.relations) return result;
+
+	for (const [relationName, relation] of Object.entries(
+		resourceSchema.relations,
+	)) {
+		if (relation.type === 'one' && relation.relationalColumn) {
+			result.set(String(relation.relationalColumn), {
+				relationName,
+				targetResource: relation.entity.name,
+			});
+		}
+	}
+
+	return result;
+}
+
+/**
+ * The name of the relation on `targetResource` that is the inverse of
+ * `relationName` on `sourceResource` — the other side of the same edge. A `many`
+ * relation's inverse is the `one` relation on the target whose `relationalColumn`
+ * matches the `many`'s `foreignColumn`, and vice versa. Pure schema query;
+ * `undefined` when no inverse is declared.
+ */
+export function inverseRelationName(
+	schema: Schema<any>,
+	sourceResource: string,
+	targetResource: string,
+	relationName: string,
+): string | undefined {
+	const sourceSchema = schema[sourceResource];
+	if (!sourceSchema?.relations) return undefined;
+
+	const sourceRelation = sourceSchema.relations[relationName];
+	if (!sourceRelation) return undefined;
+
+	const targetSchema = schema[targetResource];
+	if (!targetSchema?.relations) return undefined;
+
+	if (sourceRelation.type === 'many' && sourceRelation.foreignColumn) {
+		for (const [inverseName, relation] of Object.entries(
+			targetSchema.relations,
+		)) {
+			if (
+				relation.entity.name === sourceResource &&
+				relation.type === 'one' &&
+				relation.relationalColumn === sourceRelation.foreignColumn
+			) {
+				return inverseName;
+			}
+		}
+	}
+
+	if (sourceRelation.type === 'one' && sourceRelation.relationalColumn) {
+		for (const [inverseName, relation] of Object.entries(
+			targetSchema.relations,
+		)) {
+			if (
+				relation.entity.name === sourceResource &&
+				relation.type === 'many' &&
+				relation.foreignColumn === sourceRelation.relationalColumn
+			) {
+				return inverseName;
+			}
+		}
+	}
+
+	return undefined;
+}

--- a/packages/live-state/test/core/query-engine/relation-graph.test.ts
+++ b/packages/live-state/test/core/query-engine/relation-graph.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the Relation Graph (see CONTEXT.md → Relation Graph). These
+ * exercise edge topology and query membership directly, with no QueryEngine,
+ * Storage, or subscriptions — the seam this module was extracted to expose.
+ */
+
+import { beforeEach, describe, expect, test } from "vitest";
+import { RelationGraph } from "../../../src/core/query-engine/relation-graph";
+import {
+	createRelations,
+	createSchema,
+	id,
+	object,
+	reference,
+	string,
+} from "../../../src/schema";
+
+const user = object("users", {
+	id: id(),
+	name: string(),
+});
+
+const post = object("posts", {
+	id: id(),
+	title: string(),
+	authorId: reference("users.id"),
+});
+
+const userRelations = createRelations(user, ({ many }) => ({
+	posts: many(post, "authorId"),
+}));
+
+const postRelations = createRelations(post, ({ one }) => ({
+	author: one(user, "authorId"),
+}));
+
+const schema = createSchema({
+	users: user,
+	posts: post,
+	userRelations,
+	postRelations,
+});
+
+/** A mutation payload only needs the touched column's key present. */
+const touched = (column: string) => ({ [column]: { value: null } });
+
+describe("RelationGraph", () => {
+	let graph: RelationGraph;
+
+	beforeEach(() => {
+		graph = new RelationGraph(schema);
+	});
+
+	describe("applyWrite — edge topology", () => {
+		test("an INSERT wires the FK edge in both directions", () => {
+			graph.applyWrite("posts", "p1", { id: "p1", authorId: "u1" });
+
+			// child → parent (query perspective: follow posts' inverse up to author)
+			expect(graph.reference("p1", "users", "posts")).toBe("u1");
+			// parent → children (reverse-ref fan-out lookup)
+			expect(Array.from(graph.referencedBy("u1", "posts", "author"))).toEqual([
+				"p1",
+			]);
+		});
+
+		test("re-parenting unlinks the old author and links the new one", () => {
+			graph.applyWrite("posts", "p1", { id: "p1", authorId: "u1" });
+			graph.applyWrite(
+				"posts",
+				"p1",
+				{ id: "p1", authorId: "u2" },
+				touched("authorId"),
+			);
+
+			expect(graph.reference("p1", "users", "posts")).toBe("u2");
+			expect(graph.referencedBy("u1", "posts", "author").size).toBe(0);
+			expect(Array.from(graph.referencedBy("u2", "posts", "author"))).toEqual([
+				"p1",
+			]);
+		});
+
+		test("an FK set to null just unlinks", () => {
+			graph.applyWrite("posts", "p1", { id: "p1", authorId: "u1" });
+			graph.applyWrite(
+				"posts",
+				"p1",
+				{ id: "p1", authorId: null },
+				touched("authorId"),
+			);
+
+			expect(graph.reference("p1", "users", "posts")).toBeUndefined();
+			expect(graph.referencedBy("u1", "posts", "author").size).toBe(0);
+		});
+
+		test("a payload that does not touch the FK leaves the edge intact", () => {
+			graph.applyWrite("posts", "p1", { id: "p1", authorId: "u1" });
+			graph.applyWrite(
+				"posts",
+				"p1",
+				{ id: "p1", authorId: "u1", title: "renamed" },
+				touched("title"),
+			);
+
+			expect(graph.reference("p1", "users", "posts")).toBe("u1");
+		});
+	});
+
+	describe("ingest — resolved nested tree", () => {
+		test("wires the FK edge for a post with its author nested inline", () => {
+			graph.ingest("posts", {
+				id: "p1",
+				title: "Hello",
+				authorId: "u1",
+				author: { id: "u1", name: "Alice" },
+			});
+
+			expect(graph.reference("p1", "users", "posts")).toBe("u1");
+			expect(Array.from(graph.referencedBy("u1", "posts", "author"))).toEqual([
+				"p1",
+			]);
+			expect(graph.has("u1")).toBe(true);
+		});
+
+		test("creates a node for every row in a parent's nested many-relation", () => {
+			graph.ingest("users", {
+				id: "u1",
+				name: "Alice",
+				posts: [
+					{ id: "p1", authorId: "u1" },
+					{ id: "p2", authorId: "u1" },
+				],
+			});
+
+			// The reverse ref for a `many` is wired from each child's own FK ingest
+			// step, not this parent-tree walk — but every row still gets a node.
+			expect(graph.has("u1")).toBe(true);
+			expect(graph.has("p1")).toBe(true);
+			expect(graph.has("p2")).toBe(true);
+		});
+	});
+
+	describe("membership", () => {
+		test("setMatched / matches / clearMatched round-trip", () => {
+			graph.setMatched("p1", "queryA");
+			expect(graph.matches("p1", "queryA")).toBe(true);
+			expect(graph.matches("p1", "queryB")).toBe(false);
+
+			graph.clearMatched("p1", "queryA");
+			expect(graph.matches("p1", "queryA")).toBe(false);
+		});
+
+		test("matchedQueriesOf reflects all current matches", () => {
+			graph.setMatched("p1", "queryA");
+			graph.setMatched("p1", "queryB");
+			expect(Array.from(graph.matchedQueriesOf("p1")).sort()).toEqual([
+				"queryA",
+				"queryB",
+			]);
+		});
+
+		test("membership on an untracked id is empty, not an error", () => {
+			expect(graph.matches("ghost", "queryA")).toBe(false);
+			expect(graph.matchedQueriesOf("ghost").size).toBe(0);
+			expect(graph.has("ghost")).toBe(false);
+		});
+	});
+
+	describe("reads tolerate missing edges", () => {
+		test("reference / referencedBy on unknown ids return empty", () => {
+			expect(graph.reference("nope", "users", "posts")).toBeUndefined();
+			expect(graph.referencedBy("nope", "posts", "author").size).toBe(0);
+		});
+	});
+});


### PR DESCRIPTION
## What

Extracts the object/relation tracking graph out of the 2371-line `QueryEngine` god class into a dedicated **`RelationGraph`** deep module. `index.ts` drops **417 lines** (2371 → 1954).

This is the first of four planned query-engine deepenings (recommended order: **RelationGraph → TotalOrder → sort-relation enrichment → split `handleMutation`**).

## Why

`ObjectNode` + ~8 private methods sharing one `Map` were a coherent concept — relation topology + inverse-name resolution + query membership — held together only by convention across 6 callers. Giving it an interface concentrates the invariant in one place and makes relation-membership matching unit-testable (previously reachable only through `handleMutation` + a fake storage in the 2892-line e2e).

## The module

Small interface, `new RelationGraph(schema)`:

- **Writes** — two coarse methods: `ingest(resource, row)` (resolved, possibly nested tree; additive) and `applyWrite(resource, id, value, payload?)` (mutation; diff-aware — reassigned FK unlinks old + links new, FK→null unlinks). Together they absorb the **three** duplicate own-FK blocks plus `loadNestedRelations` and `updateRelationsFromMutation` and the inline INSERT block.
- **Reads** — `reference` / `referencedBy` / `matches` / `matchedQueriesOf` / `has`, all in **query-relation terms**: callers never compute an inverse name; the graph flips to storage perspective internally.

## Also in this change

- Pure schema helpers (`inverseRelationName`, `relationalColumns`) move to `schema-relations.ts`, shared with the engine's relational-sort logic (Candidate 3's territory) rather than duplicated.
- **Drops two write-only dead fields**: `queryNode.trackedObjects` (written in 10 places, read in 0) and `ObjectNode.type`. Membership is now the single `matchedQueries` index behind the seam.
- Records **Relation Graph** / **Object Node** in `CONTEXT.md`.

## Tests

- New `relation-graph.test.ts` — **10 unit tests** exercising topology, diffing, re-parenting, and membership with no engine, storage, or subscriptions (the seam this extraction exists to expose).
- All **850 existing tests pass unchanged** — behavior-preserving. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter relationship tracking for query results, improving how related records are discovered and matched.
  * Introduced support for following relationships in both directions for more reliable relational lookups.

* **Bug Fixes**
  * Improved handling of updates, re-parenting, and unlinking so relationship changes stay in sync.
  * Better support for nested related data and missing references without errors.

* **Documentation**
  * Expanded glossary documentation for relation handling and query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->