### PR TITLE
fix: reset client metadata when schema changes

### DIFF
--- a/packages/live-state/src/client/websocket/storage.ts
+++ b/packages/live-state/src/client/websocket/storage.ts
@@ -28,6 +28,8 @@ export class KVStorage {
       )
     );
 
+    objectHashes[META_KEY] = schemaHash;
+
     const metaDb = await openDB("live-state-databases", 1, {
       upgrade(db) {
         if (!db.objectStoreNames.contains(DATABASES_KEY))

--- a/packages/live-state/test/client/websocket/storage.test.ts
+++ b/packages/live-state/test/client/websocket/storage.test.ts
@@ -244,7 +244,10 @@ describe("KVStorage", () => {
   test("should recreate metadata and clear mutations when schema changes", async () => {
     const { openDB } = await import("idb");
     const mockOpenDB = openDB as any;
-    vi.mocked(hash).mockResolvedValue("mock-hash");
+    vi.mocked(hash)
+      .mockResolvedValueOnce("schema-hash")
+      .mockResolvedValueOnce("users-hash")
+      .mockResolvedValueOnce("posts-hash");
 
     mockIndexedDB.databases.mockResolvedValue([
       { name: "test-db", version: 1 },
@@ -300,14 +303,14 @@ describe("KVStorage", () => {
     expect(persistedMetadata.has("mutationStack")).toBe(false);
     expect(mockMetaDB.put).toHaveBeenCalledWith(
       "databases",
-      {
-        schemaHash: "mock-hash",
-        objectHashes: {
-          users: "mock-hash",
-          posts: "mock-hash",
-          __meta: "mock-hash",
-        },
-      },
+      expect.objectContaining({
+        schemaHash: "schema-hash",
+        objectHashes: expect.objectContaining({
+          users: "users-hash",
+          posts: "posts-hash",
+          __meta: "schema-hash",
+        }),
+      }),
       "test-db"
     );
   });
@@ -315,7 +318,10 @@ describe("KVStorage", () => {
   test("should preserve metadata when schema is unchanged", async () => {
     const { openDB } = await import("idb");
     const mockOpenDB = openDB as any;
-    vi.mocked(hash).mockResolvedValue("mock-hash");
+    vi.mocked(hash)
+      .mockResolvedValueOnce("schema-hash")
+      .mockResolvedValueOnce("users-hash")
+      .mockResolvedValueOnce("posts-hash");
 
     mockIndexedDB.databases.mockResolvedValue([
       { name: "test-db", version: 2 },
@@ -323,17 +329,20 @@ describe("KVStorage", () => {
     mockMetaDB.objectStoreNames.contains.mockReturnValue(true);
     mockMetaDB.getAllRecords.mockResolvedValue({
       "test-db": {
-        schemaHash: "mock-hash",
+        schemaHash: "schema-hash",
         objectHashes: {
-          users: "mock-hash",
-          posts: "mock-hash",
-          __meta: "mock-hash",
+          users: "users-hash",
+          posts: "posts-hash",
+          __meta: "schema-hash",
         },
       },
     });
     const persistedMetadata = new Map([
       ["mutationStack", [{ mutationId: "pending-mutation" }]],
     ]);
+    mockDB.get.mockImplementation((_storeName, key) =>
+      Promise.resolve(persistedMetadata.get(key))
+    );
 
     mockOpenDB.mockImplementation((name: string) =>
       Promise.resolve(name === "live-state-databases" ? mockMetaDB : mockDB)
@@ -344,7 +353,7 @@ describe("KVStorage", () => {
     expect(mockOpenDB).toHaveBeenCalledWith("test-db", 2, expect.any(Object));
     expect(mockDB.deleteObjectStore).not.toHaveBeenCalled();
     expect(mockDB.createObjectStore).not.toHaveBeenCalled();
-    expect(persistedMetadata.get("mutationStack")).toEqual([
+    expect(await storage.getMeta("mutationStack")).toEqual([
       { mutationId: "pending-mutation" },
     ]);
   });

--- a/packages/live-state/test/client/websocket/storage.test.ts
+++ b/packages/live-state/test/client/websocket/storage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { KVStorage } from "../../../src/client/websocket/storage";
 import { DefaultMutationMessage } from "../../../src/core/schemas/web-socket";
 import { Schema } from "../../../src/schema";
+import { hash } from "../../../src/utils";
 
 // Mock IndexedDB
 const mockIndexedDB = {
@@ -240,43 +241,47 @@ describe("KVStorage", () => {
     expect(mockDB.createObjectStore).toHaveBeenCalledWith("__meta");
   });
 
-  test("should delete and recreate object stores when hash changes", async () => {
+  test("should recreate metadata and clear mutations when schema changes", async () => {
     const { openDB } = await import("idb");
     const mockOpenDB = openDB as any;
+    vi.mocked(hash).mockResolvedValue("mock-hash");
 
-    mockIndexedDB.databases.mockResolvedValue([]);
+    mockIndexedDB.databases.mockResolvedValue([
+      { name: "test-db", version: 1 },
+    ]);
 
-    // Setup meta DB mock
     mockMetaDB.objectStoreNames.contains.mockReturnValue(true);
     mockMetaDB.getAllRecords.mockResolvedValue({
       "test-db": {
         schemaHash: "old-hash",
-        objectHashes: { users: "old-user-hash", posts: "old-post-hash" },
+        objectHashes: {
+          users: "old-user-hash",
+          posts: "old-post-hash",
+          __meta: "old-hash",
+        },
       },
     });
 
-    // Setup main DB mock
-    let storeExists = false;
-    mockDB.objectStoreNames.contains.mockImplementation(() => {
-      storeExists = !storeExists;
-      return storeExists;
+    const objectStores = new Set(["users", "posts", "__meta"]);
+    const persistedMetadata = new Map([
+      ["mutationStack", [{ mutationId: "pending-mutation" }]],
+    ]);
+    mockDB.objectStoreNames.contains.mockImplementation((storeName) =>
+      objectStores.has(storeName)
+    );
+    mockDB.deleteObjectStore.mockImplementation((storeName) => {
+      objectStores.delete(storeName);
+      if (storeName === "__meta") persistedMetadata.clear();
     });
-
-    let metaUpgradeCalled = false;
-    let mainUpgradeCalled = false;
+    mockDB.createObjectStore.mockImplementation((storeName) => {
+      objectStores.add(storeName);
+    });
 
     mockOpenDB.mockImplementation((name: any, version: any, options: any) => {
       if (name === "live-state-databases") {
-        if (options?.upgrade && !metaUpgradeCalled) {
-          options.upgrade(mockMetaDB);
-          metaUpgradeCalled = true;
-        }
         return Promise.resolve(mockMetaDB);
       } else if (name === "test-db") {
-        if (options?.upgrade && !mainUpgradeCalled) {
-          options.upgrade(mockDB);
-          mainUpgradeCalled = true;
-        }
+        options.upgrade(mockDB);
         return Promise.resolve(mockDB);
       }
       return Promise.resolve(mockDB);
@@ -289,6 +294,59 @@ describe("KVStorage", () => {
 
     expect(mockDB.deleteObjectStore).toHaveBeenCalledWith("posts");
     expect(mockDB.createObjectStore).toHaveBeenCalledWith("posts");
+
+    expect(mockDB.deleteObjectStore).toHaveBeenCalledWith("__meta");
+    expect(mockDB.createObjectStore).toHaveBeenCalledWith("__meta");
+    expect(persistedMetadata.has("mutationStack")).toBe(false);
+    expect(mockMetaDB.put).toHaveBeenCalledWith(
+      "databases",
+      {
+        schemaHash: "mock-hash",
+        objectHashes: {
+          users: "mock-hash",
+          posts: "mock-hash",
+          __meta: "mock-hash",
+        },
+      },
+      "test-db"
+    );
+  });
+
+  test("should preserve metadata when schema is unchanged", async () => {
+    const { openDB } = await import("idb");
+    const mockOpenDB = openDB as any;
+    vi.mocked(hash).mockResolvedValue("mock-hash");
+
+    mockIndexedDB.databases.mockResolvedValue([
+      { name: "test-db", version: 2 },
+    ]);
+    mockMetaDB.objectStoreNames.contains.mockReturnValue(true);
+    mockMetaDB.getAllRecords.mockResolvedValue({
+      "test-db": {
+        schemaHash: "mock-hash",
+        objectHashes: {
+          users: "mock-hash",
+          posts: "mock-hash",
+          __meta: "mock-hash",
+        },
+      },
+    });
+    const persistedMetadata = new Map([
+      ["mutationStack", [{ mutationId: "pending-mutation" }]],
+    ]);
+
+    mockOpenDB.mockImplementation((name: string) =>
+      Promise.resolve(name === "live-state-databases" ? mockMetaDB : mockDB)
+    );
+
+    await storage.init(mockSchema, "test-db");
+
+    expect(mockOpenDB).toHaveBeenCalledWith("test-db", 2, expect.any(Object));
+    expect(mockDB.deleteObjectStore).not.toHaveBeenCalled();
+    expect(mockDB.createObjectStore).not.toHaveBeenCalled();
+    expect(persistedMetadata.get("mutationStack")).toEqual([
+      { mutationId: "pending-mutation" },
+    ]);
   });
 
   test("should get all data for resource type", async () => {


### PR DESCRIPTION
## Summary

- include the internal `__meta` object store in schema hash comparisons
- rebuild metadata when the client schema changes, clearing stale mutation state
- preserve metadata across restarts when the schema is unchanged

## Verification

- `pnpm exec vitest run test/client/websocket/storage.test.ts` (23 tests passed)
- `pnpm exec biome lint src/client/websocket/storage.ts test/client/websocket/storage.test.ts`
- `pnpm typecheck`

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local data storage updates when the database schema changes.
  * Ensured outdated stored data and mutation metadata are cleared during schema upgrades.
  * Preserved existing data and pending mutation metadata when the schema remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->