### PR TITLE
fix(client): resolve cross-entry-point QueryBuilder identity for custom queries

### DIFF
--- a/packages/live-state/src/client/types.ts
+++ b/packages/live-state/src/client/types.ts
@@ -2,7 +2,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { QueryBuilder } from '../core/query';
 import type { CustomQueryRequest } from '../core/schemas/core-protocol';
 import type { Promisify } from '../core/utils';
-import type { InferLiveObject, LiveObjectAny } from '../schema';
+import type { IncludeClause, InferLiveObject, LiveObjectAny } from '../schema';
 import type { Simplify } from '../utils';
 
 /**
@@ -37,24 +37,42 @@ type CustomQueryLoadable<TOutput> = PromiseLike<TOutput> & {
 	buildQueryRequest: () => CustomQueryRequest;
 };
 
+/**
+ * Narrow a custom-query handler return type to its loadable client shape.
+ *
+ * The match keys off {@link QueryBuilderBrand} — a structural, type-only brand —
+ * rather than `extends QueryBuilder<...>`. `QueryBuilder` carries `private`
+ * members, so its class identity is nominal and the server- and client-bundle
+ * `.d.ts` graphs emit two incompatible declarations; a class-based check fails
+ * for published consumers who import the router from `@live-state/sync/server`
+ * and the client from `@live-state/sync/client`. The brand is compared by shape,
+ * so it survives that split (and duplicate installed versions).
+ */
 type CustomQueryResult<
 	TOutput,
 	TShouldAwait extends boolean = false,
-> = UnwrapPromise<TOutput> extends QueryBuilder<
-	infer TCollection,
-	infer TInclude,
-	infer TSingle,
-	any
->
-	? TShouldAwait extends true
-		? TSingle extends true
-			? Promise<Simplify<InferLiveObject<TCollection, TInclude>> | undefined>
-			: Promise<Simplify<InferLiveObject<TCollection, TInclude>>[]>
-		: TSingle extends true
-			? CustomQueryLoadable<
-					Simplify<InferLiveObject<TCollection, TInclude>> | undefined
-				>
-			: CustomQueryLoadable<Simplify<InferLiveObject<TCollection, TInclude>>[]>
+> = UnwrapPromise<TOutput> extends {
+	readonly __queryBuilderBrand: {
+		collection: infer TCollection extends LiveObjectAny;
+		include: infer TInclude;
+		single: infer TSingle;
+	};
+}
+	? // `TInclude` is inferred unconstrained; intersecting with its declared
+		// constraint restores assignability to `InferLiveObject` (a no-op for a
+		// well-formed brand, which always carries a valid include clause).
+		TInclude & IncludeClause<TCollection> extends infer TInc extends
+			IncludeClause<TCollection>
+		? TShouldAwait extends true
+			? TSingle extends true
+				? Promise<Simplify<InferLiveObject<TCollection, TInc>> | undefined>
+				: Promise<Simplify<InferLiveObject<TCollection, TInc>>[]>
+			: TSingle extends true
+				? CustomQueryLoadable<
+						Simplify<InferLiveObject<TCollection, TInc>> | undefined
+					>
+				: CustomQueryLoadable<Simplify<InferLiveObject<TCollection, TInc>>[]>
+		: never
 	: Promisify<UnwrapPromise<TOutput>>;
 
 type CustomQueryFunction<

--- a/packages/live-state/src/core/query.ts
+++ b/packages/live-state/src/core/query.ts
@@ -26,12 +26,41 @@ type InferQueryResult<
   ? Simplify<InferLiveObject<TCollection, TInclude>> | undefined
   : Simplify<InferLiveObject<TCollection, TInclude>>[];
 
+/**
+ * Type-only brand recording a {@link QueryBuilder}'s inferable parameters.
+ *
+ * `CustomQueryResult` (client entry point) has to recognise a query-builder
+ * value returned from a route handler whose type flows through the *server*
+ * entry point. The two entry points are emitted as separate `.d.ts` graphs, so
+ * each gets its own `declare class QueryBuilder`; because the class has
+ * `private` members, TypeScript compares those declarations *nominally* and any
+ * `extends QueryBuilder<...>` check across the boundary fails. Narrowing on this
+ * structural brand instead makes the check independent of class identity — and
+ * therefore also of duplicate installed package versions.
+ */
+export interface QueryBuilderBrand<
+  TCollection extends LiveObjectAny,
+  TInclude extends IncludeClause<TCollection>,
+  TSingle extends boolean,
+> {
+  collection: TCollection;
+  include: TInclude;
+  single: TSingle;
+}
+
 export class QueryBuilder<
   TCollection extends LiveObjectAny,
   TInclude extends IncludeClause<TCollection> = {},
   TSingle extends boolean = false,
   TShouldAwait extends boolean = false,
 > {
+  /** Never assigned at runtime; exists only to carry {@link QueryBuilderBrand}. */
+  declare readonly __queryBuilderBrand: QueryBuilderBrand<
+    TCollection,
+    TInclude,
+    TSingle
+  >;
+
   private _collection: TCollection;
   private _client: QueryExecutor;
   private _where: WhereClause<TCollection>;

--- a/packages/live-state/test/types/procedures.test-d.ts
+++ b/packages/live-state/test/types/procedures.test-d.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import {
   createSchema,
   id,
+  type IncludeClause,
+  type LiveObjectAny,
   number,
   object,
   reference,
@@ -609,5 +611,76 @@ describe("QueryBuilder-returning custom queries - fetch vs websocket", () => {
     const result = wsQuery.users.usersByAge({ minAge: 18 });
 
     expectTypeOf(result).toMatchTypeOf<PromiseLike<any>>();
+  });
+});
+
+/**
+ * Regression — cross-entry-point QueryBuilder identity.
+ *
+ * Published consumers import the router from `@live-state/sync/server` and the
+ * client from `@live-state/sync/client`. Those entry points are emitted as
+ * separate `.d.ts` graphs, so each carries its own `declare class QueryBuilder`;
+ * because the class has `private` members it is compared nominally, and the two
+ * declarations are unrelated. The in-repo tests above import everything from
+ * `src`, so they only ever see a single `QueryBuilder` identity and cannot
+ * reproduce this.
+ *
+ * `ForeignQueryBuilder` stands in for the *other* bundle's copy: a distinct
+ * nominal class (private member) that shares only the structural
+ * `__queryBuilderBrand`. A route handler returning it must still narrow to a
+ * loadable that exposes `buildQueryRequest`. Before the brand-based narrowing
+ * this fell through to `Promise<ForeignQueryBuilder<...>>` and `.buildQueryRequest`
+ * was missing — the exact published-consumer symptom.
+ */
+class ForeignQueryBuilder<
+  TCollection extends LiveObjectAny,
+  TInclude extends IncludeClause<TCollection> = {},
+  TSingle extends boolean = false,
+> {
+  private _foreignNominalMarker!: TCollection;
+  declare readonly __queryBuilderBrand: {
+    collection: TCollection;
+    include: TInclude;
+    single: TSingle;
+  };
+}
+
+const routerWithForeignBuilderQuery = createRouter({
+  schema,
+  routes: {
+    users: publicRoute.withProcedures(({ query }) => ({
+      usersByAgeForeign: query(z.object({ minAge: z.number() })).handler(
+        async () => {
+          // A query-builder-shaped value whose class identity differs from the
+          // client bundle's `QueryBuilder` (as it does across published entry
+          // points). Runtime is irrelevant here — this is a type-only test.
+          return null as unknown as ForeignQueryBuilder<typeof user>;
+        }
+      ),
+    })),
+    posts: publicRoute.withProcedures(() => ({})),
+  },
+});
+
+describe("cross-entry-point QueryBuilder identity", () => {
+  test("ws client narrows a foreign-identity QueryBuilder to a loadable", () => {
+    const {
+      store: { query: wsQuery },
+    } = createClient<typeof routerWithForeignBuilderQuery>({
+      url: "ws://localhost:5001/ws",
+      schema,
+      storage: false,
+    });
+
+    const result = wsQuery.users.usersByAgeForeign({ minAge: 18 });
+
+    // The loadable must expose `buildQueryRequest` (regressed pre-fix).
+    expectTypeOf(result).toHaveProperty("buildQueryRequest");
+    expectTypeOf(result.buildQueryRequest).toBeFunction();
+
+    // And it must still await to the inferred row type from the brand.
+    expectTypeOf(result).toMatchTypeOf<
+      PromiseLike<{ id: string; name: string; email: string; age: number }[]>
+    >();
   });
 });


### PR DESCRIPTION
## Problem

Published consumers using the websocket client got a TS error on custom queries that return a `QueryBuilder`:

```ts
client.load(store.query.organization.load().buildQueryRequest());
// Property 'buildQueryRequest' does not exist on type
// 'Promise<QueryBuilder<...>>'
```

## Root cause

`CustomQueryResult` (`src/client/types.ts`) narrowed handler return types with `UnwrapPromise<TOutput> extends QueryBuilder<...>`. `QueryBuilder` carries `private` members, so TypeScript compares it **nominally**.

The two-config tsup build emits `QueryBuilder` into two separate `.d.ts` graphs — one in `dist/server.d.ts`, one in the client chunk. A consumer imports the router type from `@live-state/sync/server` and the client from `@live-state/sync/client`, so the handler's return type (server-bundle class) and the class `CustomQueryResult` checks against (client-bundle class) are **two unrelated nominal classes**. The `extends` fails → the type falls through to `Promise<QueryBuilder<...>>` and `.buildQueryRequest` is lost.

In-repo type tests import everything from `src`, so they only ever see one `QueryBuilder` identity and couldn't catch this.

## Fix

Decouple the type contract from bundler-emitted class identity:

- Add a type-only `__queryBuilderBrand` to `QueryBuilder` (via `declare` — **no runtime emit**) carrying `TCollection` / `TInclude` / `TSingle`.
- `CustomQueryResult` now matches that brand **structurally** instead of by class. Structural comparison ignores the source's private members, so both bundles' `QueryBuilder` match — and so does any duplicate installed package version.

This is robust to the bundle split *and* consumer version skew, with no packaging/build surgery.

## Regression

Added `ForeignQueryBuilder` — a distinct nominal class sharing only the structural brand — to stand in for the *other* bundle's copy, reproducing the cross-entry-point mismatch that `src`-only imports cannot. It asserts `buildQueryRequest` survives. Reverting the fix makes it fail with the exact original symptom.

## Verification

- Regression fails without the fix (exact original error), passes with it.
- Built `dist` and typechecked a standalone consumer fixture importing the router from `dist/server.d.ts` and client from `dist/client.d.ts` (two separate graphs) — `store.query.users.load().buildQueryRequest()` compiles clean.
- `pnpm typecheck` ✓, biome lint ✓, `pnpm test` → 43 files, 861 passed, no type errors.
- Confirmed the brand produces no runtime JS.

## Follow-ups (not in this PR)

- `exports.*.types` point at `./src/...`, which isn't in the published `files` — consumers fall back to `dist` `.d.ts` (which now works). Worth making explicit separately.
- No version bump here; a canary cut may be wanted for the consumer pinned to `1.0.0-canary-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query result type handling so client-side query responses resolve more reliably across different entry points.
  * Fixed type inference for queries with included related data, making returned shapes more consistent for single-item and list queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->