### PR TITLE
fix: provide ServerDB to hooks

### DIFF
--- a/packages/live-state/src/server/storage/sql-storage.ts
+++ b/packages/live-state/src/server/storage/sql-storage.ts
@@ -29,6 +29,7 @@ import {
 } from "./dialect-helpers";
 import { type RawMutationResult, Storage } from "./interface";
 import { initializeSchema } from "./schema-init";
+import { createServerDB } from "./server-query-builder";
 import { applyInclude, applyRelationalOrderBy, applyWhere } from "./sql-utils";
 
 export class SQLStorage extends Storage {
@@ -263,8 +264,11 @@ export class SQLStorage extends Storage {
     mutationId?: string,
     context?: Record<string, any>,
   ): Promise<RawMutationResult<T>> {
+    const schema = this.schema;
+    if (!schema) throw new Error("Schema not initialized");
+
     const hooks: any = this.server?.getHooks(resourceName);
-    const entity = this.schema?.[resourceName];
+    const entity = schema[resourceName];
 
     const [mergedRecord, acceptedValues] = entity?.mergeMutation?.(
       "set",
@@ -276,6 +280,7 @@ export class SQLStorage extends Storage {
       return { data: value, acceptedValues: null };
     }
 
+    const hookDB = hooks ? createServerDB(this, schema, context) : undefined;
     let processedValue = mergedRecord as MaterializedLiveType<T>;
     const rawValueWithId = {
       ...processedValue,
@@ -293,7 +298,7 @@ export class SQLStorage extends Storage {
         ctx: context,
         value: inferredValue as any,
         rawValue: rawValueWithId,
-        db: this,
+        db: hookDB,
       });
 
       if (hookResult) {
@@ -375,7 +380,7 @@ export class SQLStorage extends Storage {
         ctx: context,
         value: inferredValue as any,
         rawValue: finalRawValue,
-        db: this,
+        db: hookDB,
       });
     }
 
@@ -390,8 +395,11 @@ export class SQLStorage extends Storage {
     mutationId?: string,
     context?: Record<string, any>,
   ): Promise<RawMutationResult<T>> {
+    const schema = this.schema;
+    if (!schema) throw new Error("Schema not initialized");
+
     const hooks: any = this.server?.getHooks(resourceName);
-    const entity = this.schema?.[resourceName];
+    const entity = schema[resourceName];
 
     const existingRecord = await this.rawFindById<T>(resourceName, resourceId);
 
@@ -405,6 +413,7 @@ export class SQLStorage extends Storage {
       return { data: value, acceptedValues: null };
     }
 
+    const hookDB = hooks ? createServerDB(this, schema, context) : undefined;
     let processedValue = mergedRecord as MaterializedLiveType<T>;
     const rawValueWithId = {
       ...processedValue,
@@ -437,7 +446,7 @@ export class SQLStorage extends Storage {
         rawValue: rawValueWithId,
         previousValue: previousInferredValue,
         previousRawValue: existingRecord,
-        db: this,
+        db: hookDB,
       });
 
       if (hookResult) {
@@ -550,7 +559,7 @@ export class SQLStorage extends Storage {
           rawValue: updatedRawValueWithId,
           previousValue: previousInferredValue,
           previousRawValue: existingRecord,
-          db: this,
+          db: hookDB,
         });
       }
     }

--- a/packages/live-state/test/server/hooks.test.ts
+++ b/packages/live-state/test/server/hooks.test.ts
@@ -242,6 +242,44 @@ describe("Server hooks registry", () => {
 		expect(beforeArgs.value.name).toBe("Alpha");
 	});
 
+	test("all hooks receive a ServerDB collection facade", async () => {
+		const observedNames: Array<string | undefined> = [];
+		testServer = server({
+			router: testRouter,
+			storage,
+			schema,
+			hooks: defineHooks<typeof schema>({
+				groups: {
+					beforeInsert: async ({ db, value }) => {
+						observedNames.push(
+							(await db.groups.one(value.id).get())?.name,
+						);
+					},
+					afterInsert: async ({ db, value }) => {
+						observedNames.push(
+							(await db.groups.one(value.id).get())?.name,
+						);
+					},
+					beforeUpdate: async ({ db, value }) => {
+						observedNames.push(
+							(await db.groups.one(value.id).get())?.name,
+						);
+					},
+					afterUpdate: async ({ db, value }) => {
+						observedNames.push(
+							(await db.groups.one(value.id).get())?.name,
+						);
+					},
+				},
+			}),
+		});
+
+		await insertGroup(testServer, "g1", "Alpha");
+		await updateGroup(testServer, "g1", "Beta");
+
+		expect(observedNames).toEqual([undefined, "Alpha", "Alpha", "Beta"]);
+	});
+
 	test("beforeUpdate and afterUpdate fire on update", async () => {
 		const beforeUpdate = vi.fn();
 		const afterUpdate = vi.fn();


### PR DESCRIPTION
## Summary

- pass a context-bound `ServerDB` facade to insert and update lifecycle hooks
- reuse the facade across the before/after hooks for each mutation
- add regression coverage for collection queries in all four hook types

## Validation

- `pnpm typecheck --filter="./packages/*"`
- `pnpm lint --filter="./packages/*" -- --diagnostic-level error`
- `pnpm test --filter="./packages/*"` (872 passed)

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side data hooks now receive a reliable database interface for reading collection data during insert and update operations.
  * Added clearer error handling when the database schema is not initialized.

* **Tests**
  * Added coverage confirming database reads work correctly across before- and after-operation hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->