### PR TITLE
fix(query-engine): match nested one relations (#218)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: pnpm lint --filter="./packages/*" -- --diagnostic-level error
 
       - name: Run tests with coverage
-        run: pnpm test --filter="./packages/*" -- --coverage --coverage.reporter=json-summary
+        run: pnpm test --filter="./packages/*" -- --coverage --coverage.reporter=json --coverage.reporter=json-summary
 
       - name: "Report Coverage"
         # Set if: always() to also generate the report if tests are failing
@@ -73,4 +73,6 @@ jobs:
         if: always()
         uses: davelosert/vitest-coverage-report-action@v2
         with:
+          vite-config-path: packages/live-state/vitest.config.ts
           json-summary-path: packages/live-state/coverage/coverage-summary.json
+          json-final-path: packages/live-state/coverage/coverage-final.json

--- a/packages/live-state/src/core/query-engine/index.ts
+++ b/packages/live-state/src/core/query-engine/index.ts
@@ -1929,26 +1929,53 @@ export class QueryEngine {
 				if (!this.graph.has(resourceId))
 					return { hash: queryNode.hash, matches: false };
 
-				if (queryNode.relationName) {
-					// queryNode.relationName is the parent-side relation (e.g. "posts"
-					// on User); the graph resolves the inverse ("author" on Post) and
-					// follows this object's FK up to its parent internally.
+				const relationName = queryNode.relationName;
+				if (relationName) {
 					const parentQuery = queryNode.parentQuery
 						? this.queryNodes.get(queryNode.parentQuery)
 						: undefined;
-					const parentResource = parentQuery?.queryStep.query.resource;
 
-					const relatedObj = parentResource
-						? this.graph.reference(
-								resourceId,
-								parentResource,
-								queryNode.relationName,
-							)
-						: undefined;
-					if (!relatedObj) return { hash: queryNode.hash, matches: false };
-
-					if (!parentQuery || !this.graph.matches(relatedObj, parentQuery.hash))
+					if (!parentQuery) {
 						return { hash: queryNode.hash, matches: false };
+					}
+
+					const parentResource = parentQuery.queryStep.query.resource;
+					const parentRelation =
+						this.schema[parentResource]?.relations?.[relationName];
+
+					if (!parentRelation) {
+						return { hash: queryNode.hash, matches: false };
+					}
+
+					if (parentRelation.type === 'one') {
+						// A `one` relation stores its FK on the parent row, so the
+						// related object has to look back at all parent rows and match
+						// when any of them is in the parent query's scope.
+						const parentIds = this.graph.referencedBy(
+							resourceId,
+							parentResource,
+							relationName,
+						);
+						if (
+							!Array.from(parentIds).some((parentId) =>
+								this.graph.matches(parentId, parentQuery.hash),
+							)
+						)
+							return { hash: queryNode.hash, matches: false };
+					} else {
+						// A `many` relation stores its FK on this child row, so follow
+						// the child's outgoing edge to its parent.
+						const relatedObj = this.graph.reference(
+							resourceId,
+							parentResource,
+							relationName,
+						);
+						if (
+							!relatedObj ||
+							!this.graph.matches(relatedObj, parentQuery.hash)
+						)
+							return { hash: queryNode.hash, matches: false };
+					}
 
 					// Relation membership holds; fall through to re-apply the
 					// include's own `where` predicate so a related-but-filtered-out

--- a/packages/live-state/test/core/query-engine/nested-one-relation.test.ts
+++ b/packages/live-state/test/core/query-engine/nested-one-relation.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Regression test for issue #218: a nested query that reaches its parent
+ * through a `one` relation must keep receiving later descendant inserts after
+ * the related parent is updated.
+ */
+
+import { beforeEach, describe, expect, test } from 'vitest';
+import { QueryEngine } from '../../../src/core/query-engine';
+import type { RawQueryRequest, SyncDelta } from '../../../src/core/schemas/core-protocol';
+import {
+	createRelations,
+	createSchema,
+	id,
+	number,
+	object,
+	reference,
+	string,
+} from '../../../src/schema';
+import { Logger, LogLevel } from '../../../src/utils';
+
+const organization = object('organizations', {
+	id: id(),
+	counter: number(),
+});
+
+const organizationUser = object('organizationUsers', {
+	id: id(),
+	userId: string(),
+	organizationId: reference('organizations.id'),
+});
+
+const thread = object('threads', {
+	id: id(),
+	organizationId: reference('organizations.id'),
+	read: string().nullable(),
+});
+
+const message = object('messages', {
+	id: id(),
+	threadId: reference('threads.id'),
+	body: string(),
+});
+
+const organizationRelations = createRelations(organization, ({ many }) => ({
+	organizationUsers: many(organizationUser, 'organizationId'),
+	threads: many(thread, 'organizationId'),
+}));
+
+const organizationUserRelations = createRelations(
+	organizationUser,
+	({ one }) => ({
+		organization: one(organization, 'organizationId'),
+	}),
+);
+
+const threadRelations = createRelations(thread, ({ one, many }) => ({
+	organization: one(organization, 'organizationId'),
+	messages: many(message, 'threadId'),
+}));
+
+const messageRelations = createRelations(message, ({ one }) => ({
+	thread: one(thread, 'threadId'),
+}));
+
+const schema = createSchema({
+	organizations: organization,
+	organizationUsers: organizationUser,
+	threads: thread,
+	messages: message,
+	organizationRelations,
+	organizationUserRelations,
+	threadRelations,
+	messageRelations,
+});
+
+const query: RawQueryRequest = {
+	resource: 'organizationUsers',
+	where: { userId: 'user-1' },
+	include: {
+		organization: {
+			include: {
+				threads: { include: { messages: true } },
+			},
+		},
+	},
+};
+
+const field = (value: unknown) => ({
+	value,
+	_meta: { timestamp: '2026-08-27T00:00:00.000Z' },
+});
+
+const materialize = (value: Record<string, unknown>) => ({
+	value: Object.fromEntries(
+		Object.entries(value).map(([key, entry]) => [key, field(entry)]),
+	),
+	_meta: { timestamp: '2026-08-27T00:00:00.000Z' },
+});
+
+const nestedResult = () => {
+	const organizationValue = materialize({
+		id: 'organization-1',
+		counter: 0,
+	});
+	const threadValue = materialize({
+		id: 'thread-1',
+		organizationId: 'organization-1',
+		read: null,
+	});
+	const initialMessageValue = materialize({
+		id: 'message-initial',
+		threadId: 'thread-1',
+		body: 'initial message',
+	});
+
+	return {
+		...materialize({
+			id: 'membership-1',
+			userId: 'user-1',
+			organizationId: 'organization-1',
+		}),
+		value: {
+			...materialize({
+				id: 'membership-1',
+				userId: 'user-1',
+				organizationId: 'organization-1',
+			}).value,
+			organization: {
+				value: {
+					...organizationValue.value,
+					threads: {
+						value: [
+							{
+								...threadValue,
+								value: {
+									...threadValue.value,
+									messages: {
+										value: [initialMessageValue],
+										_meta: { timestamp: '2026-08-27T00:00:00.000Z' },
+									},
+								},
+							},
+						],
+						_meta: { timestamp: '2026-08-27T00:00:00.000Z' },
+					},
+				},
+				_meta: { timestamp: '2026-08-27T00:00:00.000Z' },
+			},
+		},
+		_meta: { timestamp: '2026-08-27T00:00:00.000Z' },
+	};
+};
+
+const update = (
+	resource: string,
+	resourceId: string,
+	payload: Record<string, ReturnType<typeof field>>,
+	value: Record<string, unknown>,
+): { mutation: SyncDelta; entityValue: ReturnType<typeof materialize> } => ({
+	mutation: {
+		type: 'SYNC',
+		op: 'UPDATE',
+		resource,
+		resourceId,
+		payload,
+	},
+	entityValue: materialize(value),
+});
+
+describe('nested one-relation query matching (issue #218)', () => {
+	let engine: QueryEngine;
+	let received: SyncDelta[];
+
+	beforeEach(async () => {
+		const storage = {
+			get: async () => [nestedResult()],
+		};
+
+		engine = new QueryEngine({
+			storage,
+			schema,
+			logger: new Logger({ level: LogLevel.CRITICAL }),
+		});
+		received = [];
+
+		engine.subscribe(query, (mutation) => received.push(mutation));
+		await engine.get(query);
+		received = [];
+	});
+
+	const flush = async () => {
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	};
+
+	test('keeps receiving a later message insert after parent updates', async () => {
+		const organizationUpdate = update(
+			'organizations',
+			'organization-1',
+			{ counter: field(1) },
+			{ id: 'organization-1', counter: 1 },
+		);
+		engine.handleMutation(
+			organizationUpdate.mutation,
+			organizationUpdate.entityValue,
+		);
+		await flush();
+
+		const threadUpdate = update(
+			'threads',
+			'thread-1',
+			{ read: field('read-1') },
+			{ id: 'thread-1', organizationId: 'organization-1', read: 'read-1' },
+		);
+		engine.handleMutation(threadUpdate.mutation, threadUpdate.entityValue);
+		await flush();
+
+		const reply: SyncDelta = {
+			type: 'SYNC',
+			op: 'INSERT',
+			resource: 'messages',
+			resourceId: 'message-reply',
+			payload: {
+				threadId: field('thread-1'),
+				body: field('reply after read'),
+			},
+		};
+		engine.handleMutation(
+			reply,
+			materialize({
+				id: 'message-reply',
+				threadId: 'thread-1',
+				body: 'reply after read',
+			}),
+		);
+		await flush();
+
+		expect(
+			received.some(
+				(mutation) =>
+					mutation.resource === 'messages' &&
+					mutation.resourceId === 'message-reply',
+			),
+		).toBe(true);
+	});
+});

--- a/packages/live-state/test/e2e/e2e.test.ts
+++ b/packages/live-state/test/e2e/e2e.test.ts
@@ -174,18 +174,25 @@ describe("End-to-End Query Tests", () => {
       logLevel: LogLevel.DEBUG,
     });
 
-    // Wait for storage to initialize
-    // await storage.init(testSchema);
+    // Server initialization is asynchronous. Wait for a real server request
+    // before using the storage directly so setup cannot race schema creation.
+    await testServer.handleCustomQuery({
+      req: {
+        type: "CUSTOM_QUERY",
+        resource: "users",
+        procedure: "list",
+        input: undefined,
+        headers: {},
+        cookies: {},
+        queryParams: {},
+        context: {},
+      },
+    });
 
     // Clean up all tables before each test
-    try {
-      await pool.query(
-        "TRUNCATE TABLE users, users_meta, posts, posts_meta RESTART IDENTITY CASCADE"
-      );
-    } catch (error) {
-      // Ignore errors if tables don't exist yet (first run)
-      // They will be created by storage.init()
-    }
+    await pool.query(
+      "TRUNCATE TABLE users, users_meta, posts, posts_meta RESTART IDENTITY CASCADE"
+    );
 
     // Create Express server
     const { app } = expressWs(express());
@@ -541,7 +548,7 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 performs INSERT mutation
-        client1.store.mutate.users.insert({
+        await client1.store.mutate.users.insert({
           id: userId,
           name: userName,
           email: userEmail,
@@ -596,7 +603,7 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 performs UPDATE mutation
-        client1.store.mutate.users.update({
+        await client1.store.mutate.users.update({
           id: userId,
           name: updatedName,
         });
@@ -637,7 +644,7 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 performs first INSERT mutation
-        client1.store.mutate.users.insert({
+        await client1.store.mutate.users.insert({
           id: userId1,
           name: "User 1",
           email: "user1@example.com",
@@ -647,7 +654,7 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 performs second INSERT mutation
-        client1.store.mutate.users.insert({
+        await client1.store.mutate.users.insert({
           id: userId2,
           name: "User 2",
           email: "user2@example.com",
@@ -696,7 +703,7 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 first creates a user, then a post
-        client1.store.mutate.users.insert({
+        await client1.store.mutate.users.insert({
           id: userId,
           name: "Author",
           email: "author@example.com",
@@ -704,7 +711,7 @@ describe("End-to-End Query Tests", () => {
 
         await new Promise((resolve) => setTimeout(resolve, 100));
 
-        client1.store.mutate.posts.insert({
+        await client1.store.mutate.posts.insert({
           id: postId,
           title: "New Post",
           content: "Post Content",
@@ -754,7 +761,7 @@ describe("End-to-End Query Tests", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // Client1 performs INSERT mutation
-        client1.store.mutate.users.insert({
+        await client1.store.mutate.users.insert({
           id: userId,
           name: "Test User",
           email: "test@example.com",
@@ -1032,9 +1039,6 @@ describe("End-to-End Query Tests", () => {
     beforeEach(async () => {
       orderStorage = new SQLStorage(pool);
 
-      // Initialize storage to create tables and enum types
-      await orderStorage.init(orderSchema);
-
       orderServer = server({
         router: orderRouter,
         storage: orderStorage,
@@ -1042,14 +1046,23 @@ describe("End-to-End Query Tests", () => {
         logLevel: LogLevel.DEBUG,
       });
 
+      await orderServer.handleCustomQuery({
+        req: {
+          type: "CUSTOM_QUERY",
+          resource: "orders",
+          procedure: "list",
+          input: undefined,
+          headers: {},
+          cookies: {},
+          queryParams: {},
+          context: {},
+        },
+      });
+
       // Clean up tables
-      try {
-        await pool.query(
-          "TRUNCATE TABLE orders, orders_meta RESTART IDENTITY CASCADE"
-        );
-      } catch (error) {
-        // Ignore errors if tables don't exist yet
-      }
+      await pool.query(
+        "TRUNCATE TABLE orders, orders_meta RESTART IDENTITY CASCADE"
+      );
 
       const { app } = expressWs(express());
       app.use(express.json());
@@ -1166,7 +1179,7 @@ describe("End-to-End Query Tests", () => {
       test("should handle enum field mutations (insert)", async () => {
         const orderId = generateId();
 
-        orderWsClient.store.mutate.orders.insert({
+        await orderWsClient.store.mutate.orders.insert({
           id: orderId,
           status: "shipped",
           priority: "medium",
@@ -1195,7 +1208,7 @@ describe("End-to-End Query Tests", () => {
 
         await new Promise((resolve) => setTimeout(resolve, 100));
 
-        orderWsClient.store.mutate.orders.update({
+        await orderWsClient.store.mutate.orders.update({
           id: orderId,
           status: "delivered",
           priority: "high",
@@ -1280,7 +1293,7 @@ describe("End-to-End Query Tests", () => {
 
         await new Promise((resolve) => setTimeout(resolve, 100));
 
-        client1.store.mutate.orders.insert({
+        await client1.store.mutate.orders.insert({
           id: orderId,
           status: "processing",
           priority: "high",
@@ -1413,9 +1426,6 @@ describe("End-to-End Query Tests", () => {
     beforeEach(async () => {
       productStorage = new SQLStorage(pool);
 
-      // Initialize storage to create tables
-      await productStorage.init(productSchema);
-
       productServer = server({
         router: productRouter,
         storage: productStorage,
@@ -1423,14 +1433,23 @@ describe("End-to-End Query Tests", () => {
         logLevel: LogLevel.DEBUG,
       });
 
+      await productServer.handleCustomQuery({
+        req: {
+          type: "CUSTOM_QUERY",
+          resource: "products",
+          procedure: "list",
+          input: undefined,
+          headers: {},
+          cookies: {},
+          queryParams: {},
+          context: {},
+        },
+      });
+
       // Clean up tables
-      try {
-        await pool.query(
-          "TRUNCATE TABLE products, products_meta RESTART IDENTITY CASCADE"
-        );
-      } catch (error) {
-        // Ignore errors if tables don't exist yet
-      }
+      await pool.query(
+        "TRUNCATE TABLE products, products_meta RESTART IDENTITY CASCADE"
+      );
 
       const { app } = expressWs(express());
       app.use(express.json());
@@ -1582,7 +1601,7 @@ describe("End-to-End Query Tests", () => {
           },
         };
 
-        productWsClient.store.mutate.products.insert({
+        await productWsClient.store.mutate.products.insert({
           id: productId,
           name: "New Product",
           metadata,
@@ -1627,7 +1646,7 @@ describe("End-to-End Query Tests", () => {
           },
         };
 
-        productWsClient.store.mutate.products.update({
+        await productWsClient.store.mutate.products.update({
           id: productId,
           metadata: updatedMetadata,
         });
@@ -1716,7 +1735,7 @@ describe("End-to-End Query Tests", () => {
 
         await new Promise((resolve) => setTimeout(resolve, 100));
 
-        client1.store.mutate.products.insert({
+        await client1.store.mutate.products.insert({
           id: productId,
           name: "Synced Product",
           metadata,


### PR DESCRIPTION
Fixes #218. getMatchingQueries now uses reverse references for one relations, while preserving outgoing-edge matching for many relations. Added a regression test for the organizationUser to organization to threads to messages sequence. Verified the test fails without the fix with expected false to be true, then passes with it. Query-engine tests: 31 passed. Typecheck and build pass. Lint exits successfully with existing warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed nested query updates involving one-to-one and one-to-many relationships.
  - Ensured subscriptions correctly detect parent-child matches and receive later changes, including newly added messages.
  - Prevented invalid or incomplete nested queries from being treated as matches.

- **Tests**
  - Added regression coverage for nested relationship queries and subscription updates.
  - Improved end-to-end test reliability by awaiting initialization and data mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->