### PR TITLE
fix: add client query membership sets

### DIFF
--- a/packages/live-state/src/client/websocket/client.ts
+++ b/packages/live-state/src/client/websocket/client.ts
@@ -213,6 +213,7 @@ class InnerClient implements QueryExecutor {
     string,
     { query: CustomQueryRequest; subCounter: number }
   > = new Map();
+  private subscriptionRequestQueries: Record<string, string> = {};
 
   private eventListeners: Set<(event: ClientEvents) => void> = new Set();
 
@@ -287,15 +288,17 @@ class InnerClient implements QueryExecutor {
       });
 
       if (e.open) {
-        Array.from(this.remoteSubscriptions.values()).forEach(({ query }) => {
-          this.sendWsMessage({
-            id: generateId(),
-            type: "SUBSCRIBE",
-            ...query,
-          });
-        });
+        Array.from(this.remoteSubscriptions.entries()).forEach(
+          ([queryHash, { query }]) => {
+            this.sendSubscription(query, queryHash);
+          },
+        );
 
         this.replayCustomMutationStack();
+      } else {
+        // Replies from the closed transport can no longer arrive. Reconnect
+        // creates fresh request ids for every active subscription.
+        this.subscriptionRequestQueries = {};
       }
     });
   }
@@ -383,16 +386,24 @@ class InnerClient implements QueryExecutor {
         }
 
         const parsedSyncData = syncReplyDataSchema.parse(data);
+        const queryHash = this.subscriptionRequestQueries[id];
+        delete this.subscriptionRequestQueries[id];
+
+        // A reply can race with the final unsubscribe. It no longer represents
+        // an active Membership Set, so do not resurrect either the set or rows.
+        if (queryHash && !this.remoteSubscriptions.has(queryHash)) return;
 
         this.emitEvent({
           type: "DATA_LOAD_REPLY",
           resource: parsedSyncData.resource,
           itemCount: parsedSyncData.data.length,
+          subscriptionId: id,
         });
 
         this.store.loadConsolidatedState(
           parsedSyncData.resource,
           parsedSyncData.data,
+          queryHash,
         );
 
         this.emitEvent({
@@ -418,12 +429,6 @@ class InnerClient implements QueryExecutor {
       subscriptionId,
     });
 
-    this.sendWsMessage({
-      id: subscriptionId,
-      type: "SUBSCRIBE",
-      ...query,
-    });
-
     const isNewSubscription = !this.remoteSubscriptions.has(key);
 
     if (this.remoteSubscriptions.has(key)) {
@@ -431,6 +436,16 @@ class InnerClient implements QueryExecutor {
       this.remoteSubscriptions.get(key)!.subCounter += 1;
     } else {
       this.remoteSubscriptions.set(key, { query, subCounter: 1 });
+      this.store.activateRemoteQuery(key);
+    }
+
+    if (this.ws.connected()) {
+      this.subscriptionRequestQueries[subscriptionId] = key;
+      this.sendWsMessage({
+        id: subscriptionId,
+        type: "SUBSCRIBE",
+        ...query,
+      });
     }
 
     if (isNewSubscription) {
@@ -450,6 +465,7 @@ class InnerClient implements QueryExecutor {
         // biome-ignore lint/style/noNonNullAssertion: false positive
         if (this.remoteSubscriptions.get(key)!.subCounter <= 0) {
           this.remoteSubscriptions.delete(key);
+          this.store.deactivateRemoteQuery(key);
           this.sendWsMessage({
             id: generateId(),
             type: "UNSUBSCRIBE",
@@ -464,6 +480,16 @@ class InnerClient implements QueryExecutor {
         }
       }
     };
+  }
+
+  private sendSubscription(query: CustomQueryRequest, queryHash: string) {
+    const id = generateId();
+    this.subscriptionRequestQueries[id] = queryHash;
+    this.sendWsMessage({
+      id,
+      type: "SUBSCRIBE",
+      ...query,
+    });
   }
 
   public subscribe(
@@ -542,7 +568,9 @@ class InnerClient implements QueryExecutor {
       this.replyHandlers[mutationMessage.id] = {
         timeoutHandle: setTimeout(() => {
           delete this.replyHandlers[mutationMessage.id];
-          this.emitUndoEvents(this.store.undoCustomMutation(mutationMessage.id));
+          this.emitUndoEvents(
+            this.store.undoCustomMutation(mutationMessage.id),
+          );
           reject(new Error("Reply timeout"));
         }, 5000),
         handler: (data: any) => {
@@ -665,7 +693,8 @@ class InnerClient implements QueryExecutor {
 
   private setBootstrapStatus(next: ClientBootstrapStatus) {
     if (
-      BOOTSTRAP_STATUS_RANK[next] <= BOOTSTRAP_STATUS_RANK[this._bootstrapStatus]
+      BOOTSTRAP_STATUS_RANK[next] <=
+      BOOTSTRAP_STATUS_RANK[this._bootstrapStatus]
     )
       return;
     this._bootstrapStatus = next;

--- a/packages/live-state/src/client/websocket/store.ts
+++ b/packages/live-state/src/client/websocket/store.ts
@@ -26,12 +26,18 @@ type RawObjPool = Record<
   Record<string, MaterializedLiveType<LiveObjectAny> | undefined> | undefined
 >;
 
+type MembershipSets = Record<string, Record<string, Set<string>>>;
+type PersistedMembershipSets = Record<string, Record<string, string[]>>;
+
 export class OptimisticStore {
   private rawObjPool: RawObjPool = {} as RawObjPool;
   public optimisticMutationStack: Record<string, SyncDeltaMessage[]> = {};
   public customMutationStack: MutationMessage[] = [];
   private optimisticObjGraph: ObjectGraph;
   private optimisticRawObjPool: RawObjPool = {} as RawObjPool;
+  private membershipSets: MembershipSets = {};
+  private deactivatedRemoteQueries = new Set<string>();
+  private repliedRemoteQueries = new Set<string>();
   private logger: Logger;
   private onQuerySubscriptionTriggered?: (query: RawQueryRequest) => void;
   public customMutationIndex: Record<
@@ -78,8 +84,9 @@ export class OptimisticStore {
           this.kvStorage.getMeta<typeof this.customMutationIndex>(
             "customMutationIndex",
           ),
+          this.kvStorage.getMeta<PersistedMembershipSets>("membershipSets"),
         ])
-          .then(([mutStack, customStack, customIndex]) => {
+          .then(([mutStack, customStack, customIndex, membershipSets]) => {
             if (mutStack && Object.keys(mutStack).length > 0) {
               this.optimisticMutationStack = mutStack;
             }
@@ -88,6 +95,25 @@ export class OptimisticStore {
             }
             if (customIndex && Object.keys(customIndex).length > 0) {
               this.customMutationIndex = customIndex;
+            }
+            if (membershipSets) {
+              Object.entries(membershipSets).forEach(
+                ([queryHash, resources]) => {
+                  if (
+                    this.deactivatedRemoteQueries.has(queryHash) ||
+                    this.repliedRemoteQueries.has(queryHash)
+                  )
+                    return;
+
+                  const restoredResources = Object.fromEntries(
+                    Object.entries(resources).map(([resource, ids]) => [
+                      resource,
+                      new Set(ids),
+                    ]),
+                  );
+                  this.membershipSets[queryHash] = restoredResources;
+                },
+              );
             }
             afterLoadMutations?.(
               this.optimisticMutationStack,
@@ -221,10 +247,29 @@ export class OptimisticStore {
     };
   }
 
+  public activateRemoteQuery(queryHash: string) {
+    this.deactivatedRemoteQueries.delete(queryHash);
+    if (this.membershipSets[queryHash]) return;
+
+    this.membershipSets[queryHash] = {};
+    this.persistMembershipSets();
+  }
+
+  public deactivateRemoteQuery(queryHash: string) {
+    this.deactivatedRemoteQueries.add(queryHash);
+    this.repliedRemoteQueries.delete(queryHash);
+    if (!this.membershipSets[queryHash]) return;
+
+    delete this.membershipSets[queryHash];
+    this.persistMembershipSets();
+    this.trimUnreferencedRows();
+  }
+
   public addMutation(
     routeName: string,
     mutation: SyncDeltaMessage,
     optimistic: boolean = false,
+    trackMembership: boolean = true,
   ) {
     const schema = this.schema[routeName];
 
@@ -232,12 +277,10 @@ export class OptimisticStore {
 
     if (!schema) throw new Error("Schema not found");
 
-    // A scope-out delta (window eviction or a visible row leaving scope) carries
-    // only the id: drop the row from the local store so windowed queries re-sort
-    // the rows they still hold. The row may still exist server-side, outside
-    // this query's scope (see ADR-0003).
+    // Sync deltas do not identify their subscription yet. A scope-out therefore
+    // cannot safely remove the row: another active query may still retain it.
+    // The next complete query reply will correct the relevant membership set.
     if (mutation.op === "DELETE") {
-      this.removeFromPool(routeName, mutation.resourceId);
       return;
     }
 
@@ -246,8 +289,7 @@ export class OptimisticStore {
     let undidMatchingOptimistic = false;
 
     if (optimistic) {
-      this.optimisticMutationStack[routeName] ??=
-        [] as SyncDeltaMessage[];
+      this.optimisticMutationStack[routeName] ??= [] as SyncDeltaMessage[];
       this.optimisticMutationStack[routeName].push(mutation);
     } else {
       this.optimisticMutationStack[routeName] =
@@ -256,18 +298,16 @@ export class OptimisticStore {
         ) ?? [];
 
       const originId = (mutation as any).meta?.originMutationId;
-      this.logger.debug(
-        "Broadcast mutation received",
-        {
-          mutationId: mutation.id,
-          resource: routeName,
-          resourceId: mutation.resourceId,
-          op: mutation.op,
-          originMutationId: originId ?? "(none)",
-          customMutationIndexKeys: Object.keys(this.customMutationIndex),
-          optimisticStackSize: this.optimisticMutationStack[routeName]?.length ?? 0,
-        },
-      );
+      this.logger.debug("Broadcast mutation received", {
+        mutationId: mutation.id,
+        resource: routeName,
+        resourceId: mutation.resourceId,
+        op: mutation.op,
+        originMutationId: originId ?? "(none)",
+        customMutationIndexKeys: Object.keys(this.customMutationIndex),
+        optimisticStackSize:
+          this.optimisticMutationStack[routeName]?.length ?? 0,
+      });
       if (originId && this.customMutationIndex[originId]) {
         const entries = this.customMutationIndex[originId];
         const matchingEntries = entries.filter((e) => e.resource === routeName);
@@ -287,7 +327,10 @@ export class OptimisticStore {
           ) {
             this.logger.debug(
               "Removing optimistic mutation (resourceId match)",
-              { optimisticMutationId: entry.mutationId, resourceId: mutation.resourceId },
+              {
+                optimisticMutationId: entry.mutationId,
+                resourceId: mutation.resourceId,
+              },
             );
             this.undoMutation(routeName, entry.mutationId);
             undidMatchingOptimistic = true;
@@ -361,6 +404,12 @@ export class OptimisticStore {
       mutation.payload,
       relationPrevValue,
     );
+
+    // Scope-in is conservative until deltas carry subscription identity. Adding
+    // the id to every active set can over-retain, but cannot wrongly evict.
+    if (!optimistic && trackMembership && mutation.op === "INSERT") {
+      this.addToActiveMembershipSets(routeName, mutation.resourceId);
+    }
   }
 
   public undoMutation(routeName: string, mutationId: string) {
@@ -410,24 +459,22 @@ export class OptimisticStore {
 
   public confirmCustomMutation(messageId: string) {
     const mutations = this.customMutationIndex[messageId];
-    this.logger.debug(
-      "confirmCustomMutation called",
-      {
-        messageId,
-        hasIndex: !!mutations,
-        mutations: mutations ?? [],
-      },
-    );
+    this.logger.debug("confirmCustomMutation called", {
+      messageId,
+      hasIndex: !!mutations,
+      mutations: mutations ?? [],
+    });
     if (!mutations) return;
 
     for (const { resource, mutationId } of mutations) {
       const stillInStack = !!this.optimisticMutationStack[resource]?.find(
         (m) => m.id === mutationId,
       );
-      this.logger.debug(
-        "confirmCustomMutation: undoing mutation",
-        { resource, mutationId, stillInStack },
-      );
+      this.logger.debug("confirmCustomMutation: undoing mutation", {
+        resource,
+        mutationId,
+        stillInStack,
+      });
       this.undoMutation(resource, mutationId);
     }
 
@@ -488,10 +535,17 @@ export class OptimisticStore {
   public loadConsolidatedState(
     resourceType: string,
     data: SyncDeltaMessage["payload"][],
+    queryHash?: string,
   ) {
+    const replyMembership: Record<string, Set<string>> = {
+      [resourceType]: new Set(),
+    };
+
     data.forEach((payload) => {
       const id = payload.id?.value as string | undefined;
       if (!id) return;
+
+      replyMembership[resourceType].add(id);
 
       const { cleanedPayload, nestedMutations } = this.extractNestedRelations(
         resourceType,
@@ -499,18 +553,28 @@ export class OptimisticStore {
       );
 
       nestedMutations.forEach((mutation) => {
-        this.addMutation(mutation.resource, mutation);
+        replyMembership[mutation.resource] ??= new Set();
+        replyMembership[mutation.resource].add(mutation.resourceId);
+        this.addMutation(mutation.resource, mutation, false, false);
       });
 
-      this.addMutation(resourceType, {
+      const rootMutation: SyncDeltaMessage = {
         id,
         type: "SYNC",
         resource: resourceType,
         resourceId: id,
         op: "INSERT",
         payload: cleanedPayload,
-      });
+      };
+      this.addMutation(resourceType, rootMutation, false, false);
     });
+
+    if (queryHash) {
+      this.repliedRemoteQueries.add(queryHash);
+      this.membershipSets[queryHash] = replyMembership;
+      this.persistMembershipSets();
+      this.trimUnreferencedRows();
+    }
   }
 
   private extractNestedRelations(
@@ -606,12 +670,6 @@ export class OptimisticStore {
     return { cleanedPayload, nestedMutations };
   }
 
-  /**
-   * Drop a row from every local store surface in response to a scope-out
-   * (`DELETE`) delta, then notify subscribers so windowed queries re-derive.
-   * Any pending optimistic mutation for the row is left untouched — it is
-   * reconciled through its own reply/reject path.
-   */
   private removeFromPool(routeName: string, resourceId: string) {
     if (!this.schema[routeName]) return;
 
@@ -622,6 +680,73 @@ export class OptimisticStore {
 
     this.notifyCollectionSubscribers(routeName);
     this.optimisticObjGraph.notifySubscribers(resourceId);
+  }
+
+  private addToActiveMembershipSets(resource: string, resourceId: string) {
+    let changed = false;
+
+    Object.values(this.membershipSets).forEach((membership) => {
+      membership[resource] ??= new Set();
+      if (membership[resource].has(resourceId)) return;
+
+      membership[resource].add(resourceId);
+      changed = true;
+    });
+
+    if (changed) this.persistMembershipSets();
+  }
+
+  private persistMembershipSets() {
+    const persisted = Object.fromEntries(
+      Object.entries(this.membershipSets).map(([queryHash, resources]) => [
+        queryHash,
+        Object.fromEntries(
+          Object.entries(resources).map(([resource, ids]) => [
+            resource,
+            Array.from(ids),
+          ]),
+        ),
+      ]),
+    );
+
+    this.kvStorage.setMeta("membershipSets", persisted);
+  }
+
+  private trimUnreferencedRows() {
+    const retainedIds: Record<string, Set<string>> = {};
+
+    Object.values(this.membershipSets).forEach((membership) => {
+      Object.entries(membership).forEach(([resource, ids]) => {
+        retainedIds[resource] ??= new Set();
+        ids.forEach((id) => {
+          retainedIds[resource].add(id);
+        });
+      });
+    });
+
+    const resources = new Set([
+      ...Object.keys(this.rawObjPool),
+      ...Object.keys(this.optimisticRawObjPool),
+    ]);
+
+    resources.forEach((resource) => {
+      const ids = new Set([
+        ...Object.keys(this.rawObjPool[resource] ?? {}),
+        ...Object.keys(this.optimisticRawObjPool[resource] ?? {}),
+      ]);
+
+      ids.forEach((id) => {
+        if (retainedIds[resource]?.has(id)) return;
+        if (
+          this.optimisticMutationStack[resource]?.some(
+            (mutation) => mutation.resourceId === id,
+          )
+        )
+          return;
+
+        this.removeFromPool(resource, id);
+      });
+    });
   }
 
   private updateRawObjPool(
@@ -769,7 +894,8 @@ export class OptimisticStore {
             this.materializeOneWithInclude(
               node.references.get(refName),
               isSubQueryInclude(nestedInclude)
-                ? ((nestedInclude.include ?? {}) as IncludeClause<LiveObjectAny>)
+                ? ((nestedInclude.include ??
+                    {}) as IncludeClause<LiveObjectAny>)
                 : typeof nestedInclude === "object" && nestedInclude !== null
                   ? (nestedInclude as IncludeClause<LiveObjectAny>)
                   : {},
@@ -790,7 +916,8 @@ export class OptimisticStore {
                       this.materializeOneWithInclude(
                         v,
                         isSubQueryInclude(nestedInclude)
-                          ? ((nestedInclude.include ?? {}) as IncludeClause<LiveObjectAny>)
+                          ? ((nestedInclude.include ??
+                              {}) as IncludeClause<LiveObjectAny>)
                           : typeof nestedInclude === "object" &&
                               nestedInclude !== null
                             ? (nestedInclude as IncludeClause<LiveObjectAny>)
@@ -801,8 +928,10 @@ export class OptimisticStore {
                 : this.materializeOneWithInclude(
                     referencedBy,
                     isSubQueryInclude(nestedInclude)
-                      ? ((nestedInclude.include ?? {}) as IncludeClause<LiveObjectAny>)
-                      : typeof nestedInclude === "object" && nestedInclude !== null
+                      ? ((nestedInclude.include ??
+                          {}) as IncludeClause<LiveObjectAny>)
+                      : typeof nestedInclude === "object" &&
+                          nestedInclude !== null
                         ? (nestedInclude as IncludeClause<LiveObjectAny>)
                         : {},
                   ),
@@ -851,7 +980,9 @@ export class OptimisticStore {
       result.push(targetEntityName);
 
       if (typeof value === "object" && value !== null) {
-        const nestedInclude = isSubQueryInclude(value) ? (value.include ?? {}) : value;
+        const nestedInclude = isSubQueryInclude(value)
+          ? (value.include ?? {})
+          : value;
         result.push(
           ...this.flattenIncludes(
             nestedInclude as IncludeClause<LiveObjectAny>,

--- a/packages/live-state/test/client/status.test.ts
+++ b/packages/live-state/test/client/status.test.ts
@@ -167,4 +167,48 @@ describe('client bootstrap status', () => {
 
 		client.client.ws.disconnect();
 	});
+
+	test('reconnect reply trims rows that left a remote query scope', async () => {
+		const { client, ws } = await makeClient();
+		const query = { resource: 'posts', procedure: 'list', input: {} };
+		const unload = client.client.load(query);
+		const firstSubscribe = JSON.parse(ws.send.mock.calls.at(-1)?.[0]);
+
+		ws.simulateMessage(
+			JSON.stringify({
+				type: 'REPLY',
+				id: firstSubscribe.id,
+				data: {
+					resource: 'posts',
+					data: [
+						{
+							id: { value: 'post-1' },
+							title: { value: 'Open before disconnect' },
+						},
+					],
+				},
+			}),
+		);
+		expect(client.store.query.posts.one('post-1').get()).toBeDefined();
+
+		ws.close();
+		await client.client.ws.connect();
+		const reconnectedWs = (client.client.ws as any).ws as MockWebSocket;
+		reconnectedWs.simulateOpen();
+		const reconnectSubscribe = JSON.parse(
+			reconnectedWs.send.mock.calls.at(-1)?.[0],
+		);
+		reconnectedWs.simulateMessage(
+			JSON.stringify({
+				type: 'REPLY',
+				id: reconnectSubscribe.id,
+				data: { resource: 'posts', data: [] },
+			}),
+		);
+
+		expect(client.store.query.posts.one('post-1').get()).toBeUndefined();
+
+		unload();
+		client.client.ws.disconnect();
+	});
 });

--- a/packages/live-state/test/client/websocket/store.test.ts
+++ b/packages/live-state/test/client/websocket/store.test.ts
@@ -23,12 +23,12 @@ import { hash } from "../../../src/utils";
 
 // Mock the hash function
 vi.mock("../../../src/utils", async () => {
-	const actual = await vi.importActual("../../../src/utils");
-	return {
-		...actual,
-		hash: vi.fn(),
-		applyWhere: vi.fn(),
-	};
+  const actual = await vi.importActual("../../../src/utils");
+  return {
+    ...actual,
+    hash: vi.fn(),
+    applyWhere: vi.fn(),
+  };
 });
 
 // Mock fast-deep-equal
@@ -99,6 +99,7 @@ describe("OptimisticStore", () => {
       getMeta: vi.fn().mockResolvedValue(undefined),
       get: vi.fn().mockResolvedValue({}),
       set: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
       setMeta: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -110,6 +111,7 @@ describe("OptimisticStore", () => {
       subscribe: vi.fn().mockReturnValue(() => {}),
       createLink: vi.fn(),
       removeLink: vi.fn(),
+      removeNode: vi.fn(),
       notifySubscribers: vi.fn(),
     };
 
@@ -673,22 +675,32 @@ describe("OptimisticStore", () => {
     store.loadConsolidatedState("users", data);
 
     expect(addMutationSpy).toHaveBeenCalledTimes(2);
-    expect(addMutationSpy).toHaveBeenCalledWith("users", {
-      id: "user1",
-      type: "SYNC",
-      resource: "users",
-      resourceId: "user1",
-      payload: data[0],
-      op: "INSERT",
-    });
-    expect(addMutationSpy).toHaveBeenCalledWith("users", {
-      id: "user2",
-      type: "SYNC",
-      resource: "users",
-      resourceId: "user2",
-      payload: data[1],
-      op: "INSERT",
-    });
+    expect(addMutationSpy).toHaveBeenCalledWith(
+      "users",
+      {
+        id: "user1",
+        type: "SYNC",
+        resource: "users",
+        resourceId: "user1",
+        payload: data[0],
+        op: "INSERT",
+      },
+      false,
+      false,
+    );
+    expect(addMutationSpy).toHaveBeenCalledWith(
+      "users",
+      {
+        id: "user2",
+        type: "SYNC",
+        resource: "users",
+        resourceId: "user2",
+        payload: data[1],
+        op: "INSERT",
+      },
+      false,
+      false,
+    );
   });
 
   test("should handle empty mutation stack during initialization", async () => {
@@ -1784,6 +1796,211 @@ describe("OptimisticStore", () => {
 
       expect(result).toBeDefined();
       expect(result?.value).toHaveProperty("posts");
+    });
+  });
+
+  describe("Remote query membership", () => {
+    const userPayload = (idValue: string, name: string) => ({
+      id: { value: idValue },
+      name: { value: name, _meta: { timestamp: "2023-01-01" } },
+    });
+
+    beforeEach(() => {
+      store = new OptimisticStore(
+        mockSchema,
+        { name: "test-storage" },
+        mockLogger,
+      );
+    });
+
+    test("replaces a query membership set and trims rows omitted by its reply", () => {
+      store.activateRemoteQuery("open-users");
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("user1", "John"), userPayload("user2", "Jane")],
+        "open-users",
+      );
+
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("user2", "Jane")],
+        "open-users",
+      );
+
+      expect(store["rawObjPool"].users?.user1).toBeUndefined();
+      expect(store["rawObjPool"].users?.user2).toBeDefined();
+      expect(mockKVStorage.delete).toHaveBeenCalledWith("users", "user1");
+      expect(mockKVStorage.setMeta).toHaveBeenCalledWith("membershipSets", {
+        "open-users": { users: ["user2"] },
+      });
+    });
+
+    test("retains a row named by another active query", () => {
+      store.activateRemoteQuery("query-a");
+      store.activateRemoteQuery("query-b");
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("shared", "Shared")],
+        "query-a",
+      );
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("shared", "Shared")],
+        "query-b",
+      );
+
+      store.loadConsolidatedState("users", [], "query-a");
+
+      expect(store["rawObjPool"].users?.shared).toBeDefined();
+
+      store.loadConsolidatedState("users", [], "query-b");
+
+      expect(store["rawObjPool"].users?.shared).toBeUndefined();
+    });
+
+    test("trims only after the last retaining query is deactivated", () => {
+      store.activateRemoteQuery("query-a");
+      store.activateRemoteQuery("query-b");
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("shared", "Shared")],
+        "query-a",
+      );
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("shared", "Shared")],
+        "query-b",
+      );
+
+      store.deactivateRemoteQuery("query-a");
+      expect(store["rawObjPool"].users?.shared).toBeDefined();
+
+      store.deactivateRemoteQuery("query-b");
+      expect(store["rawObjPool"].users?.shared).toBeUndefined();
+    });
+
+    test("does not trim a row with a pending optimistic mutation", () => {
+      store.activateRemoteQuery("query-a");
+      store.loadConsolidatedState(
+        "users",
+        [userPayload("user1", "John")],
+        "query-a",
+      );
+      store.addMutation(
+        "users",
+        {
+          id: "optimistic-1",
+          type: "SYNC",
+          resource: "users",
+          resourceId: "user1",
+          op: "UPDATE",
+          payload: {
+            name: {
+              value: "Johnny",
+              _meta: { timestamp: "2023-01-02" },
+            },
+          },
+        },
+        true,
+      );
+
+      store.loadConsolidatedState("users", [], "query-a");
+
+      expect(store["rawObjPool"].users?.user1).toBeDefined();
+      expect(store["optimisticRawObjPool"].users?.user1).toBeDefined();
+      expect(mockKVStorage.delete).not.toHaveBeenCalledWith("users", "user1");
+    });
+
+    test("records nested include rows under their own resource", () => {
+      store.activateRemoteQuery("users-with-posts");
+      store.loadConsolidatedState(
+        "users",
+        [
+          {
+            ...userPayload("user1", "John"),
+            posts: {
+              value: [
+                {
+                  value: {
+                    id: { value: "post1" },
+                    title: { value: "Post one" },
+                    userId: { value: "user1" },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        "users-with-posts",
+      );
+
+      expect(store["membershipSets"]["users-with-posts"]).toEqual({
+        users: new Set(["user1"]),
+        posts: new Set(["post1"]),
+      });
+      expect(store["rawObjPool"].posts?.post1).toBeDefined();
+    });
+
+    test("handles unidentified deltas conservatively", () => {
+      store.activateRemoteQuery("query-a");
+      store.activateRemoteQuery("query-b");
+      store.loadConsolidatedState("users", [], "query-a");
+      store.loadConsolidatedState("users", [], "query-b");
+
+      store.addMutation("users", {
+        id: "scope-in",
+        type: "SYNC",
+        resource: "users",
+        resourceId: "user1",
+        op: "INSERT",
+        payload: userPayload("user1", "John"),
+      });
+
+      expect(store["membershipSets"]["query-a"].users).toEqual(
+        new Set(["user1"]),
+      );
+      expect(store["membershipSets"]["query-b"].users).toEqual(
+        new Set(["user1"]),
+      );
+
+      store.addMutation("users", {
+        id: "scope-out",
+        type: "SYNC",
+        resource: "users",
+        resourceId: "user1",
+        op: "DELETE",
+        payload: {},
+      });
+
+      expect(store["rawObjPool"].users?.user1).toBeDefined();
+      expect(store["membershipSets"]["query-a"].users).toEqual(
+        new Set(["user1"]),
+      );
+      expect(mockKVStorage.delete).not.toHaveBeenCalledWith("users", "user1");
+    });
+
+    test("restores persisted membership sets alongside the pool", async () => {
+      mockKVStorage.getMeta.mockImplementation((key: string) => {
+        if (key === "membershipSets") {
+          return Promise.resolve({ query: { users: ["user1"] } });
+        }
+        return Promise.resolve(undefined);
+      });
+      mockKVStorage.get.mockImplementation((resource: string) =>
+        Promise.resolve(
+          resource === "users" ? { user1: { name: { value: "John" } } } : {},
+        ),
+      );
+
+      store = new OptimisticStore(
+        mockSchema,
+        { name: "test-storage" },
+        mockLogger,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(store["membershipSets"].query.users).toEqual(new Set(["user1"]));
+      expect(store["rawObjPool"].users?.user1).toBeDefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- persist a membership set per active remote query and replace it from complete query replies
- trim rows against the union of active sets while retaining pending optimistic mutations and nested include rows
- conservatively handle unidentified sync deltas until subscription identity is available
- associate subscription request ids with query hashes across reconnects

## Validation

- client test suite: 289 passed, 1 skipped
- package and client TypeScript checks pass
- Biome lint passes for changed source files
- full SQLite-dependent suite could not run because better-sqlite3 does not build with the local Node 26 runtime

Closes #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time synchronization after reconnecting, including removal of records no longer matching active queries.
  * Prevented outdated subscription responses from affecting local data.
  * Improved cleanup when remote queries are deactivated.
* **Improvements**
  * Remote query membership is now maintained more accurately across updates and app restarts.
  * Optimistic updates are handled more reliably while preserving records shared by multiple queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->