### PR TITLE
fix(client): add outbound WebSocket message events

### DIFF
--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -703,10 +703,11 @@ class InnerClient implements QueryExecutor {
   private sendWsMessage(message: ClientMessage) {
     if (!this.ws?.connected()) return;
 
-    this.ws.send(JSON.stringify(message));
+    const serializedMessage = JSON.stringify(message);
+    this.ws.send(serializedMessage);
     this.emitEvent({
       type: "MESSAGE_SENT",
-      message,
+      message: JSON.parse(serializedMessage),
     });
   }
 

--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -51,6 +51,11 @@ export type MessageReceivedEvent = {
   message: ServerMessage;
 };
 
+export type MessageSentEvent = {
+  type: "MESSAGE_SENT";
+  message: ClientMessage;
+};
+
 export type ClientStorageLoadedEvent = {
   type: "CLIENT_STORAGE_LOADED";
   resource: string;
@@ -156,6 +161,7 @@ const BOOTSTRAP_STATUS_RANK: Record<ClientBootstrapStatus, number> = {
 export type ClientEvents =
   | ConnectionStateChangeEvent
   | MessageReceivedEvent
+  | MessageSentEvent
   | ClientStorageLoadedEvent
   | DataLoadRequestedEvent
   | DataLoadReplyEvent
@@ -695,7 +701,13 @@ class InnerClient implements QueryExecutor {
   }
 
   private sendWsMessage(message: ClientMessage) {
-    if (this.ws?.connected()) this.ws.send(JSON.stringify(message));
+    if (!this.ws?.connected()) return;
+
+    this.ws.send(JSON.stringify(message));
+    this.emitEvent({
+      type: "MESSAGE_SENT",
+      message,
+    });
   }
 
   private emitEvent(event: ClientEvents) {

--- a/packages/live-state/test/client/message-events.test.ts
+++ b/packages/live-state/test/client/message-events.test.ts
@@ -108,7 +108,7 @@ describe('client outbound message events', () => {
 			input: {},
 		});
 		const queryPromise = (client.store.query.posts as any)
-			.somePostsQuery({})
+			.somePostsQuery()
 			.then((value: unknown) => value);
 		const mutationPromise = (client.store.mutate as any).posts.createPost({
 			id: 'post-1',
@@ -128,6 +128,10 @@ describe('client outbound message events', () => {
 				message,
 			})),
 		);
+		const customQueryEvent = sentEvents.find(
+			(event) => event.message.type === 'CUSTOM_QUERY',
+		);
+		expect(customQueryEvent?.message).not.toHaveProperty('input');
 
 		for (const message of sentMessages) {
 			if (message.type === 'CUSTOM_QUERY' || message.type === 'MUTATE') {

--- a/packages/live-state/test/client/message-events.test.ts
+++ b/packages/live-state/test/client/message-events.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+	type ClientEvents,
+	createClient,
+} from '../../src/client/websocket/client';
+import { createSchema, id, object, string } from '../../src/schema';
+
+class MockWebSocket {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+
+	readyState = MockWebSocket.CLOSED;
+	eventListeners: Record<string, Array<(event: any) => void>> = {};
+
+	send = vi.fn();
+	close = vi.fn(() => {
+		this.readyState = MockWebSocket.CLOSED;
+		this.dispatchEvent(new CloseEvent('close'));
+	});
+
+	constructor(public url: string) {
+		this.readyState = MockWebSocket.CONNECTING;
+	}
+
+	addEventListener(event: string, callback: (event: any) => void): void {
+		(this.eventListeners[event] ??= []).push(callback);
+	}
+
+	removeEventListener(event: string, callback: (event: any) => void): void {
+		this.eventListeners[event] = (this.eventListeners[event] ?? []).filter(
+			(cb) => cb !== callback,
+		);
+	}
+
+	dispatchEvent(event: Event): boolean {
+		(this.eventListeners[event.type] ?? []).forEach((listener) =>
+			listener(event),
+		);
+		return true;
+	}
+
+	simulateOpen(): void {
+		this.readyState = MockWebSocket.OPEN;
+		this.dispatchEvent(new Event('open'));
+	}
+
+	simulateMessage(data: unknown): void {
+		this.dispatchEvent(new MessageEvent('message', { data }));
+	}
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+const posts = object('posts', {
+	id: id(),
+	title: string(),
+});
+
+const schema = createSchema({ posts });
+
+type TestRouter = {
+	routes: {
+		posts: {
+			resourceSchema: typeof posts;
+			customMutations: {};
+			customQueries: {};
+		};
+	};
+};
+
+const connectClient = async (opts: Record<string, unknown> = {}) => {
+	const client = createClient<TestRouter>({
+		url: 'ws://localhost:1234',
+		schema,
+		storage: false,
+		connection: { autoConnect: false, autoReconnect: false },
+		...opts,
+	});
+	await client.client.ws.connect();
+	const ws = (client.client.ws as any).ws as MockWebSocket;
+	ws.simulateOpen();
+	return { client, ws };
+};
+
+describe('client outbound message events', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		vi.clearAllTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('emits MESSAGE_SENT for every outbound protocol frame', async () => {
+		const { client, ws } = await connectClient();
+		const events: ClientEvents[] = [];
+		const unsubscribe = client.client.addEventListener((event) =>
+			events.push(event),
+		);
+
+		const unsubscribeQuery = client.client.load({
+			resource: 'posts',
+			procedure: 'list',
+			input: {},
+		});
+		const queryPromise = (client.store.query.posts as any)
+			.somePostsQuery({})
+			.then((value: unknown) => value);
+		const mutationPromise = (client.store.mutate as any).posts.createPost({
+			id: 'post-1',
+			title: 'Hello',
+		});
+		unsubscribeQuery();
+
+		const sentMessages = ws.send.mock.calls.map(([raw]) => JSON.parse(raw));
+		const sentEvents = events.filter(
+			(event): event is Extract<ClientEvents, { type: 'MESSAGE_SENT' }> =>
+				event.type === 'MESSAGE_SENT',
+		);
+
+		expect(sentEvents).toEqual(
+			sentMessages.map((message: unknown) => ({
+				type: 'MESSAGE_SENT',
+				message,
+			})),
+		);
+
+		for (const message of sentMessages) {
+			if (message.type === 'CUSTOM_QUERY' || message.type === 'MUTATE') {
+				ws.simulateMessage(
+					JSON.stringify({ type: 'REPLY', id: message.id, data: {} }),
+				);
+			}
+		}
+
+		await expect(queryPromise).resolves.toEqual({});
+		await expect(mutationPromise).resolves.toEqual({});
+		unsubscribe();
+		client.client.ws.disconnect();
+	});
+
+	test('emits MESSAGE_SENT when an offline mutation is replayed', async () => {
+		const client = createClient<TestRouter>({
+			url: 'ws://localhost:1234',
+			schema,
+			storage: false,
+			optimisticMutations: {
+				getHandler: () => ({ input, storage }: any) => {
+					storage.posts.insert(input);
+				},
+			} as any,
+			connection: { autoConnect: false, autoReconnect: false },
+		});
+		const events: ClientEvents[] = [];
+		const unsubscribe = client.client.addEventListener((event) =>
+			events.push(event),
+		);
+
+		await (client.store.mutate as any).posts.createPost({
+			id: 'offline-post',
+			title: 'Offline',
+		});
+		expect(events.filter((event) => event.type === 'MESSAGE_SENT')).toHaveLength(
+			0,
+		);
+
+		await client.client.ws.connect();
+		const ws = (client.client.ws as any).ws as MockWebSocket;
+		ws.simulateOpen();
+
+		const sentEvents = events.filter(
+			(event): event is Extract<ClientEvents, { type: 'MESSAGE_SENT' }> =>
+				event.type === 'MESSAGE_SENT',
+		);
+		expect(sentEvents).toHaveLength(1);
+		expect(sentEvents[0]).toEqual({
+			type: 'MESSAGE_SENT',
+			message: expect.objectContaining({
+				type: 'MUTATE',
+				id: expect.any(String),
+				resource: 'posts',
+				procedure: 'createPost',
+			}),
+		});
+
+		const sentMessage = JSON.parse(ws.send.mock.calls[0][0]);
+		ws.simulateMessage(
+			JSON.stringify({ type: 'REPLY', id: sentMessage.id, data: {} }),
+		);
+		unsubscribe();
+		client.client.ws.disconnect();
+	});
+});


### PR DESCRIPTION
## Summary

- add a public `MESSAGE_SENT` client event carrying every outbound `ClientMessage`
- emit it at the shared WebSocket send boundary, including replayed mutations and reconnect-driven frames
- add regression coverage for protocol frames and offline mutation replay

## Validation

- `pnpm --filter @live-state/sync typecheck`
- `pnpm --filter @live-state/sync exec vitest run test/client/message-events.test.ts test/client/status.test.ts test/client/ws-wrapper.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications when outbound messages are successfully sent over the WebSocket.
  * Sent-message events include the original message details for improved event handling.
  * Offline changes replayed after reconnect now also trigger sent-message notifications.

* **Bug Fixes**
  * Prevented send attempts while disconnected until a connection is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->