### PR TITLE
fix(server): support collections named update

### DIFF
--- a/packages/live-state/src/server/storage/server-query-builder.ts
+++ b/packages/live-state/src/server/storage/server-query-builder.ts
@@ -3,13 +3,13 @@
 import { QueryBuilder, type QueryExecutor } from '../../core/query';
 import type { RawQueryRequest } from '../../core/schemas/core-protocol';
 import type {
-  InferInsert,
-  InferLiveCollection,
-  InferUpdate,
-  LiveCollectionAny,
-  LiveTypeAny,
-  MaterializedLiveType,
-  Schema,
+	InferInsert,
+	InferLiveCollection,
+	InferUpdate,
+	LiveCollectionAny,
+	LiveTypeAny,
+	MaterializedLiveType,
+	Schema,
 } from '../../schema';
 import { inferValue } from '../../schema';
 import type { Simplify } from '../../utils';
@@ -113,6 +113,25 @@ export type ServerDB<TSchema extends Schema<any>> = {
 };
 
 /**
+ * Keeps a deprecated method callable while exposing a collection facade when a
+ * collection name collides with that method.
+ */
+const mergeCollectionWithLegacyMethod = <T extends LiveCollectionAny>(
+	legacyMethod: (...args: any[]) => any,
+	collection: ServerCollection<T>,
+): ServerCollection<T> & ((...args: any[]) => any) => {
+	return new Proxy(legacyMethod, {
+		get(target, property, receiver) {
+			if (property in collection) {
+				const value = Reflect.get(collection, property);
+				return typeof value === 'function' ? value.bind(collection) : value;
+			}
+			return Reflect.get(target, property, receiver);
+		},
+	}) as ServerCollection<T> & ((...args: any[]) => any);
+};
+
+/**
  * Creates a ServerDB proxy that wraps a Storage instance with QueryBuilder-based syntax.
  *
  * @example
@@ -192,98 +211,108 @@ export function createServerDB<TSchema extends Schema<any>>(
 		return collection;
 	};
 
+	type LegacyMethod = (...args: any[]) => any;
+	const createLegacyMethod = (prop: string): LegacyMethod | undefined => {
+		// Handle deprecated Storage methods
+		if (prop === 'findOne') {
+			return storage.findOne.bind(storage);
+		}
+		if (prop === 'find') {
+			return storage.find.bind(storage);
+		}
+		if (prop === 'insert') {
+			return <T extends LiveCollectionAny>(
+				resource: T,
+				value: Simplify<InferInsert<T>>,
+			) => {
+				const now = storage._getTimestamp();
+				return storage
+					.rawInsert(
+						resource.name,
+						(value as any).id as string,
+						{
+							value: Object.fromEntries(
+								Object.entries(value).map(([k, v]) => [
+									k,
+									{ value: v, _meta: { timestamp: now } },
+								]),
+							),
+						} as unknown as MaterializedLiveType<T>,
+						undefined,
+						context,
+					)
+					.then((result) => inferValue(result.data));
+			};
+		}
+		if (prop === 'update') {
+			return <T extends LiveCollectionAny>(
+				resource: T,
+				resourceId: string,
+				value: InferUpdate<T>,
+			) => {
+				const now = storage._getTimestamp();
+				const { id: _, ...rest } = value as any;
+				return storage
+					.rawUpdate(
+						resource.name,
+						resourceId,
+						{
+							value: Object.fromEntries(
+								Object.entries(rest).map(([k, v]) => [
+									k,
+									{ value: v, _meta: { timestamp: now } },
+								]),
+							),
+						} as unknown as MaterializedLiveType<T>,
+						undefined,
+						context,
+					)
+					.then((result) => {
+						const inferred = inferValue(result.data) as any;
+						const filtered: any = {};
+						for (const key of Object.keys(rest)) {
+							if (key in inferred) {
+								filtered[key] = inferred[key];
+							}
+						}
+						return filtered;
+					});
+			};
+		}
+
+		// Handle transaction
+		if (prop === 'transaction') {
+			return async <T>(
+				fn: (opts: {
+					trx: ServerDB<TSchema>;
+					commit: () => Promise<void>;
+					rollback: () => Promise<void>;
+				}) => Promise<T>,
+			): Promise<T> => {
+				return storage.transaction(async ({ trx, commit, rollback }) => {
+					const trxDB = createServerDB(trx, schema, context);
+					return fn({ trx: trxDB, commit, rollback });
+				});
+			};
+		}
+
+		return undefined;
+	};
+
 	const handler: ProxyHandler<object> = {
 		get(_target, prop: string) {
-			// Handle deprecated Storage methods
-			if (prop === 'findOne') {
-				return storage.findOne.bind(storage);
-			}
-			if (prop === 'find') {
-				return storage.find.bind(storage);
-			}
-			if (prop === 'insert') {
-				return <T extends LiveCollectionAny>(
-					resource: T,
-					value: Simplify<InferInsert<T>>,
-				) => {
-					const now = storage._getTimestamp();
-					return storage
-						.rawInsert(
-							resource.name,
-							(value as any).id as string,
-							{
-								value: Object.fromEntries(
-									Object.entries(value).map(([k, v]) => [
-										k,
-										{ value: v, _meta: { timestamp: now } },
-									]),
-								),
-							} as unknown as MaterializedLiveType<T>,
-							undefined,
-							context,
-						)
-						.then((result) => inferValue(result.data));
-				};
-			}
-			if (prop === 'update') {
-				return <T extends LiveCollectionAny>(
-					resource: T,
-					resourceId: string,
-					value: InferUpdate<T>,
-				) => {
-					const now = storage._getTimestamp();
-					const { id: _, ...rest } = value as any;
-					return storage
-						.rawUpdate(
-							resource.name,
-							resourceId,
-							{
-								value: Object.fromEntries(
-									Object.entries(rest).map(([k, v]) => [
-										k,
-										{ value: v, _meta: { timestamp: now } },
-									]),
-								),
-							} as unknown as MaterializedLiveType<T>,
-							undefined,
-							context,
-						)
-						.then((result) => {
-							const inferred = inferValue(result.data) as any;
-							const filtered: any = {};
-							for (const key of Object.keys(rest)) {
-								if (key in inferred) {
-									filtered[key] = inferred[key];
-								}
-							}
-							return filtered;
-						});
-				};
+			const legacyMethod = createLegacyMethod(prop);
+
+			// Handle collection access (e.g., db.users, db.posts). If a collection
+			// name collides with a legacy method, expose both APIs on one value.
+			if (Object.hasOwn(schema, prop)) {
+				const collection = createCollection(schema[prop]);
+				return legacyMethod
+					? mergeCollectionWithLegacyMethod(legacyMethod, collection)
+					: collection;
 			}
 
-			// Handle transaction
-			if (prop === 'transaction') {
-				return async <T>(
-					fn: (opts: {
-						trx: ServerDB<TSchema>;
-						commit: () => Promise<void>;
-						rollback: () => Promise<void>;
-					}) => Promise<T>,
-				): Promise<T> => {
-					return storage.transaction(async ({ trx, commit, rollback }) => {
-						const trxDB = createServerDB(trx, schema, context);
-						return fn({ trx: trxDB, commit, rollback });
-					});
-				};
-			}
-
-			// Handle collection access (e.g., db.users, db.posts)
-			if (prop in schema) {
-				const resourceSchema = schema[prop];
-				return createCollection(resourceSchema);
-			}
-
-			return undefined;
+			return legacyMethod;
 		},
 	};
 

--- a/packages/live-state/test/server/storage/server-query-builder.test.ts
+++ b/packages/live-state/test/server/storage/server-query-builder.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test, vi } from 'vitest';
+import { createSchema, id, object, string } from '../../../src/schema';
+import {
+	createServerDB,
+	type Storage,
+} from '../../../src/server/storage';
+
+const updateCollection = object('update', {
+	id: id(),
+	replicatedStr: string(),
+});
+
+const schema = createSchema({ update: updateCollection });
+
+describe('createServerDB', () => {
+	test('supports a collection named update alongside the legacy method', async () => {
+		const get = vi
+			.fn()
+			.mockResolvedValue([{ id: 'update-1', replicatedStr: 'pending' }]);
+		const rawUpdate = vi.fn().mockResolvedValue({
+			data: {
+				value: {
+					replicatedStr: { value: 'done' },
+				},
+			},
+			acceptedValues: {},
+		});
+		const storage = {
+			get,
+			_getTimestamp: vi.fn().mockReturnValue('2026-01-01T00:00:00.000Z'),
+			rawUpdate,
+		} as unknown as Storage;
+		const db = createServerDB(storage, schema);
+
+		expect(typeof db.update).toBe('function');
+		await expect(db.update.one('update-1').get()).resolves.toEqual({
+			id: 'update-1',
+			replicatedStr: 'pending',
+		});
+		expect(get).toHaveBeenCalledWith(
+			expect.objectContaining({
+				resource: 'update',
+				where: { id: 'update-1' },
+				limit: 1,
+			}),
+		);
+
+		await expect(
+			db.update.update('update-1', { replicatedStr: 'done' }),
+		).resolves.toEqual({ replicatedStr: 'done' });
+		await expect(
+			db.update(schema.update, 'update-1', { replicatedStr: 'legacy' }),
+		).resolves.toEqual({ replicatedStr: 'done' });
+		expect(rawUpdate).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/live-state/test/types/server-db.test-d.ts
+++ b/packages/live-state/test/types/server-db.test-d.ts
@@ -34,6 +34,15 @@ const schema = createSchema({
 
 type TestSchema = typeof schema;
 
+const updateCollection = object("update", {
+  id: id(),
+  name: string(),
+});
+
+const collisionSchema = createSchema({ update: updateCollection });
+
+type CollisionSchema = typeof collisionSchema;
+
 describe("routeFactory<TSchema>() - typed db in procedure handlers", () => {
   const typedRoute = routeFactory<TestSchema>();
 
@@ -155,6 +164,22 @@ describe("routeFactory<TSchema>() - procedure-only routes", () => {
     typedRoute.withProcedures(({ query }) => ({
       getStats: query().handler(async ({ db }) => {
         expectTypeOf(db).toEqualTypeOf<ServerDB<TestSchema>>();
+        return {};
+      }),
+    }));
+  });
+});
+
+describe("routeFactory<TSchema>() - legacy method name collisions", () => {
+  const typedRoute = routeFactory<CollisionSchema>();
+
+  test("update collection retains its query facade and legacy method", () => {
+    typedRoute.withProcedures(({ mutation }) => ({
+      edit: mutation().handler(async ({ db }) => {
+        db.update.one("update-1").get();
+        await db.update(collisionSchema.update, "update-1", {
+          name: "updated",
+        });
         return {};
       }),
     }));


### PR DESCRIPTION
## Summary

- preserve deprecated ServerDB methods when a schema collection name collides with one
- expose the collection query/mutation facade through the callable legacy value
- add runtime and type regression coverage for a collection named update

## Validation

- pnpm typecheck
- pnpm exec biome lint --diagnostic-level error
- focused server and type tests: 57 passed
- pnpm build
- broader E2E suites remain environment-blocked by the existing better-sqlite3 Node ABI mismatch (compiled for module 127, runner requires 147)

Fixes #211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where collections named `update` could conflict with the existing update operation.
  * Collection queries and legacy update calls now work correctly through the server database interface.

* **Tests**
  * Added coverage for reading from an `update` collection and using both supported update call forms.
  * Added type validation to ensure the collection query interface remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->